### PR TITLE
Implement batching and performance improvements

### DIFF
--- a/doc/source/configuration/modules/omhttp.rst
+++ b/doc/source/configuration/modules/omhttp.rst
@@ -296,7 +296,9 @@ This parameter activates batching mode, which queues messages and sends them as 
 
 Note that rsyslog core is the ultimate authority on when a batch must be submitted, due to the way that batching is implemented. This plugin implements the `output plugin transaction interface <https://www.rsyslog.com/doc/v8-stable/development/dev_oplugins.html#output-plugin-transaction-interface>`_. There may be multiple batches in a single transaction, but a batch will never span multiple transactions. This means that if batch.maxsize_ or batch.maxbytes_ is set very large, you may never actually see batches hit this size. Additionally, the number of messages per transaction is determined by the size of the main, action, and ruleset queues as well.
 
-Additionally, due to some open issues with rsyslog and the transaction interface, batching requires some nuanced retry_ configuration.
+The plugin flushes a batch early if either the configured batch.maxsize_ is reached or if adding the next message would exceed batch.maxbytes_ once serialized (format overhead included). When dynrestpath_ is enabled, a change of the effective REST path also forces a flush so that each batch targets a single path.
+
+Additionally, due to some open issues with rsyslog and the transaction interface, batching requires some nuanced retry_ configuration. By default, omhttp signals transport/server failures to rsyslog core (suspend/resume), which performs retries. The retry.ruleset_ mechanism remains available for advanced per-message retry handling in batch mode.
 
 
 batch.format


### PR DESCRIPTION
### Summary (non-technical, complete)
This change significantly improves the performance and reliability of the `omhttp` output module when using batching. It ensures that messages are grouped into batches more efficiently, avoiding sending batches that are too small or too large, which boosts throughput. It also fixes an issue where dynamic REST paths (`dynrestpath`) were not handled correctly across batches, ensuring that all messages in a batch go to the intended destination and preventing memory leaks. The module continues to be fully backward compatible, and its documentation has been updated to reflect these improvements and clarify retry behavior.

### References
Refs: https://github.com/rsyslog/rsyslog/issues/5957

### Notes (optional)
- Documentation in `doc/source/configuration/modules/omhttp.rst` has been updated to describe the refined flush conditions, `dynrestpath` batching, and default retry behavior.
- Impact: Improved batching efficiency and correctness for `omhttp` module, especially when using `dynrestpath`.

---
<a href="https://cursor.com/background-agent?bcId=bc-452040d8-e92a-40b4-b6c7-88cf0b775b4c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-452040d8-e92a-40b4-b6c7-88cf0b775b4c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

