### PR TITLE
docs: fix doc build instructions (Sphinx 4.5+, main, monorepo)

### DIFF
--- a/doc/BUILDS_README.md
+++ b/doc/BUILDS_README.md
@@ -158,7 +158,7 @@ and is useful to identify a dev build from a release set of documentation.
    installing `pip`, setting up the virtual environment and installing
    the latest version of the Sphinx package.
 1. Run `git clone https://github.com/rsyslog/rsyslog.git`
+1. Change into the cloned repository: `cd rsyslog`
 1. Run `git checkout main`
-1. Change to doc folder
-1. Run `sphinx-build -b html source build` to generate HTML format and
-   `sphinx-build -b epub source build` to build an epub file.
+1. Change into the documentation folder: `cd doc`
+1. Run `sphinx-build -b html source build` to generate HTML format and `sphinx-build -b epub source build` to build an epub file.

--- a/doc/BUILDS_README.md
+++ b/doc/BUILDS_README.md
@@ -4,7 +4,7 @@
 
 This doc is intended for maintainers and regular contributors to
 the project. The [`README.md`](README.md) doc covers the basic steps for one-off
-builds from the `master` branch.
+builds from the `main` branch.
 
 In all cases, the version number and release string do not *need* to be
 manually specified, though the directions do provide steps for doing so
@@ -43,11 +43,11 @@ steps in this document.
 1. Review the [`README.md`](README.md) file for instructions that cover
    installing `pip`, setting up the virtual environment and installing
    the latest version of the Sphinx package.
-1. Clone the https://github.com/rsyslog/rsyslog-doc.git repo
-1. Merge `master` into the current stable branch (e.g., `v8-stable`)
+1. Change to the `doc/` folder within the rsyslog repository
+1. Merge `main` into the current stable branch (e.g., `v8-stable`)
 1. Tag the stable branch
 1. Push all changes to the remote
-1. Run the `release_build.sh` script
+1. Run the `doc/tools/release_build.sh` script
 1. Sync the contents of the `build` directory over to the web server
 1. Sync the latest release doc tarball to where the previous release
    tarball is hosted. Update references to this tarball as necessary.
@@ -72,7 +72,7 @@ You have several options:
    was within the tarball
     - For example, `cd /tmp/rsyslog-8.33.0`
       (the `rsyslog-8.33.0` folder is within the tarball)
-1. Run `sphinx -b html source build`
+1. Run `sphinx-build -b html source build`
 
 You may need to first follow the directions in the [`README.md`](README.md)
 doc to create or activate your virtual environment if the `sphinx` package
@@ -80,8 +80,8 @@ is not already installed and known to your installation of Python.
 
 #### Build from GitHub download
 
-1. Visit https://github.com/rsyslog/rsyslog-doc
-1. Click on 'Branch: master' and choose 'Tags' from the right-column
+1. Visit https://github.com/rsyslog/rsyslog
+1. Click on 'Branch: main' and choose 'Tags' from the right-column
 1. Select the `v8.33.0` tag
 1. Click on the 'Clone or download' green button to the far right
 1. Click 'Download ZIP' and save the file to your system
@@ -91,7 +91,7 @@ is not already installed and known to your installation of Python.
    within the tarball.
     - For example, `cd C:\users\deoren\Downloads\rsyslog-8.33.0`
       (the `rsyslog-8.33.0` folder is within the tarball)
-1. `sphinx -D version="8.33" release="8.33.0" -b html source build`
+1. `sphinx-build -D version="8.33" release="8.33.0" -b html source build`
     - You have to specify the `version` and `release` values here for now
       because we do not modify the `source/conf.py` file in the stable branch
       or its tags to hard-code the new version number.
@@ -105,9 +105,10 @@ is not already installed and known to your installation of Python.
 1. Review the [`README.md`](README.md) file for instructions that cover
    installing `pip`, setting up the virtual environment and installing
    the latest version of the Sphinx package.
-1. Run `git clone https://github.com/rsyslog/rsyslog-doc.git`
+1. Run `git clone https://github.com/rsyslog/rsyslog.git`
+1. Move to doc directory.
 1. Run `git checkout v8.33.0`
-1. Run `sphinx -D version="8.33" release="8.33.0" -b html source build`
+1. Run `sphinx-build -D version="8.33" release="8.33.0" -b html source build`
 
 You may need to first follow the directions in the [`README.md`](README.md)
 doc to create or activate your virtual environment if the `sphinx` package
@@ -119,7 +120,7 @@ is not already installed and known to your installation of Python.
 ### Obtain docs
 
 You have several options for obtaining a snapshot of the branch you would
-like to build (most often this is the `master` branch):
+like to build (most often this is the `main` branch):
 
 - Download a zip file from GitHub
 - Clone GitHub repo using Git
@@ -130,23 +131,23 @@ of the docs.
 
 ### Build from GitHub download
 
-These directions assume that you wish to build the docs from the `master`
-branch. Substitute `master` for any other branch that you wish to build.
+These directions assume that you wish to build the docs from the `main`
+branch. Substitute `main` for any other branch that you wish to build.
 
 1. Follow the steps previously given for downloading the zip file from GitHub,
    this time substituting the tag download option for the branch you wish
    to obtain doc sources for.
 1. Decompress the zip file and change your current working directory to
    that path.
