### PR TITLE
docs(ci): enable PR preview for PR and PR target events

### DIFF
--- a/.github/workflows/doc_build.yml
+++ b/.github/workflows/doc_build.yml
@@ -6,6 +6,8 @@ name: documentation build
 on:
   pull_request_target:
     types: [opened, synchronize, reopened, closed]
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
   push:
     branches: [main, master]
   workflow_dispatch:
@@ -16,7 +18,7 @@ permissions:
   id-token: write
 
 concurrency:
-  group: ${{github.workflow}}-${{github.event.pull_request.number||github.ref}}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -29,6 +31,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 8
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Check for doc changes
         id: doc_changes
@@ -38,23 +41,23 @@ jobs:
             doc/**/*.rst
 
       - name: Setup Python
-        if: ${{github.event_name!='pull_request'||steps.doc_changes.outputs.any_changed=='true'}}
+        if: ${{ (github.event_name != 'pull_request' && github.event_name != 'pull_request_target') || steps.doc_changes.outputs.any_changed == 'true' }}
         uses: actions/setup-python@v5
         with:
           python-version: '3.x'
 
       - name: Install Sphinx
-        if: ${{github.event_name!='pull_request'||steps.doc_changes.outputs.any_changed=='true'}}
+        if: ${{ (github.event_name != 'pull_request' && github.event_name != 'pull_request_target') || steps.doc_changes.outputs.any_changed == 'true' }}
         run: python -m pip install -r doc/requirements.txt
 
       - name: Build documentation
-        if: ${{github.event_name!='pull_request'||steps.doc_changes.outputs.any_changed=='true'}}
+        if: ${{ (github.event_name != 'pull_request' && github.event_name != 'pull_request_target') || steps.doc_changes.outputs.any_changed == 'true' }}
         run: |
           cd doc
           make html SPHINXOPTS="-W -q --keep-going"
 
       - name: Upload build artifact
-        if: ${{github.event_name!='pull_request'||steps.doc_changes.outputs.any_changed=='true'}}
+        if: ${{ (github.event_name != 'pull_request' && github.event_name != 'pull_request_target') || steps.doc_changes.outputs.any_changed == 'true' }}
         uses: actions/upload-artifact@v4
         with:
           name: docs-html
@@ -66,7 +69,8 @@ jobs:
     needs: build_docs
     runs-on: ubuntu-latest
     if: >-
-      ${{github.event_name=='pull_request'&&
+      ${{ (github.event_name=='pull_request'||github.event_name=='pull_request_target')&&
+      github.event.action!='closed'&&
       github.event.pull_request.head.repo.full_name==github.repository&&
       needs.build_docs.outputs.docs_changed=='true'}}
     permissions:
@@ -170,7 +174,7 @@ jobs:
     name: Cleanup PR preview (on close)
     runs-on: ubuntu-latest
     if: >-
-      ${{github.event_name=='pull_request'&&github.event.action=='closed'}}
+      ${{(github.event_name=='pull_request'||github.event_name=='pull_request_target')&&github.event.action=='closed'}}
     permissions:
       contents: write
     steps:

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -57,5 +57,3 @@ Contributing to Documentation
 This documentation is hosted on `GitHub
 <https://github.com/rsyslog/rsyslog/tree/main/doc>`_. Use the "Edit in
 GitHub" button on any page to suggest improvements.
-
-Dummy change to trigger a build.


### PR DESCRIPTION
This changes the docs workflow so the PR preview is published for both `pull_request` and `pull_request_target` events. Previously the `publish_pr_preview` job was gated to `pull_request` only, so runs triggered by `pull_request_target` were skipped.

What changed
- Add `pull_request` trigger to the workflow.
- Concurrency group now includes the event name to avoid cross-run cancellation between `pull_request` and `pull_request_target`.
- Checkout uses the PR head SHA for PR events (falls back to github.sha) so we build/deploy the PR’s content when appropriate.
- Gate heavy steps (setup, build, upload) on docs changes for both PR event types to keep behavior unchanged.
- Allow publish/cleanup jobs for both PR events, exclude `closed`, keep same-repo restriction, and require `docs_changed == 'true'`.

Why
- Fixes “Publish PR preview” being skipped on `pull_request_target`.
- Prevents cross-cancel when both events fire.
- Preserves safety by restricting preview publish to same-repo PRs and only when doc files changed.

Impact
- PR doc previews are published for same-repo PRs regardless of whether the workflow was triggered via `pull_request` or `pull_request_target`.
- Fork PRs continue to be excluded from publish by policy.
- No changes to non-doc PRs; they continue to skip heavy steps.

<!--
Thanks for your PR!

Commit Assistant (recommended for the commit message):
- Web (humans): https://www.rsyslog.com/tool_rsyslog-commit-assistant
- Base prompt (canonical): https://github.com/rsyslog/rsyslog/blob/main/ai/rsyslog_commit_assistant/base_prompt.txt

Important: put the substance into the **commit message** (not only here).
If needed, amend first (`git commit --amend`) and then open the PR.
-->

### Summary (non-technical, complete)
<!-- Why this change matters: modernization, maintainability, perf/security,
     Docker/CI readiness, or user value. This text should mirror the commit’s
     non-technical intro. -->

### References
<!-- Full GitHub URLs; use Fixes: only if conclusively fixed. -->
Refs: https://github.com/rsyslog/rsyslog/issues/<id>

### Notes (optional)
<!-- Mention tests/docs updates or planned follow-ups. If behavior changed,
     ensure the commit body has a one-line Impact and a one-line Before/After. -->

---

#### Quick check (optional)
- Commit message follows rules (ASCII; title ≤62, body ≤72; `<component>:`).
- Commit message includes non-technical “why”, Impact (if behavior/tests changed),
  and a one-line Before/After when behavior changed.
- Used the Commit Assistant or mirrored its structure.

---

#### Git workflow tips (optional, but helps reviews)
- Start by crafting the commit message locally (use the Assistant).
- If you already committed, improve it with:
  ```
  git commit --amend
  ```
- Squash related commits before PR where appropriate.
- Push your branch and then open the PR.
- If key info is only in the PR text, maintainers may ask you to move it
  into the commit message for a clean history.

