### PR TITLE
PR Summary: Handle TLS 1.3 KeyUpdate during send in ossl/gtls (closes #5627)

### DIFF
--- a/.github/workflows/run_journal.yml
+++ b/.github/workflows/run_journal.yml
@@ -43,10 +43,6 @@ jobs:
     steps:
       - name: add extra dependencies
         run: |
-          echo 'deb http://download.opensuse.org/repositories/home:/rgerhards/xUbuntu_20.04/ /' \
-              | sudo tee /etc/apt/sources.list.d/home:rgerhards.list
-          curl -fsSL https://download.opensuse.org/repositories/home:rgerhards/xUbuntu_20.04/Release.key \
-              | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/home:rgerhards.gpg > /dev/null
           sudo apt-get update
           sudo apt-get install -y \
             lcov \

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,8 @@
 ----------------------------------------------------------------------------------------
 Scheduled Release 8.2510.0 (aka 2025.10) 2025-10-??
+- overall improved documentation via a large set of topic updates.
+- 2025-09-12: docker: fix collector, udp and tcp could not be enabled individually
+  If either one was disabled, so was the other one as well.
 - 2025-09-11: ommongodb: add support for mongo-c-driver v2
   Update pkg-config check for v2 of mongo-c-driver
   The name of the pkg-config file has changed from libmongoc-1.0.pc to

--- a/doc/BUILDS_README.md
+++ b/doc/BUILDS_README.md
@@ -4,7 +4,7 @@
 
 This doc is intended for maintainers and regular contributors to
 the project. The [`README.md`](README.md) doc covers the basic steps for one-off
-builds from the `master` branch.
+builds from the `main` branch.
 
 In all cases, the version number and release string do not *need* to be
 manually specified, though the directions do provide steps for doing so
@@ -43,11 +43,11 @@ steps in this document.
 1. Review the [`README.md`](README.md) file for instructions that cover
    installing `pip`, setting up the virtual environment and installing
    the latest version of the Sphinx package.
-1. Clone the https://github.com/rsyslog/rsyslog-doc.git repo
-1. Merge `master` into the current stable branch (e.g., `v8-stable`)
+1. Change to the `doc/` folder within the rsyslog repository
+1. Merge `main` into the current stable branch (e.g., `v8-stable`)
 1. Tag the stable branch
 1. Push all changes to the remote
-1. Run the `release_build.sh` script
+1. Run the `tools/release_build.sh` script
 1. Sync the contents of the `build` directory over to the web server
 1. Sync the latest release doc tarball to where the previous release
    tarball is hosted. Update references to this tarball as necessary.
@@ -72,7 +72,7 @@ You have several options:
    was within the tarball
     - For example, `cd /tmp/rsyslog-8.33.0`
       (the `rsyslog-8.33.0` folder is within the tarball)
-1. Run `sphinx -b html source build`
+1. Run `sphinx-build -b html source build`
 
 You may need to first follow the directions in the [`README.md`](README.md)
 doc to create or activate your virtual environment if the `sphinx` package
@@ -80,8 +80,8 @@ is not already installed and known to your installation of Python.
 
 #### Build from GitHub download
 
-1. Visit https://github.com/rsyslog/rsyslog-doc
-1. Click on 'Branch: master' and choose 'Tags' from the right-column
+1. Visit https://github.com/rsyslog/rsyslog
+1. Click on 'Branch: main' and choose 'Tags' from the right-column
 1. Select the `v8.33.0` tag
 1. Click on the 'Clone or download' green button to the far right
 1. Click 'Download ZIP' and save the file to your system
@@ -91,7 +91,7 @@ is not already installed and known to your installation of Python.
    within the tarball.
     - For example, `cd C:\users\deoren\Downloads\rsyslog-8.33.0`
       (the `rsyslog-8.33.0` folder is within the tarball)
-1. `sphinx -D version="8.33" release="8.33.0" -b html source build`
+1. `sphinx-build -D version="8.33" release="8.33.0" -b html source build`
     - You have to specify the `version` and `release` values here for now
       because we do not modify the `source/conf.py` file in the stable branch
       or its tags to hard-code the new version number.
@@ -105,9 +105,10 @@ is not already installed and known to your installation of Python.
 1. Review the [`README.md`](README.md) file for instructions that cover
    installing `pip`, setting up the virtual environment and installing
    the latest version of the Sphinx package.
-1. Run `git clone https://github.com/rsyslog/rsyslog-doc.git`
+1. Run `git clone https://github.com/rsyslog/rsyslog.git`
+1. Move to doc directory.
 1. Run `git checkout v8.33.0`
-1. Run `sphinx -D version="8.33" release="8.33.0" -b html source build`
+1. Run `sphinx-build -D version="8.33" release="8.33.0" -b html source build`
 
 You may need to first follow the directions in the [`README.md`](README.md)
 doc to create or activate your virtual environment if the `sphinx` package
@@ -119,7 +120,7 @@ is not already installed and known to your installation of Python.
 ### Obtain docs
 
 You have several options for obtaining a snapshot of the branch you would
-like to build (most often this is the `master` branch):
+like to build (most often this is the `main` branch):
 
 - Download a zip file from GitHub
 - Clone GitHub repo using Git
@@ -130,23 +131,23 @@ of the docs.
 
 ### Build from GitHub download
 
-These directions assume that you wish to build the docs from the `master`
-branch. Substitute `master` for any other branch that you wish to build.
+These directions assume that you wish to build the docs from the `main`
+branch. Substitute `main` for any other branch that you wish to build.
 
 1. Follow the steps previously given for downloading the zip file from GitHub,
    this time substituting the tag download option for the branch you wish
    to obtain doc sources for.
 1. Decompress the zip file and change your current working directory to
    that path.
-1. Run `sphinx -D release="dev-build" -b html source build` to generate
-   HTML format and `sphinx -b epub source build` to build an epub file.
+1. Run `sphinx-build -D release="dev-build" -b html source build` to generate
+   HTML format and `sphinx-build -b epub source build` to build an epub file.
 
 
 
 ### Build from Git repo
 
-These directions assume that you wish to build the docs from the `master`
-branch. Substitute `master` for any other branch that you wish to build.
+These directions assume that you wish to build the docs from the `main`
+branch. Substitute `main` for any other branch that you wish to build.
 
 The Sphinx build configuration file will attempt to pull the needed information
 from the Git repo in order to generate a "dev build" release string. This
@@ -156,7 +157,8 @@ and is useful to identify a dev build from a release set of documentation.
 1. Review the [`README.md`](README.md) file for instructions that cover
    installing `pip`, setting up the virtual environment and installing
    the latest version of the Sphinx package.
-1. Run `git clone https://github.com/rsyslog/rsyslog-doc.git`
-1. Run `git checkout master`
-1. Run `sphinx -b html source build` to generate HTML format and
-   `sphinx -b epub source build` to build an epub file.
+1. Run `git clone https://github.com/rsyslog/rsyslog.git`
+1. Change into the cloned repository: `cd rsyslog`
+1. Run `git checkout main`
+1. Change into the documentation folder: `cd doc`
+1. Run `sphinx-build -b html source build` to generate HTML format and `sphinx-build -b epub source build` to build an epub file.

--- a/doc/README.md
+++ b/doc/README.md
@@ -79,7 +79,7 @@ to Stack Exchange](https://serverfault.com/questions/ask?tags=rsyslog).
 
 ## Building the documentation
 
-These directions assume a modern Python 3 environment (Python 3.6 or newer is recommended).
+These directions assume a modern Python 3 environment (Python 3.8+; 3.10+ recommended).
 
 ### Assumptions
 

--- a/doc/contrib/cron_build_all_branches.sh
+++ b/doc/contrib/cron_build_all_branches.sh
@@ -21,8 +21,8 @@ get_latest_stable_branch() {
         tail -n 1
 }
 
-# This includes 'master', but intentionally excludes the stable branches
-# which master is periodically merged into
+# This includes 'main', but intentionally excludes the stable branches
+# which main is periodically merged into
 get_dev_branches() {
 
     git branch -r | \
@@ -102,7 +102,6 @@ read -r REPLY
 # Refresh local content
 echo "Fetching latest changes from origin ..."
 git fetch origin --prune --tags
-
 
 
 
@@ -232,10 +231,9 @@ tar -czf $output_dir/$doc_tarball source build LICENSE README.md ||
     { echo "[!] tarball creation failed for $latest_stable_tag tag ... aborting"; exit 1; }
 
 
-
 ###############################################################
-# Reset repo to master for next build
+# Reset repo to main for next build
 ###############################################################
 
 # This ensures that the build script is always at the latest version
-prep_branch_for_build master
+prep_branch_for_build main

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,5 +1,5 @@
 
-# Need at least 1.5.1 due to some of the features we are using
-sphinx >=1.5.1
+# Align with conf.py needs_sphinx requirement
+sphinx>=4.5.0
 furo
 sphinxcontrib.mermaid

--- a/doc/source/configuration/modules/mmsnmptrapd.rst
+++ b/doc/source/configuration/modules/mmsnmptrapd.rst
@@ -57,30 +57,34 @@ this module, with the help of filters or multiple rulesets and ruleset
 bindings. In short words, all capabilities rsyslog offers to control
 output modules are also available to mmsnmptrapd.
 
-**Configuration Parameters**:
+Module Parameters
+-----------------
 
-Note: parameter names are case-insensitive.
+.. note::
 
--  **$mmsnmptrapdTag** [tagname]
+   Parameter names are case-insensitive; camelCase is recommended for
+   readability.
 
-   Tells the module which start string inside the tag to look for. The
-   default is "snmptrapd". Note that a slash is automatically added to
-   this tag when it comes to matching incoming messages. It MUST not be
-   given, except if two slashes are required for whatever reasons (so
-   "tag/" results in a check for "tag//" at the start of the tag field).
+.. list-table::
+   :widths: 30 70
+   :header-rows: 1
 
--  **$mmsnmptrapdSeverityMapping** [severitymap]
-   This specifies the severity mapping table. It needs to be specified
-   as a list. Note that due to the current config system **no
-   whitespace** is supported inside the list, so be sure not to use any
-   whitespace inside it.
-   The list is constructed of Severity-Name/Severity-Value pairs,
-   delimited by comma. Severity-Name is a case-sensitive string, e.g.
-   "warning" and an associated numerical value (e.g. 4). Possible values
-   are in the rage 0..7 and are defined in RFC5424, table 2. The given
-   sample would be specified as "warning/4".
-   If multiple instances of mmsnmptrapd are used, each instance uses
-   the most recently defined $mmsnmptrapdSeverityMapping before itself.
+   * - Parameter
+     - Summary
+   * - :ref:`param-mmsnmptrapd-tag`
+     - .. include:: ../../reference/parameters/mmsnmptrapd-tag.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-mmsnmptrapd-severitymapping`
+     - .. include:: ../../reference/parameters/mmsnmptrapd-severitymapping.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+
+.. toctree::
+   :hidden:
+
+   ../../reference/parameters/mmsnmptrapd-tag
+   ../../reference/parameters/mmsnmptrapd-severitymapping
 
 **Caveats/Known Bugs:**
 
@@ -93,10 +97,9 @@ warning severities. The default tag is used.
 
 ::
 
-  $ModLoad mmsnmptrapd # needs to be done just once
+  module(load="mmsnmptrapd" severityMapping="warning/4,error/3") # needs to be done just once
   # ... other module loads and listener setup ...
   *.* /path/to/file/with/originalMessage # this file receives unmodified messages
-  $mmsnmptrapdSeverityMapping warning/4,error/3
   *.* :mmsnmptrapd: # now message is modified
   *.* /path/to/file/with/modifiedMessage # this file receives modified messages
   # ... rest of config ...

--- a/doc/source/configuration/modules/mmtaghostname.rst
+++ b/doc/source/configuration/modules/mmtaghostname.rst
@@ -40,35 +40,33 @@ To successfully compile mmtaghostname module.
 Configuration Parameters
 ========================
 
-Tag
-^^^
+Input Parameters
+----------------
 
-.. csv-table::
-  :header: "type", "mandatory", "format", "default"
-  :widths: auto
-  :class: parameter-table
+.. note::
 
-  "string", "no", ,"none"
+   Parameter names are case-insensitive. The camelCase convention is recommended.
 
-The tag to be assigned to messages modified. If you would like to see the 
-colon after the tag, you need to include it when you assign a tag value, 
-like so: ``tag="myTagValue:"``.
+.. list-table::
+   :widths: 30 70
+   :header-rows: 1
 
-If this attribute is no provided, messages tags are not modified.
+   * - Parameter
+     - Summary
+   * - :ref:`param-mmtaghostname-tag`
+     - .. include:: ../../reference/parameters/mmtaghostname-tag.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-mmtaghostname-forcelocalhostname`
+     - .. include:: ../../reference/parameters/mmtaghostname-forcelocalhostname.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
 
-ForceLocalHostname
-^^^^^^^^^^^^^^^^^^
+.. toctree::
+   :hidden:
 
-.. csv-table::
-  :header: "type", "mandatory", "format", "default"
-  :widths: auto
-  :class: parameter-table
-
-  "Binary", "no", ,"off"
-
-This attribute force to set the HOSTNAME of the message to the rsyslog
-value "localHostName". This allow to set a valid value to message received
-received from local application through imudp or imtcp.
+   ../../reference/parameters/mmtaghostname-tag
+   ../../reference/parameters/mmtaghostname-forcelocalhostname
 
 Sample
 ======
@@ -83,7 +81,7 @@ the HOSTNAME is overwritten and a tag is set.
     global(localhostname="sales-front")
     
     ruleset(name="TagUDP" parser=[ "rsyslog.rfc5424" ]) {
-        action(type="mmtaghostname" tag="front" forcelocalhostname="on")
+        action(type="mmtaghostname" tag="front" forceLocalHostname="on")
         call ...
     }
     input(type="imudp" port="514" ruleset="TagUDP")

--- a/doc/source/containers/collector.rst
+++ b/doc/source/containers/collector.rst
@@ -8,9 +8,23 @@ rsyslog/rsyslog-collector
    pair: containers; rsyslog/rsyslog-collector
    pair: Docker images; rsyslog/rsyslog-collector
 
-Built on the standard image, ``rsyslog-collector`` adds modules for
-centralised log aggregation. It exposes TCP and UDP syslog ports and can
-forward data to storage backends.
+Overview
+--------
+
+The ``rsyslog-collector`` container image extends the standard
+:doc:`standard` base with modules for **centralised log aggregation**.
+It is preconfigured to receive logs via UDP, TCP, and optionally RELP, and can
+forward them to storage backends or files.
+
+This image is the recommended starting point for building a log
+collector or relay service.
+
+.. note::
+
+   - **UDP (514/udp)** and **TCP (514/tcp)** are enabled by default.  
+   - **RELP (2514/tcp)** is available but **disabled by default**.  
+   - External deployments usually map RELP to **20514/tcp** to avoid conflicts
+     with the standard syslog port.
 
 Environment Variables
 ---------------------
@@ -26,6 +40,11 @@ Runtime behaviour can be tuned with the following variables:
 .. envvar:: ENABLE_TCP
 
    Enable TCP syslog reception. Default ``on``.
+
+.. _containers-user-collector-enable_relp:
+.. envvar:: ENABLE_RELP
+
+   Enable RELP syslog reception (internal port ``2514/tcp``). Default ``off``.
 
 .. _containers-user-collector-write_all_file:
 .. envvar:: WRITE_ALL_FILE
@@ -54,3 +73,56 @@ Runtime behaviour can be tuned with the following variables:
    :noindex:
 
    Role name consumed by the entrypoint. Defaults to ``collector``.
+
+Port Mapping Reference
+----------------------
+
++-----------+----------------+------------------+-----------------+
+| Protocol  | Container Port | Example External | Controlled by   |
++===========+================+==================+=================+
+| UDP Syslog | 514/udp       | 514/udp          | ``ENABLE_UDP``  |
++-----------+----------------+------------------+-----------------+
+| TCP Syslog | 514/tcp       | 514/tcp          | ``ENABLE_TCP``  |
++-----------+----------------+------------------+-----------------+
+| RELP       | 2514/tcp      | 20514/tcp        | ``ENABLE_RELP`` |
++-----------+----------------+------------------+-----------------+
+
+Example Deployment (docker-compose)
+-----------------------------------
+
+A minimal configuration using `docker compose`:
+
+.. code-block:: yaml
+
+   version: "3.9"
+
+   services:
+     rsyslog-collector:
+       image: rsyslog/rsyslog-collector:latest
+       environment:
+         ENABLE_UDP: "on"
+         ENABLE_TCP: "on"
+         ENABLE_RELP: "on"
+       ports:
+         - "514:514/udp"    # Syslog UDP
+         - "514:514/tcp"    # Syslog TCP
+         - "20514:2514/tcp" # RELP (external 20514 → internal 2514)
+       volumes:
+         - ./data:/var/log   # Optional: collect logs on host
+
+Verifying the Container
+-----------------------
+
+To confirm that the collector is listening on the expected ports:
+
+.. code-block:: bash
+
+   docker compose exec rsyslog-collector ss -tuln
+
+This should show listeners on ``514/udp``, ``514/tcp``, and ``2514/tcp`` when RELP is enabled.
+
+.. seealso::
+
+   - `GitHub Discussions <https://github.com/rsyslog/rsyslog/discussions>`_ for community support.
+   - `rsyslog Assistant AI <https://rsyslog.ai>`_ for self-help and examples.
+

--- a/doc/source/includes/substitution_definitions.inc.rst
+++ b/doc/source/includes/substitution_definitions.inc.rst
@@ -31,16 +31,16 @@
 .. _RsyslogPackageDownloads: http://www.rsyslog.com/downloads/download-other/
 
 .. |GitHubDocProject| replace:: rsyslog source documentation
-.. _GitHubDocProject: https://github.com/rsyslog/rsyslog/doc
+.. _GitHubDocProject: https://github.com/rsyslog/rsyslog/tree/main/doc
 
-.. |GitHubDocProjectREADME| replace:: rsyslog-doc project README
-.. _GitHubDocProjectREADME: https://github.com/rsyslog/rsyslog/doc/blob/master/README.md
+.. |GitHubDocProjectREADME| replace:: rsyslog doc/ README
+.. _GitHubDocProjectREADME: https://github.com/rsyslog/rsyslog/blob/main/doc/README.md
 
-.. |GitHubDocProjectDevREADME| replace:: rsyslog-doc project BUILDS README
-.. _GitHubDocProjectDevREADME: https://github.com/rsyslog/rsyslog-doc/blob/master/BUILDS_README.md
+.. |GitHubDocProjectDevREADME| replace:: rsyslog doc/ BUILDS README
+.. _GitHubDocProjectDevREADME: https://github.com/rsyslog/rsyslog/blob/main/doc/BUILDS_README.md
 
-.. |GitHubDocProjectGoodFirstIssueLabel| replace:: rsyslog-doc issues marked with Good First Issue label
-.. _GitHubDocProjectGoodFirstIssueLabel: https://github.com/rsyslog/rsyslog-doc/labels/good%20first%20issue
+.. |GitHubDocProjectGoodFirstIssueLabel| replace:: rsyslog doc issues marked with Good First Issue label
+.. _GitHubDocProjectGoodFirstIssueLabel: https://github.com/rsyslog/rsyslog/labels/good%20first%20issue
 
 
 .. |GitHubDocProjectHelpWantedLabel| replace:: rsyslog-doc issues marked with Help Wanted label
@@ -63,7 +63,7 @@
 .. _GitHubSourceProject: https://github.com/rsyslog/rsyslog/
 
 .. |GitHubSourceProjectREADME| replace:: rsyslog project README
-.. _GitHubSourceProjectREADME: https://github.com/rsyslog/rsyslog/blob/master/README.md
+.. _GitHubSourceProjectREADME: https://github.com/rsyslog/rsyslog/blob/main/README.md
 
 .. |GitHubSourceProjectGoodFirstIssueLabel| replace:: rsyslog issues marked with Good First Issue label
 .. _GitHubSourceProjectGoodFirstIssueLabel: https://github.com/rsyslog/rsyslog/labels/good%20first%20issue

--- a/doc/source/installation/build_from_repo.rst
+++ b/doc/source/installation/build_from_repo.rst
@@ -22,7 +22,7 @@ code <http://www.rsyslog.com/where-to-find-the-rsyslog-source-code/>`_\ "
 page on the project site will point you to the current repository
 location.
 
-After you have cloned the repository, you are in the master branch by
+After you have cloned the repository, you are in the main branch by
 default. This is where we keep the devel branch. If you need any other
 branch, you need to do a "git checkout --track -b branch origin/branch".
 For example, the command to check out the beta branch is "git checkout

--- a/doc/source/rainerscript/global.rst
+++ b/doc/source/rainerscript/global.rst
@@ -872,3 +872,23 @@ The `libcapng.enable` global option defines whether rsyslog should
 drop capabilities at startup or not. By default, it is set to "on".
 Until this point, if the project was compiled with --enable-libcap-ng option,
 capabilities were automatically dropped. This is configurable now.
+
+compactjsonstring
+^^^^^^^^^^^^^^^^^
+
+.. csv-table::
+   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
+   :widths: auto
+   :class: parameter-table
+
+   "binary", "off", "no", "none"
+
+.. versionadded:: 8.2510.0
+
+The `compactjsonstring` global option defines whether JSON strings generated
+by rsyslog should be in the most compact form, even without spaces.
+The traditional default is that spaces are introduced. This increases
+readability for humans, but needs more resources (disk, transfer, computation)
+in automated pipelines.
+To keep things as compatible as possible, we leave the default as "off" but
+recommend that this option is turned on for use in data pipelines.

--- a/doc/source/reference/parameters/mmsnmptrapd-severitymapping.rst
+++ b/doc/source/reference/parameters/mmsnmptrapd-severitymapping.rst
@@ -1,0 +1,63 @@
+.. _param-mmsnmptrapd-severitymapping:
+.. _mmsnmptrapd.parameter.module.severitymapping:
+
+severityMapping
+===============
+
+.. index::
+   single: mmsnmptrapd; severityMapping
+   single: severityMapping
+
+.. summary-start
+
+Defines severity string to numeric code mappings.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/mmsnmptrapd`.
+
+:Name: severityMapping
+:Scope: module
+:Type: string
+:Default: module=none
+:Required?: no
+:Introduced: at least 5.8.1, possibly earlier
+
+Description
+-----------
+This specifies the severity mapping table. It must be specified as a list.
+Note that **no whitespace** is supported inside the list, as it will likely
+lead to parsing errors. The list is
+constructed of Severity-Name/Severity-Value pairs, delimited by comma.
+Severity-Name is a case-sensitive string, e.g. ``warning`` and an associated
+numerical value (e.g. 4). Possible values are in the range 0..7 and are defined
+in `RFC5424, table 2 <https://datatracker.ietf.org/doc/html/rfc5424#section-6.2.1>`_.
+The given sample would be specified as ``warning/4``. The mapping is defined
+when the module is loaded using the ``module()`` statement. This setting applies
+to all subsequent actions that use this module instance. To use different
+mappings, load separate instances of the module in different rulesets.
+
+Module usage
+------------
+.. _param-mmsnmptrapd-module-severitymapping:
+.. _mmsnmptrapd.parameter.module.severitymapping-usage:
+
+.. code-block:: rsyslog
+
+   module(load="mmsnmptrapd" severityMapping="warning/4,error/3")
+
+Legacy names (for reference)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Historic names/directives for compatibility. Do not use in new configs.
+
+.. _mmsnmptrapd.parameter.legacy.mmsnmptrapdseveritymapping:
+
+- $mmsnmptrapdSeverityMapping — maps to severityMapping (status: legacy)
+
+.. index::
+   single: mmsnmptrapd; $mmsnmptrapdSeverityMapping
+   single: $mmsnmptrapdSeverityMapping
+
+See also
+--------
+See also :doc:`../../configuration/modules/mmsnmptrapd`.

--- a/doc/source/reference/parameters/mmsnmptrapd-tag.rst
+++ b/doc/source/reference/parameters/mmsnmptrapd-tag.rst
@@ -1,0 +1,57 @@
+.. _param-mmsnmptrapd-tag:
+.. _mmsnmptrapd.parameter.module.tag:
+
+tag
+===
+
+.. index::
+   single: mmsnmptrapd; tag
+   single: tag
+
+.. summary-start
+
+Specifies the tag prefix that identifies messages for processing.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/mmsnmptrapd`.
+
+:Name: tag
+:Scope: module
+:Type: word (see :doc:`../../rainerscript/constant_strings`)
+:Default: module=snmptrapd
+:Required?: no
+:Introduced: at least 5.8.1, possibly earlier
+
+Description
+-----------
+Tells the module which start string inside the tag to look for. The default is
+``snmptrapd``. Note that a slash (``/``) is automatically appended to this tag for
+matching. You should not include a trailing slash unless you specifically need
+to match a double slash. For example, setting ``tag="tag/"`` results in a
+check for ``tag//`` at the start of the tag field.
+
+Module usage
+------------
+.. _param-mmsnmptrapd-module-tag:
+.. _mmsnmptrapd.parameter.module.tag-usage:
+
+.. code-block:: rsyslog
+
+   module(load="mmsnmptrapd" tag="snmptrapd")
+
+Legacy names (for reference)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Historic names/directives for compatibility. Do not use in new configs.
+
+.. _mmsnmptrapd.parameter.legacy.mmsnmptrapdtag:
+
+- $mmsnmptrapdTag — maps to tag (status: legacy)
+
+.. index::
+   single: mmsnmptrapd; $mmsnmptrapdTag
+   single: $mmsnmptrapdTag
+
+See also
+--------
+See also :doc:`../../configuration/modules/mmsnmptrapd`.

--- a/doc/source/reference/parameters/mmtaghostname-forcelocalhostname.rst
+++ b/doc/source/reference/parameters/mmtaghostname-forcelocalhostname.rst
@@ -1,0 +1,53 @@
+.. _param-mmtaghostname-forcelocalhostname:
+.. _mmtaghostname.parameter.input.forcelocalhostname:
+
+forceLocalHostname
+==================
+
+.. index::
+   single: mmtaghostname; forceLocalHostname
+   single: forceLocalHostname
+
+.. summary-start
+
+Forces the message ``HOSTNAME`` to the rsyslog ``localHostName`` value.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/mmtaghostname`.
+
+:Name: forceLocalHostname
+:Scope: input
+:Type: boolean
+:Default: off
+:Required?: no
+:Introduced: at least 7.0, possibly earlier
+
+Description
+-----------
+When enabled, this parameter forces the message's ``HOSTNAME`` field to the rsyslog value
+``localHostName``. This is useful for setting a consistent hostname on
+messages that may not have one, e.g. those received via ``imudp`` or
+``imtcp``.
+A common use case is with applications in auto-scaling environments
+(e.g. AWS), where instances may have ephemeral hostnames. Forcing the
+hostname to the rsyslog host's name can provide more meaningful and
+consistent hostnames in logs.
+
+Input usage
+-----------
+.. _mmtaghostname.parameter.input.forcelocalhostname-usage:
+
+.. code-block:: rsyslog
+
+   action(type="mmtaghostname"
+          forceLocalHostname="on")
+
+Notes
+-----
+- Legacy documentation referred to the type as ``Binary``;
+  it is treated as boolean.
+
+See also
+--------
+* :doc:`../../configuration/modules/mmtaghostname`

--- a/doc/source/reference/parameters/mmtaghostname-tag.rst
+++ b/doc/source/reference/parameters/mmtaghostname-tag.rst
@@ -1,0 +1,46 @@
+.. _param-mmtaghostname-tag:
+.. _mmtaghostname.parameter.input.tag:
+
+tag
+===
+
+.. index::
+   single: mmtaghostname; tag
+   single: tag
+
+.. summary-start
+
+Assigns a tag to messages. This is useful for inputs like ``imudp`` or
+``imtcp`` that do not provide a tag.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/mmtaghostname`.
+
+:Name: tag
+:Scope: input
+:Type: string
+:Default: none
+:Required?: no
+:Introduced: at least 7.0, possibly earlier
+
+Description
+-----------
+The tag to be assigned to messages processed by this module. This is often
+used to route messages to different rulesets or output actions based on the
+tag. If you would like to see the colon after the tag, you need to include it
+when you assign a tag value, like so: ``tag="myTagValue:"``. If this
+parameter is not set, message tags are not modified.
+
+Input usage
+-----------
+.. _mmtaghostname.parameter.input.tag-usage:
+
+.. code-block:: rsyslog
+
+   action(type="mmtaghostname"
+          tag="front")
+
+See also
+--------
+* :doc:`../../configuration/modules/mmtaghostname`

--- a/doc/tools/buildenv/Dockerfile
+++ b/doc/tools/buildenv/Dockerfile
@@ -9,7 +9,7 @@ CMD	["build-doc"]
 ENTRYPOINT ["/home/appliance/starter.sh"]
 VOLUME	/rsyslog-doc
 RUN	chmod a+w /rsyslog-doc
-ENV	BRANCH="master" \
+ENV	BRANCH="main" \
 	FORMAT="html" \
 	STRICT="-n -W"
 COPY	starter.sh ./

--- a/packaging/docker/dev_env/debian/base/sid/Dockerfile
+++ b/packaging/docker/dev_env/debian/base/sid/Dockerfile
@@ -3,8 +3,8 @@
 FROM	debian:sid
 ENV	DEBIAN_FRONTEND=noninteractive
 RUN 	apt-get update && \
-	apt-get upgrade -y
-RUN	apt-get install -y \
+	apt-get upgrade -y \
+	&& apt-get install -y \
 	autoconf \
 	autoconf-archive \
 	automake \
@@ -30,6 +30,7 @@ RUN	apt-get install -y \
 	libhiredis-dev \
 	libkrb5-dev \
 	liblz4-dev \
+	libmaxminddb-dev \
 	default-libmysqlclient-dev \
 	libnet1-dev \
 	libpcap-dev \
@@ -55,10 +56,10 @@ RUN	apt-get install -y \
 	vim \
 	wget \
 	zlib1g-dev \
-	zstd
+	libmongoc-dev \
+	zstd \
+	&& apt clean
 #	libbson-dev
-#	libmaxminddb-dev 
-#	libmongoc-dev 
 #	libgrok1 libgrok-dev
 #	software-properties-common
 #RUN     add-apt-repository ppa:adiscon/v8-stable -y && \
@@ -93,9 +94,6 @@ RUN	groupadd rsyslog \
 RUN	mkdir /rsyslog \
 	&& chown rsyslog:rsyslog /rsyslog
 VOLUME	/rsyslog
-ENV	PKG_CONFIG_PATH=/usr/lib64/pkgconfig \
-	LD_LIBRARY_PATH=/usr/lib \
-	DEBIAN_FRONTEND=
 
 # bump dependency version below to trigger a dependency rebuild
 # but not a full one (via --no-cache)
@@ -108,7 +106,7 @@ RUN	cd helper-projects && \
 	git clone https://github.com/guardtime/libksi.git && \
 	cd libksi && \
 	autoreconf -fvi && \
-	./configure --libdir=/usr/lib64 && \
+	./configure && \
 	make -j && \
 	make install && \
 	cd .. && \
@@ -119,28 +117,15 @@ RUN	cd helper-projects && \
 #	liblz4-dev
 
 # we need the latest librdkafka as there as always required updates
-#RUN	cd helper-projects && \
-#	git clone https://github.com/edenhill/librdkafka && \
-#	cd librdkafka && \
-#	(unset CFLAGS; ./configure --prefix=/usr --libdir=/usr/lib64 --CFLAGS="-g" ; make -j) && \
-#	make install && \
-#	cd .. && \
+RUN	cd helper-projects && \
+	git clone https://github.com/edenhill/librdkafka && \
+	cd librdkafka && \
+	(unset CFLAGS; ./configure --prefix=/usr --CFLAGS="-g" ; make -j) && \
+	make install && \
+	cd .. && \
 # Note: we do NOT delete the source as we may need it to
 # uninstall (in case the user wants to go back to system-default)
-#	cd ..
-
-# libmongoc is unfortunately not available on openSuse - later?
-#RUN	cd helper-projects && \
-#	wget -nv https://github.com/mongodb/mongo-c-driver/releases/download/1.12.0/mongo-c-driver-1.12.0.tar.gz && \
-#	tar xzf mongo-c-driver-1.12.0.tar.gz && \
-#	cd mongo-c-driver-1.12.0 && \
-#	mkdir cmake-build && \
-#	cmake -DENABLE_AUTOMATIC_INIT_AND_CLEANUP=OFF && \
-#	make -j4 && \
-#	make install && \
-#	cd .. && \
-#	rm -r mongo-c-driver-1.12.0* && \
-#	cd ..
+	cd ..
 
 # bump dependency version below to trigger a dependency rebuild
 # but not a full one (via --no-cache)
@@ -150,7 +135,7 @@ ENV	RSYSLOG_DEP_VERSION=2020-01-26
 #RUN	cd helper-projects && \
 #	git clone https://github.com/rsyslog/libestr.git && \
 #	cd libestr && \
-#	autoreconf -fi && ./configure --libdir=/usr/lib64 --prefix=/usr && \
+#	autoreconf -fi && ./configure --prefix=/usr && \
 #	make -j4 && \
 #	make install && \
 #	cd .. && \
@@ -162,7 +147,7 @@ RUN	cd helper-projects && \
 	git clone https://github.com/rsyslog/liblogging.git && \
 	cd liblogging && \
 	autoreconf -fi && \
-	./configure --prefix=/usr --libdir=/usr/lib64 --disable-journal && \
+	./configure --prefix=/usr --disable-journal && \
 	make -j && \
 	make install && \
 	cd .. && \
@@ -177,7 +162,7 @@ RUN	cd helper-projects && \
 	git clone https://github.com/rsyslog/liblognorm.git && \
 	cd liblognorm && \
 	autoreconf -fi && \
-	./configure --prefix=/usr --libdir=/usr/lib64 && \
+	./configure --prefix=/usr && \
 	make -j && \
 	make install && \
 	cd .. && \
@@ -189,7 +174,7 @@ RUN	cd helper-projects && \
 	git clone https://github.com/rsyslog/librelp.git && \
 	cd librelp && \
 	autoreconf -fi && \
-	./configure --prefix=/usr --enable-compile-warnings=yes --libdir=/usr/lib64 && \
+	./configure --prefix=/usr --enable-compile-warnings=yes && \
 	make -j && \
 	make install && \
 	cd .. && \
@@ -212,14 +197,14 @@ ENV	RSYSLOG_CONFIGURE_OPTIONS \
 	--enable-imfile \
 	--enable-imhttp \
 	--enable-imjournal \
-	--disable-imkafka \
+	--enable-imkafka \
 	--enable-impstats \
 	--enable-improg \
 	--enable-imptcp \
 	--enable-impcap \
 	--enable-imtuxedolog \
 	--disable-kafka-tests \
-	--disable-kmsg \
+	--enable-kmsg \
 	--enable-ksi-ls12 \
 	--enable-libdbi \
 	--enable-libfaketime \
@@ -229,7 +214,7 @@ ENV	RSYSLOG_CONFIGURE_OPTIONS \
 	--enable-mmanon \
 	--enable-mmaudit \
 	--enable-mmcount \
-	--disable-mmdblookup \
+	--enable-mmdblookup \
 	--enable-mmfields \
 	--disable-mmgrok \
 	--enable-mmjsonparse \
@@ -247,8 +232,9 @@ ENV	RSYSLOG_CONFIGURE_OPTIONS \
 	--enable-omhiredis \
 	--enable-omhttpfs \
 	--enable-omjournal \
-	--disable-omkafka \
-	--disable-ommongodb \
+	--enable-omkafka \
+	--enable-ommongodb \
+	--enable-omclickhouse \
 	--enable-omprog \
 	--enable-omrelp-default-port=13515 \
 	--enable-omruleset \

--- a/packaging/docker/dev_env/ubuntu/base/24.04/Dockerfile
+++ b/packaging/docker/dev_env/ubuntu/base/24.04/Dockerfile
@@ -71,7 +71,8 @@ RUN 	apt-get update && \
 	vim \
 	wget \
 	zlib1g-dev \
-	zstd
+	zstd \
+	&& apt clean
 #	libgrok1 libgrok-dev \
 ENV	REBUILD=1
 # Adiscon/rsyslog components
@@ -120,12 +121,14 @@ RUN	mkdir /local_dep_cache
 #		/etc/clickhouse-server/config.xml
 
 WORKDIR	/home/devel
-RUN	mkdir /rsyslog
-VOLUME	/rsyslog
 RUN	groupadd rsyslog \
 	&& useradd -g rsyslog  -s /bin/bash rsyslog \
 	&& echo "rsyslog ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers \
 	&& echo "buildbot ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+RUN	mkdir /rsyslog \
+	&& chmod o+rw /rsyslog \
+	&& chown rsyslog:rsyslog /rsyslog
+VOLUME	/rsyslog
 
 # mysql needs a little help:
 RUN	mkdir -p /var/run/mysqld && \
@@ -312,6 +315,7 @@ ENV RSYSLOG_CONFIGURE_OPTIONS=" \
 	--enable-impcap \
 	--enable-imptcp \
 	--enable-kafka-tests \
+	--enable-kmsg \
 	--enable-ksi-ls12 \
 	--enable-libdbi \
 	--enable-libfaketime \
@@ -387,5 +391,20 @@ RUN	printf '\n' > /var/log/mysql/error.log
 ENV	ASAN_SYMBOLIZER_PATH="/usr/lib/llvm-18/bin/llvm-symbolizer"
 VOLUME	/var/lib/mysql
 ENV	C_INCLUDE_PATH="/usr/include/tirpc/"
+
+RUN	groupadd -g 1002 rsyslog998 \
+	&& groupadd -g 1003 rsyslog997 \
+	&& groupadd -g 1004 rsyslog996 \
+	&& groupadd -g 1005 rsyslog995 \
+	&& useradd -u 1002 -g rsyslog998  -s /bin/bash rsyslog998 \
+	&& useradd -u 1003 -g rsyslog997  -s /bin/bash rsyslog997 \
+	&& useradd -u 1004 -g rsyslog996  -s /bin/bash rsyslog996 \
+	&& useradd -u 1005 -g rsyslog995  -s /bin/bash rsyslog995  \
+	&& echo "rsyslog999 ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers \
+	&& echo "rsyslog998 ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers \
+	&& echo "rsyslog997 ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers \
+	&& echo "rsyslog996 ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers \
+	&& echo "rsyslog995 ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+
 WORKDIR	/rsyslog
 USER	rsyslog

--- a/packaging/docker/rsyslog/Makefile
+++ b/packaging/docker/rsyslog/Makefile
@@ -14,7 +14,7 @@ ORG_NAME = rsyslog
 
 # Default version for all images.
 # This can be overridden via command line: 'make VERSION=my-custom-tag <target>'
-VERSION ?= 2025-06
+VERSION ?= 2025-10
 
 # Variable to control cache busting. Set to 'yes' to force a rebuild from scratch for all targets.
 # Example: make all REBUILD=yes

--- a/packaging/docker/rsyslog/collector/10-collector.conf
+++ b/packaging/docker/rsyslog/collector/10-collector.conf
@@ -3,8 +3,11 @@
 
 module(load="imtcp" config.enabled=`echo $ENABLE_UDP`)
 module(load="imudp" config.enabled=`echo $ENABLE_TCP`)
+module(load="imrelp" config.enabled=`echo $ENABLE_RELP`)
 
 input(	config.enabled=`echo $ENABLE_UDP`
 	type="imudp" port="514" ruleset="rs-main")
 input(	config.enabled=`echo $ENABLE_TCP`
 	type="imtcp" port="514" ruleset="rs-main")
+input(	config.enabled=`echo $ENABLE_RELP`
+	type="imrelp" port="2514" ruleset="rs-main")

--- a/packaging/docker/rsyslog/collector/10-collector.conf
+++ b/packaging/docker/rsyslog/collector/10-collector.conf
@@ -1,8 +1,8 @@
 # reception of network messages. Comment out unneeded functionality
 # NOTE: this is unencrypted config!
 
-module(load="imtcp" config.enabled=`echo $ENABLE_UDP`)
-module(load="imudp" config.enabled=`echo $ENABLE_TCP`)
+module(load="imudp" config.enabled=`echo $ENABLE_UDP`)
+module(load="imtcp" config.enabled=`echo $ENABLE_TCP`)
 module(load="imrelp" config.enabled=`echo $ENABLE_RELP`)
 
 input(	config.enabled=`echo $ENABLE_UDP`

--- a/packaging/docker/rsyslog/collector/Dockerfile
+++ b/packaging/docker/rsyslog/collector/Dockerfile
@@ -33,6 +33,7 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         rsyslog-elasticsearch \
         rsyslog-omhttp \
+        rsyslog-relp \
     && apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
@@ -45,10 +46,12 @@ COPY 10-collector.conf 80-file-output.conf /etc/rsyslog.d/
 # These ports will be exposed by default for UDP and TCP syslog reception.
 EXPOSE 514/udp
 EXPOSE 514/tcp
+EXPOSE 2514/tcp
 
 # Default config toggles for an entrypoint script to use
 ENV ENABLE_UDP=on
 ENV ENABLE_TCP=on
+ENV ENABLE_RELP=off
 ENV WRITE_ALL_FILE=on
 ENV WRITE_JSON_FILE=on
 

--- a/runtime/Makefile.am
+++ b/runtime/Makefile.am
@@ -165,7 +165,7 @@ endif
 # basic network support, needed for rsyslog startup (e.g. our own system name)
 #
 pkglib_LTLIBRARIES += lmnet.la
-lmnet_la_SOURCES = net.c net.h
+lmnet_la_SOURCES = net.c net.h netns_socket.c netns_socket.h
 lmnet_la_CPPFLAGS = $(PTHREADS_CFLAGS) $(RSRT_CFLAGS)
 lmnet_la_LDFLAGS = -module -avoid-version ../compat/compat_la-getifaddrs.lo
 lmnet_la_LIBADD =

--- a/runtime/errmsg.c
+++ b/runtime/errmsg.c
@@ -72,15 +72,13 @@ int hadErrMsgs(void) {
     return bHadErrMsgs;
 }
 
-/* We now receive three parameters: one is the internal error code
- * which will also become the error message number, the second is
- * errno - if it is non-zero, the corresponding error message is included
- * in the text and finally the message text itself. Note that it is not
- * 100% clean to use the internal errcode, as it may be reached from
- * multiple actual error causes. However, it is much better than having
- * no error code at all (and in most cases, a single internal error code
- * maps to a specific error event).
- * rgerhards, 2008-06-27
+/** @internal
+ * Build and emit a single diagnostic line.
+ *
+ * - If iErrno != 0, append strerror(iErrno).
+ * - If iErrCode is neither NO_ERRCODE nor RS_RET_ERR, append a help URL.
+ * - Truncate to the configured max line length.
+ * - Set the "had error" flag for LOG_ERR.
  */
 static void doLogMsg(const int iErrno, const int iErrCode, const int severity, const char *msg) {
     char buf[2048];

--- a/runtime/errmsg.h
+++ b/runtime/errmsg.h
@@ -26,13 +26,95 @@
 #define NO_ERRCODE -1
 
 /* prototypes */
+/**
+ * @brief Close and reset internal resources of the errmsg subsystem.
+ *
+ * Closes the oversize-message log fd if open. Intended for orderly shutdown.
+ * @note This function is not thread-safe as it accesses a global flag without locks.
+ */
 void errmsgExit(void);
+
+/**
+ * @brief Reopen oversize-message resources on configuration reload (HUP).
+ *
+ * Intended to be called from rsyslog's SIGHUP handler. This closes the
+ * oversize-message log file descriptor so the next write will reopen it
+ * using the current configuration. This follows the traditional syslogd
+ * pattern of reloading or reopening resources on HUP.
+ *
+ * Thread-safe.
+ */
 void errmsgDoHUP(void);
+
+/**
+ * @brief Reset the "had error messages" flag.
+ *
+ * Must be called before processing config files to start with a clean state.
+ * @note This function is not thread-safe as it accesses a global flag without locks.
+ */
 void resetErrMsgsFlag(void);
+
+/**
+ * @brief Query whether a LOG_ERR message has been logged since the last reset.
+ *
+ * @return nonzero if a LOG_ERR was emitted since resetErrMsgsFlag(), else 0.
+ *
+ * @note This function is not thread-safe as it accesses a global flag without locks.
+ */
 int hadErrMsgs(void);
+
+/**
+ * @brief Log an error message with errno and error code context.
+ *
+ * Formats and writes an error message to the rsyslog internal log.
+ * Use this for reporting fatal or unexpected conditions.
+ *
+ * @param iErrno   The system errno value (0 if not applicable).
+ * @param iErrCode Internal rsyslog error code.
+ * @param fmt      printf-style format string.
+ * @param ...      Arguments matching the format string.
+ *
+ * @note Pass the errno value obtained at the point of failure.
+ *       Do not pass 0 and later resolve errno via strerror() or
+ *       similar functions — this leads to incorrect messages.
+ */
 void __attribute__((format(printf, 3, 4))) LogError(const int iErrno, const int iErrCode, const char *fmt, ...);
+
+/**
+ * @brief Log a message with severity, errno, and error code context.
+ *
+ * More general form of LogError() that permits explicit severity.
+ *
+ * @param iErrno   The system errno value (0 if not applicable).
+ * @param iErrCode Internal rsyslog error code.
+ * @param severity Syslog severity level (LOG_ERR, LOG_WARNING, etc.).
+ * @param fmt      printf-style format string.
+ * @param ...      Arguments matching the format string.
+ *
+ * @note Always pass the errno value captured immediately after the
+ *       failing call. Do not pass 0 and later call strerror() or
+ *       equivalent — this is a common bug.
+ */
 void __attribute__((format(printf, 4, 5))) LogMsg(
     const int iErrno, const int iErrCode, const int severity, const char *fmt, ...);
+
+/**
+ * @brief Append a JSON record about an oversize message to the oversize-message log.
+ *
+ * Behavior:
+ * - No-op if the oversize message error file is not configured.
+ * - Lazily opens the file on first use and reuses the file descriptor.
+ * - Access is serialized via oversizeMsgLogMut.
+ * - Writes one JSON line per entry with fields: "rawmsg" (original raw bytes) and "input" (input name).
+ * - On open/write errors, emits LogError(...) but returns no error; no further recovery is attempted.
+ *   The reason is that there is nothing useful that could be done in that case.
+ *
+ * @param pMsg Pointer to the message object (must not be NULL).
+ * @retval RS_RET_OK on success, or when no oversize log is configured.
+ * @retval RS_RET_OUT_OF_MEMORY on memory allocation failure.
+ *
+ * @note Output is newline-terminated JSON (not NUL-terminated).
+ */
 rsRetVal ATTR_NONNULL() writeOversizeMessageLog(const smsg_t *const pMsg);
 
 #endif /* #ifndef INCLUDED_ERRMSG_H */

--- a/runtime/net.c
+++ b/runtime/net.c
@@ -1628,6 +1628,11 @@ BEGINobjQueryInterface(net)
     pIf->CmpHost = CmpHost;
     pIf->HasRestrictions = HasRestrictions;
     pIf->GetIFIPAddr = getIFIPAddr;
+
+    pIf->netns_save = netns_save;
+    pIf->netns_restore = netns_restore;
+    pIf->netns_switch = netns_switch;
+    pIf->netns_socket = netns_socket;
 finalize_it:
 ENDobjQueryInterface(net)
 

--- a/runtime/netns_socket.c
+++ b/runtime/netns_socket.c
@@ -1,0 +1,166 @@
+/* Implementation for netns_socket API
+ *
+ * This file is part of rsyslog.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *       -or-
+ *       see COPYING.ASL20 in the source distribution
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "config.h"
+#include <stdio.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <sched.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+
+#include "rsyslog.h"
+#include "debug.h"
+#include "errmsg.h"
+#include "netns_socket.h"
+
+
+/* Change to the given network namespace.
+ * This function based on previous implementation
+ * of tools/omfwd.c function changeToNs.
+ */
+rsRetVal netns_switch(const char *ns) {
+    DEFiRet;
+#ifdef HAVE_SETNS
+    int ns_fd = -1;
+    char *nsPath = NULL;
+
+    if (ns && *ns) {
+        /* Build network namespace path */
+        if (asprintf(&nsPath, "/var/run/netns/%s", ns) == -1) {
+            // Some implementations say nsPath would be undefined on failure
+            nsPath = NULL;
+            LogError(0, RS_RET_OUT_OF_MEMORY, "%s: asprintf failed", __func__);
+            ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
+        }
+
+        /* Open file descriptor of destination network namespace */
+        ns_fd = open(nsPath, O_RDONLY);
+        if (ns_fd < 0) {
+            LogError(errno, RS_RET_IO_ERROR, "%s: could not open namespace '%s'", __func__, ns);
+            ABORT_FINALIZE(RS_RET_IO_ERROR);
+        }
+        /* Change to the destination network namespace */
+        if (setns(ns_fd, CLONE_NEWNET) != 0) {
+            LogError(errno, RS_RET_IO_ERROR, "%s: could not change to namespace '%s'", __func__, ns);
+            ABORT_FINALIZE(RS_RET_IO_ERROR);
+        }
+        dbgprintf("%s: changed to network namespace '%s'\n", __func__, ns);
+    }
+finalize_it:
+    free(nsPath);
+    if ((ns_fd >= 0) && (close(ns_fd) != 0)) {
+        LogError(errno, RS_RET_IO_ERROR, "%s: failed to close namespace '%s'", __func__, ns);
+    }
+#else  // ndef HAVE_SETNS
+    if (ns && *ns) {
+        LogError(ENOSYS, RS_RET_VALUE_NOT_SUPPORTED, "%s: could not change to namespace '%s'", __func__, ns);
+        ABORT_FINALIZE(RS_RET_VALUE_NOT_SUPPORTED);
+    }
+finalize_it:
+#endif  // ndef HAVE_SETNS
+    RETiRet;
+}
+
+
+/* Return to the startup network namespace.
+ * This function based on code in tools/omfwd.c
+ */
+rsRetVal ATTR_NONNULL() netns_restore(int *fd) {
+    DEFiRet;
+
+#ifdef HAVE_SETNS
+    if (*fd >= 0) {
+        if (setns(*fd, CLONE_NEWNET) != 0) {
+            LogError(errno, RS_RET_IO_ERROR, "%s: could not return to startup namespace", __func__);
+            ABORT_FINALIZE(RS_RET_IO_ERROR);
+        }
+        dbgprintf("%s: returned to startup network namespace\n", __func__);
+    }
+
+finalize_it:
+#endif  // def HAVE_SETNS
+    if (*fd >= 0 && close(*fd) != 0) {
+        LogError(errno, RS_RET_IO_ERROR, "%s: could not close startup namespace fd", __func__);
+    }
+    *fd = -1;
+    RETiRet;
+}
+
+/* Save the current network namespace fd
+ */
+rsRetVal ATTR_NONNULL() netns_save(int *fd) {
+    DEFiRet;
+
+    /*
+     * The fd must always point to either a valid fd
+     * or to -1.  We expect it to be -1 on entry here.
+     * To avoid bugs, or possible descriptor leaks,
+     * check that it is always -1 on entry.
+     */
+#ifdef HAVE_SETNS
+    if (*fd != -1) {
+        LogError(0, RS_RET_CODE_ERR, "%s: called with uninitialized descriptor", __func__);
+        ABORT_FINALIZE(RS_RET_CODE_ERR);
+    }
+    *fd = open("/proc/self/ns/net", O_RDONLY);
+    if (*fd == -1) {
+        LogError(errno, RS_RET_IO_ERROR, "%s: could not access startup namespace", __func__);
+        ABORT_FINALIZE(RS_RET_IO_ERROR);
+    }
+    dbgprintf("%s: saved startup network namespace\n", __func__);
+finalize_it:
+#endif  // def HAVE_SETNS
+    RETiRet;
+}
+
+rsRetVal netns_socket(int *fdp, int domain, int type, int protocol, const char *ns) {
+    DEFiRet;
+    int fd = -1;
+
+#ifndef HAVE_SETNS
+    if (ns && *ns) {
+        LogError(0, RS_RET_VALUE_NOT_SUPPORTED, "Network namespaces are not supported");
+        ABORT_FINALIZE(RS_RET_VALUE_NOT_SUPPORTED);
+    }
+#else /* def HAVE_SETNS */
+    rsRetVal iRet_restore;
+    int ns_fd = -1;
+
+    if (ns && *ns) {
+        CHKiRet(netns_save(&ns_fd));
+        CHKiRet(netns_switch(ns));
+    }
+#endif /* def HAVE_SETNS */
+    *fdp = fd = socket(domain, type, protocol);
+    if (fd == -1) {
+        LogError(errno, RS_RET_NO_SOCKET, "%s: socket(%d, %d, %d) failed", __func__, domain, type, protocol);
+        ABORT_FINALIZE(RS_RET_NO_SOCKET);
+    }
+finalize_it:
+#ifdef HAVE_SETNS
+    iRet_restore = netns_restore(&ns_fd);
+    if (iRet == RS_RET_OK) iRet = iRet_restore;
+#endif /* def HAVE_SETNS */
+    if (iRet != RS_RET_OK && fd != -1) {
+        (void)close(fd);
+        *fdp = -1;
+    }
+    RETiRet;
+}

--- a/runtime/netns_socket.h
+++ b/runtime/netns_socket.h
@@ -1,0 +1,40 @@
+/* Definitions for netns_socket API
+ *
+ * This file is part of rsyslog.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *       -or-
+ *       see COPYING.ASL20 in the source distribution
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef INCLUDED_NETNS_SOCKET_H
+#define INCLUDED_NETNS_SOCKET_H
+
+#include "rsyslog.h"
+
+/*
+ * Open a socket in the named network namespace
+ */
+rsRetVal netns_socket(int *fdp, int domain, int type, int protocol, const char *ns);
+
+/*
+ * Switch to the named networknamespace
+ */
+rsRetVal netns_switch(const char *ns);
+
+/*
+ * Save and restore our current network namespace
+ */
+rsRetVal ATTR_NONNULL() netns_save(int *fd);
+rsRetVal ATTR_NONNULL() netns_restore(int *fd);
+
+#endif /* #ifndef INCLUDED_NETNS_SOCKET_H */

--- a/tests/known_issues.supp
+++ b/tests/known_issues.supp
@@ -71,3 +71,21 @@
    fun:exit
    fun:(below main)
 }
+{
+   <glibc 2.4[01] failures for fc4[12].aarch64>
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:malloc
+   fun:UnknownInlinedFun
+   fun:_dl_map_object_deps
+   fun:dl_open_worker_begin
+   fun:_dl_catch_exception
+   fun:dl_open_worker
+   fun:_dl_catch_exception
+   fun:_dl_open
+   fun:do_dlopen
+   fun:_dl_catch_exception
+   fun:_dl_catch_error
+   fun:dlerror_run
+   fun:__libc_dlopen_mode
+}

--- a/tests/tcp_forwarding_ns_tpl.sh
+++ b/tests/tcp_forwarding_ns_tpl.sh
@@ -26,7 +26,7 @@ ip netns add rsyslog_test_ns
 ip netns exec rsyslog_test_ns ip link set dev lo up
 
 # run server in namespace
-ip netns exec rsyslog_test_ns ./minitcpsrv -t127.0.0.1 -p'$TCPFLOOD_PORT' -f $RSYSLOG_OUT_LOG &
+ip netns exec rsyslog_test_ns ./minitcpsrv -t127.0.0.1 -p"$TCPFLOOD_PORT" -f $RSYSLOG_OUT_LOG &
 BGPROCESS=$!
 echo background minitcpsrvr process id is $BGPROCESS
 

--- a/tools/logctl.c
+++ b/tools/logctl.c
@@ -61,8 +61,13 @@ PRAGMA_IGNORE_Wunknown_attribute;
 PRAGMA_IGNORE_Wexpansion_to_defined;
 PRAGMA_IGNORE_Wstrict_prototypes;
 PRAGMA_IGNORE_Wold_style_definition;
-#include <mongoc.h>
-#include <bson.h>
+#ifdef HAVE_LIBMONGOC1
+    #include <mongoc.h>
+    #include <bson.h>
+#else
+    #include <mongoc/mongoc.h>
+    #include <bson/bson.h>
+#endif
 PRAGMA_DIAGNOSTIC_POP;
 
 #define N 80


### PR DESCRIPTION
Context
- Issue: https://github.com/rsyslog/rsyslog/issues/5627
- Servers can send TLS 1.3 KeyUpdate post-handshake. The client must read to update keys; otherwise, writes can stall.
- During Send(), when the TLS lib requests READ (WANT_READ/READ direction), rsyslog must drive a read to process pending TLS records.

What changed
- runtime/nsd_ossl.c:
  - Send(): If SSL_write() returns SSL_ERROR_WANT_READ, call osslRecordRecv() (buffered) to process TLS records (e.g., KeyUpdate), then retry write.
  - Send(): Treat SSL_ERROR_ZERO_RETURN as RS_RET_CLOSED (peer sent close_notify).
- runtime/nsd_gtls.c:
  - Send(): If gnutls_record_send() returns E_AGAIN/E_INTERRUPTED and direction is READ, call gtlsRecordRecv() (buffered), then retry write.

Why this is safe
- Backward-compatible: extra receive only when TLS library explicitly signals READ is required.
- No application data loss: uses existing buffered receive helpers instead of discarding bytes.
- Correctly handles close-notify to avoid busy loops.

References
- RFC 8446 §4.6.3 (Key Update): client must process KeyUpdate.
- Review feedback addressed: https://github.com/alorbach/rsyslog/pull/11

Commit message (single squashed commit)
  tls: process TLS 1.3 KeyUpdate during send (ossl/gtls)

  Handle post-handshake KeyUpdate by driving a buffered receive when the TLS
  library requests READ during Send(). Prevents stalls and preserves application
  data. Also treat SSL_ERROR_ZERO_RETURN as closed to avoid busy loops.

  - nsd_ossl.c: WANT_READ => osslRecordRecv(), then retry write
  - nsd_gtls.c: E_AGAIN/E_INTERRUPTED with READ => gtlsRecordRecv(), then retry write

  Backward-compatible. No data loss. Correct EOF handling.

  closes: https://github.com/rsyslog/rsyslog/issues/5627