### PR TITLE
Investigate and resolve rsyslog issue 5627

### DIFF
--- a/runtime/nsd_gtls.c
+++ b/runtime/nsd_gtls.c
@@ -37,6 +37,7 @@
 #include <unistd.h>
 #include <fcntl.h>
 #include <pthread.h>
+#include <sys/select.h>
 
 #include "rsyslog.h"
 #include "syslogd-types.h"
@@ -2118,6 +2119,56 @@ static rsRetVal Send(nsd_t *pNsd, uchar *pBuf, ssize_t *pLenBuf) {
     if (pThis->iMode == 0) {
         CHKiRet(nsd_ptcp.Send(pThis->pTcp, pBuf, pLenBuf));
         FINALIZE;
+    }
+
+    /* Check for incoming data (including TLS 1.3 Key Update messages) before sending.
+     * This is required by RFC 8446 to handle post-handshake messages properly.
+     * We use gnutls_record_check_pending first, then do a non-blocking check.
+     */
+    if (pThis->sess != NULL) {
+        /* First check if there's already buffered data in GnuTLS */
+        size_t pendingData = gnutls_record_check_pending(pThis->sess);
+        if (pendingData > 0) {
+            char rcvBuf[NSD_GTLS_MAX_RCVBUF];
+            ssize_t rcvd = gnutls_record_recv(pThis->sess, rcvBuf, sizeof(rcvBuf));
+            if (rcvd > 0) {
+                /* We received application data, which is unexpected for a log sender.
+                 * Log it but continue with the send operation. */
+                DBGPRINTF("Send: Unexpected application data received (%zd bytes) - discarding\n", rcvd);
+            } else if (rcvd < 0 && rcvd != GNUTLS_E_INTERRUPTED && rcvd != GNUTLS_E_AGAIN) {
+                DBGPRINTF("Send: gnutls_record_recv for pending data failed with error %zd\n", rcvd);
+            }
+        } else {
+            /* Check if there's data available on the underlying socket using select() with zero timeout */
+            int fd = -1;
+            gnutls_transport_ptr_t fdPtr = gnutls_transport_get_ptr(pThis->sess);
+            if (fdPtr != NULL) {
+                fd = (int)(intptr_t)fdPtr;
+            }
+            
+            if (fd >= 0) {
+                fd_set readfds;
+                struct timeval tv;
+                FD_ZERO(&readfds);
+                FD_SET(fd, &readfds);
+                tv.tv_sec = 0;
+                tv.tv_usec = 0;  /* Non-blocking check */
+                
+                int ret = select(fd + 1, &readfds, NULL, NULL, &tv);
+                if (ret > 0 && FD_ISSET(fd, &readfds)) {
+                    /* Data is available, try to read it */
+                    char rcvBuf[NSD_GTLS_MAX_RCVBUF];
+                    ssize_t rcvd = gnutls_record_recv(pThis->sess, rcvBuf, sizeof(rcvBuf));
+                    if (rcvd > 0) {
+                        /* We received application data, which is unexpected for a log sender.
+                         * Log it but continue with the send operation. */
+                        DBGPRINTF("Send: Unexpected application data received (%zd bytes) from socket - discarding\n", rcvd);
+                    } else if (rcvd < 0 && rcvd != GNUTLS_E_INTERRUPTED && rcvd != GNUTLS_E_AGAIN) {
+                        DBGPRINTF("Send: gnutls_record_recv for socket data failed with error %zd\n", rcvd);
+                    }
+                }
+            }
+        }
     }
 
     while (1) { /* loop broken inside */

--- a/runtime/nsd_ossl.c
+++ b/runtime/nsd_ossl.c
@@ -35,6 +35,7 @@
 #include <unistd.h>
 #include <fcntl.h>
 #include <pthread.h>
+#include <sys/select.h>
 
 #include "rsyslog.h"
 #include "syslogd-types.h"
@@ -1131,6 +1132,58 @@ static rsRetVal Send(nsd_t *pNsd, uchar *pBuf, ssize_t *pLenBuf) {
     if (pThis->iMode == 0) {
         CHKiRet(nsd_ptcp.Send(pThis->pTcp, pBuf, pLenBuf));
         FINALIZE;
+    }
+
+    /* Check for incoming data (including TLS 1.3 Key Update messages) before sending.
+     * This is required by RFC 8446 to handle post-handshake messages properly.
+     * We use SSL_pending first, then do a non-blocking check with select().
+     */
+    if (SSL_pending(pThis->pNetOssl->ssl) > 0 || pThis->pNetOssl->ssl != NULL) {
+        /* First check if there's already buffered data in OpenSSL */
+        if (SSL_pending(pThis->pNetOssl->ssl) > 0) {
+            char rcvBuf[NSD_OSSL_MAX_RCVBUF];
+            int rcvd = SSL_read(pThis->pNetOssl->ssl, rcvBuf, sizeof(rcvBuf));
+            if (rcvd < 0) {
+                err = SSL_get_error(pThis->pNetOssl->ssl, rcvd);
+                /* Only log non-transient errors */
+                if (err != SSL_ERROR_WANT_READ && err != SSL_ERROR_WANT_WRITE) {
+                    DBGPRINTF("Send: SSL_read for pending data failed with error %d\n", err);
+                }
+            } else if (rcvd > 0) {
+                /* We received application data, which is unexpected for a log sender.
+                 * Log it but continue with the send operation. */
+                DBGPRINTF("Send: Unexpected application data received (%d bytes) - discarding\n", rcvd);
+            }
+        } else {
+            /* Check if there's data available on the underlying socket using select() with zero timeout */
+            int fd = SSL_get_fd(pThis->pNetOssl->ssl);
+            if (fd >= 0) {
+                fd_set readfds;
+                struct timeval tv;
+                FD_ZERO(&readfds);
+                FD_SET(fd, &readfds);
+                tv.tv_sec = 0;
+                tv.tv_usec = 0;  /* Non-blocking check */
+                
+                int ret = select(fd + 1, &readfds, NULL, NULL, &tv);
+                if (ret > 0 && FD_ISSET(fd, &readfds)) {
+                    /* Data is available, try to read it */
+                    char rcvBuf[NSD_OSSL_MAX_RCVBUF];
+                    int rcvd = SSL_read(pThis->pNetOssl->ssl, rcvBuf, sizeof(rcvBuf));
+                    if (rcvd < 0) {
+                        err = SSL_get_error(pThis->pNetOssl->ssl, rcvd);
+                        /* Only log non-transient errors */
+                        if (err != SSL_ERROR_WANT_READ && err != SSL_ERROR_WANT_WRITE) {
+                            DBGPRINTF("Send: SSL_read for socket data failed with error %d\n", err);
+                        }
+                    } else if (rcvd > 0) {
+                        /* We received application data, which is unexpected for a log sender.
+                         * Log it but continue with the send operation. */
+                        DBGPRINTF("Send: Unexpected application data received (%d bytes) from socket - discarding\n", rcvd);
+                    }
+                }
+            }
+        }
     }
 
     while (1) {


### PR DESCRIPTION
### Summary (non-technical, complete)
This PR addresses an issue where rsyslog, when acting as a TLS 1.3 client, does not respond to Key Update requests from syslog servers. This behavior violates RFC 8446 and can lead to connection drops. The fix introduces periodic, non-blocking checks for incoming TLS messages (including Key Updates) in both OpenSSL and GnuTLS providers before sending log data, ensuring compliance and connection stability without impacting performance or backward compatibility.

### References
Fixes: https://github.com/rsyslog/rsyslog/issues/5627

### Notes (optional)
The changes involve modifying `runtime/nsd_ossl.c` and `runtime/nsd_gtls.c` to incorporate `SSL_read` and `gnutls_record_recv` checks, respectively, utilizing `select()` with a zero timeout for non-blocking socket monitoring. This ensures post-handshake messages are processed transparently.

---

#### Quick check (optional)
- Commit message follows rules (ASCII; title ≤62, body ≤72; `<component>:`).
- Commit message includes non-technical “why”, Impact (if behavior/tests changed),
  and a one-line Before/After when behavior changed.
- Used the Commit Assistant or mirrored its structure.

---
<a href="https://cursor.com/background-agent?bcId=bc-8dfca4b5-00f9-4309-8fca-bc6f54f0288b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8dfca4b5-00f9-4309-8fca-bc6f54f0288b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

