### PR TITLE
Add github pages deployment to doc build workflow

### DIFF
--- a/.github/workflows/doc_build.yml
+++ b/.github/workflows/doc_build.yml
@@ -1,10 +1,18 @@
 name: documentation build
 
-# This workflow runs on all pull requests because branch protection requires it.
-# If no documentation files change, the build steps are skipped to save time.
+# This workflow runs on all pull requests for validation and
+# on pushes to main/master branches for deployment to GitHub Pages.
 
 on:
   pull_request:
+  push:
+    branches: [main, master]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -25,19 +33,53 @@ jobs:
         with:
           files: |
             doc/**/*.rst
+        if: github.event_name == 'pull_request'
 
       - name: Setup Python
-        if: steps.doc_changes.outputs.any_changed == 'true'
+        if: github.event_name != 'pull_request' || steps.doc_changes.outputs.any_changed == 'true'
         uses: actions/setup-python@v5
         with:
           python-version: '3.x'
 
       - name: Install Sphinx
-        if: steps.doc_changes.outputs.any_changed == 'true'
+        if: github.event_name != 'pull_request' || steps.doc_changes.outputs.any_changed == 'true'
         run: python -m pip install -r doc/requirements.txt
 
       - name: Build documentation
-        if: steps.doc_changes.outputs.any_changed == 'true'
+        if: github.event_name != 'pull_request' || steps.doc_changes.outputs.any_changed == 'true'
         run: |
           cd doc
           make html SPHINXOPTS="-W -q --keep-going"
+
+      - name: Upload documentation artifact
+        if: github.event_name != 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name: html-docs
+          path: doc/build/html
+
+  deploy_pages:
+    needs: build_docs
+    if: (github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master')) || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: html-docs
+          path: ./html-docs
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+
+      - name: Upload to Pages
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./html-docs
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
### Summary (non-technical, complete)
This PR introduces automated GitHub Pages deployment for the project's Sphinx documentation. It ensures that documentation is automatically built and published on pushes to the `main` or `master` branches, and can also be triggered manually. This enhances user access to the latest documentation and streamlines the release process.

### References
Refs: https://github.com/rsyslog/rsyslog/issues/xxxx

### Notes (optional)
- **Impact:** This change significantly alters the documentation publication workflow. Previously, documentation was only built for PR validation; now, it is also automatically deployed to GitHub Pages.
- **Before:** Documentation required manual building and hosting.
- **After:** Documentation is automatically built and deployed to GitHub Pages on `main`/`master` pushes, or via manual `workflow_dispatch`. PRs continue to validate documentation changes.
- Sphinx warnings are now consistently treated as errors (`-W`) during the build process to maintain documentation quality.

---

#### Quick check (optional)
- Commit message follows rules (ASCII; title ≤62, body ≤72; `<component>:`).
- Commit message includes non-technical “why”, Impact (if behavior/tests changed),
  and a one-line Before/After when behavior changed.
- Used the Commit Assistant or mirrored its structure.

---

#### Git workflow tips (optional, but helps reviews)
- Start by crafting the commit message locally (use the Assistant).
- If you already committed, improve it with:
  ```
  git commit --amend
  ```
- Squash related commits before PR where appropriate.
- Push your branch and then open the PR.
- If key info is only in the PR text, maintainers may ask you to move it
  into the commit message for a clean history.

---
<a href="https://cursor.com/background-agent?bcId=bc-97cfefb5-79c7-430a-aa74-8b94716523bf">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-97cfefb5-79c7-430a-aa74-8b94716523bf">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