-1. Run `sphinx -D release="dev-build" -b html source build` to generate
-   HTML format and `sphinx -b epub source build` to build an epub file.
+1. Run `sphinx-build -D release="dev-build" -b html source build` to generate
+   HTML format and `sphinx-build -b epub source build` to build an epub file.
 
 
 
 ### Build from Git repo
 
-These directions assume that you wish to build the docs from the `master`
-branch. Substitute `master` for any other branch that you wish to build.
+These directions assume that you wish to build the docs from the `main`
+branch. Substitute `main` for any other branch that you wish to build.
 
 The Sphinx build configuration file will attempt to pull the needed information
 from the Git repo in order to generate a "dev build" release string. This
@@ -156,7 +157,8 @@ and is useful to identify a dev build from a release set of documentation.
 1. Review the [`README.md`](README.md) file for instructions that cover
    installing `pip`, setting up the virtual environment and installing
    the latest version of the Sphinx package.
-1. Run `git clone https://github.com/rsyslog/rsyslog-doc.git`
-1. Run `git checkout master`
-1. Run `sphinx -b html source build` to generate HTML format and
-   `sphinx -b epub source build` to build an epub file.
+1. Run `git clone https://github.com/rsyslog/rsyslog.git`
+1. Run `git checkout main`
+1. Change to doc folder
+1. Run `sphinx-build -b html source build` to generate HTML format and
+   `sphinx-build -b epub source build` to build an epub file.

--- a/doc/BUILDS_README.md
+++ b/doc/BUILDS_README.md
@@ -47,7 +47,7 @@ steps in this document.
 1. Merge `main` into the current stable branch (e.g., `v8-stable`)
 1. Tag the stable branch
 1. Push all changes to the remote
-1. Run the `doc/tools/release_build.sh` script
+1. Run the `tools/release_build.sh` script
 1. Sync the contents of the `build` directory over to the web server
 1. Sync the latest release doc tarball to where the previous release
    tarball is hosted. Update references to this tarball as necessary.

--- a/doc/README.md
+++ b/doc/README.md
@@ -79,7 +79,7 @@ to Stack Exchange](https://serverfault.com/questions/ask?tags=rsyslog).
 
 ## Building the documentation
 
-These directions assume a modern Python 3 environment (Python 3.6 or newer is recommended).
+These directions assume a modern Python 3 environment (Python 3.8+; 3.10+ recommended).
 
 ### Assumptions
 

--- a/doc/contrib/cron_build_all_branches.sh
+++ b/doc/contrib/cron_build_all_branches.sh
@@ -21,8 +21,8 @@ get_latest_stable_branch() {
         tail -n 1
 }
 
-# This includes 'master', but intentionally excludes the stable branches
-# which master is periodically merged into
+# This includes 'main', but intentionally excludes the stable branches
+# which main is periodically merged into
 get_dev_branches() {
 
     git branch -r | \
@@ -102,7 +102,6 @@ read -r REPLY
 # Refresh local content
 echo "Fetching latest changes from origin ..."
 git fetch origin --prune --tags
-
 
 
 
@@ -232,10 +231,9 @@ tar -czf $output_dir/$doc_tarball source build LICENSE README.md ||
     { echo "[!] tarball creation failed for $latest_stable_tag tag ... aborting"; exit 1; }
 
 
-
 ###############################################################
-# Reset repo to master for next build
+# Reset repo to main for next build
 ###############################################################
 
 # This ensures that the build script is always at the latest version
-prep_branch_for_build master
+prep_branch_for_build main

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,5 +1,5 @@
 
-# Need at least 1.5.1 due to some of the features we are using
-sphinx >=1.5.1
+# Align with conf.py needs_sphinx requirement
+sphinx>=4.5.0
 furo
 sphinxcontrib.mermaid

--- a/doc/source/includes/substitution_definitions.inc.rst
+++ b/doc/source/includes/substitution_definitions.inc.rst
@@ -31,13 +31,13 @@
 .. _RsyslogPackageDownloads: http://www.rsyslog.com/downloads/download-other/
 
 .. |GitHubDocProject| replace:: rsyslog source documentation
-.. _GitHubDocProject: https://github.com/rsyslog/rsyslog/doc
+.. _GitHubDocProject: https://github.com/rsyslog/rsyslog/tree/main/doc
 
-.. |GitHubDocProjectREADME| replace:: rsyslog-doc project README
-.. _GitHubDocProjectREADME: https://github.com/rsyslog/rsyslog/doc/blob/master/README.md
+.. |GitHubDocProjectREADME| replace:: rsyslog doc/ README
+.. _GitHubDocProjectREADME: https://github.com/rsyslog/rsyslog/blob/main/doc/README.md
 
-.. |GitHubDocProjectDevREADME| replace:: rsyslog-doc project BUILDS README
-.. _GitHubDocProjectDevREADME: https://github.com/rsyslog/rsyslog-doc/blob/master/BUILDS_README.md
+.. |GitHubDocProjectDevREADME| replace:: rsyslog doc/ BUILDS README
+.. _GitHubDocProjectDevREADME: https://github.com/rsyslog/rsyslog/blob/main/doc/BUILDS_README.md
 
 .. |GitHubDocProjectGoodFirstIssueLabel| replace:: rsyslog-doc issues marked with Good First Issue label
 .. _GitHubDocProjectGoodFirstIssueLabel: https://github.com/rsyslog/rsyslog-doc/labels/good%20first%20issue
@@ -63,7 +63,7 @@
 .. _GitHubSourceProject: https://github.com/rsyslog/rsyslog/
 
 .. |GitHubSourceProjectREADME| replace:: rsyslog project README
-.. _GitHubSourceProjectREADME: https://github.com/rsyslog/rsyslog/blob/master/README.md
+.. _GitHubSourceProjectREADME: https://github.com/rsyslog/rsyslog/blob/main/README.md
 
 .. |GitHubSourceProjectGoodFirstIssueLabel| replace:: rsyslog issues marked with Good First Issue label
 .. _GitHubSourceProjectGoodFirstIssueLabel: https://github.com/rsyslog/rsyslog/labels/good%20first%20issue

--- a/doc/source/includes/substitution_definitions.inc.rst
+++ b/doc/source/includes/substitution_definitions.inc.rst
@@ -39,8 +39,8 @@
 .. |GitHubDocProjectDevREADME| replace:: rsyslog doc/ BUILDS README
 .. _GitHubDocProjectDevREADME: https://github.com/rsyslog/rsyslog/blob/main/doc/BUILDS_README.md
 
-.. |GitHubDocProjectGoodFirstIssueLabel| replace:: rsyslog-doc issues marked with Good First Issue label
-.. _GitHubDocProjectGoodFirstIssueLabel: https://github.com/rsyslog/rsyslog-doc/labels/good%20first%20issue
+.. |GitHubDocProjectGoodFirstIssueLabel| replace:: rsyslog doc issues marked with Good First Issue label
+.. _GitHubDocProjectGoodFirstIssueLabel: https://github.com/rsyslog/rsyslog/labels/good%20first%20issue
 
 
 .. |GitHubDocProjectHelpWantedLabel| replace:: rsyslog-doc issues marked with Help Wanted label

--- a/doc/source/installation/build_from_repo.rst
+++ b/doc/source/installation/build_from_repo.rst
@@ -22,7 +22,7 @@ code <http://www.rsyslog.com/where-to-find-the-rsyslog-source-code/>`_\ "
 page on the project site will point you to the current repository
 location.
 
-After you have cloned the repository, you are in the master branch by
+After you have cloned the repository, you are in the main branch by
 default. This is where we keep the devel branch. If you need any other
 branch, you need to do a "git checkout --track -b branch origin/branch".
 For example, the command to check out the beta branch is "git checkout

--- a/doc/tools/buildenv/Dockerfile
+++ b/doc/tools/buildenv/Dockerfile
@@ -9,7 +9,7 @@ CMD	["build-doc"]
 ENTRYPOINT ["/home/appliance/starter.sh"]
 VOLUME	/rsyslog-doc
 RUN	chmod a+w /rsyslog-doc
-ENV	BRANCH="master" \
+ENV	BRANCH="main" \
 	FORMAT="html" \
 	STRICT="-n -W"
 COPY	starter.sh ./


### PR DESCRIPTION
### Summary
Align documentation build instructions and tooling with current project standards (Sphinx >= 4.5, main branch, monorepo layout) and ensure consistent CLI usage.

### What changed
- Set Sphinx minimum to 4.5.0 to match `needs_sphinx` in `conf.py`
- Use `sphinx-build` consistently instead of the `sphinx` wrapper
- Replace references to branch “master” with “main” where a branch name is intended
- Update references from the legacy `rsyslog-doc` repo to the monorepo (`rsyslog/rsyslog`, `doc/` folder)
- Refresh Python guidance to “Python 3.8+” (3.10+ recommended)

### Why
Building with Sphinx versions lower than 4.5 conflicts with `conf.py` (`needs_sphinx='4.5.0'`). Standardizing on `main` and the monorepo eliminates confusion. Consistent `sphinx-build` usage avoids CLI ambiguity.

### How to test
1) From repo root:
   - `cd doc`
   - `python3 -m venv .venv-docs`
   - `source .venv-docs/bin/activate`
   - `python -m pip install --upgrade pip`
   - `python -m pip install -r requirements.txt`
2) Build:
   - `sphinx-build -b html source build`
   - `sphinx-build -b epub source build`
3) Open `doc/build/index.html` and confirm pages render. Confirm `doc/build/rsyslog.epub` exists.

### Impact
- Documentation only; no runtime changes.

### Affected files
- `doc/requirements.txt`
- `doc/README.md`
- `doc/BUILDS_README.md`
- `doc/source/includes/substitution_definitions.inc.rst`
- `doc/source/installation/build_from_repo.rst`
- `doc/tools/buildenv/Dockerfile`
- `doc/contrib/cron_build_all_branches.sh`
