### PR TITLE
mmsnarewinsec: ignore placeholder-valued fields

### DIFF
--- a/plugins/mmsnarewinsec/mmsnarewinsec.c
+++ b/plugins/mmsnarewinsec/mmsnarewinsec.c
@@ -3206,7 +3206,6 @@ static rsRetVal parse_field_value_enhanced(const char *value,
         return RS_RET_OK;
     }
     if (is_placeholder_value(trimmed)) {
-        json_add_string(target, key, trimmed);
         if (storedOut != NULL) *storedOut = -1;
         free(trimmed);
         return RS_RET_OK;
@@ -4049,8 +4048,6 @@ static rsRetVal parse_snare_text(
         return RS_RET_OUT_OF_MEMORY;
     }
     json_object_object_add(ctx.root, "Event", ctx.event);
-
-    initialize_observability(&ctx);
 
     initialize_observability(&ctx);
 

--- a/tests/mmsnarewinsec-comprehensive.sh
+++ b/tests/mmsnarewinsec-comprehensive.sh
@@ -140,7 +140,15 @@ content_check '"newlogonaccountname":"SYSTEM"' $RSYSLOG_OUT_LOG.json
 content_check '"newlogonaccountdomain":"NT AUTHORITY"' $RSYSLOG_OUT_LOG.json
 content_check '"logonprocess":"Advapi"' $RSYSLOG_OUT_LOG.json
 content_check '"authenticationpackage":"Negotiate"' $RSYSLOG_OUT_LOG.json
-content_check '"packagename":"-"' $RSYSLOG_OUT_LOG.json
+# Placeholder tokens such as "-" should now be dropped entirely by the parser.
+# The JSON template still emits empty strings when a property is missing, so we
+# assert that hyphen placeholders never surface in the flattened output.
+check_not_present '"restrictedadminmode":"-"' "$RSYSLOG_OUT_LOG.json"
+check_not_present '"networkaccountname":"-"' "$RSYSLOG_OUT_LOG.json"
+check_not_present '"sourcenetworkaddress":"-"' "$RSYSLOG_OUT_LOG.json"
+check_not_present '"sourceport":"-"' "$RSYSLOG_OUT_LOG.json"
+check_not_present '"transitedservices":"-"' "$RSYSLOG_OUT_LOG.json"
+check_not_present '"packagename":"-"' "$RSYSLOG_OUT_LOG.json"
 
 # Validate structured JSON extraction from Windows 2025 data
 content_check '"categorytext":"Audit Policy Change"' $RSYSLOG_OUT_LOG.json

--- a/tests/mmsnarewinsec-enhanced-validation.sh
+++ b/tests/mmsnarewinsec-enhanced-validation.sh
@@ -14,6 +14,7 @@ template(name="validation_test_json" type="list" option.jsonf="on") {
     property(outname="eventid" name="$!win!Event!EventID" format="jsonf")
     property(outname="validation_errors" name="$!win!Validation!Errors" format="jsonf")
     property(outname="parsing_stats" name="$!win!Stats!ParsingStats" format="jsonf")
+    property(outname="event_json" name="$!win" format="jsonf")
 }
 
 input(type="imtcp" port="'$TCPFLOOD_PORT'")
@@ -73,6 +74,32 @@ if errors != []:
 expected_stats = {"total_fields": 25, "successful_parses": 25, "failed_parses": 0}
 if stats != expected_stats:
     raise SystemExit(f"unexpected parsing stats: {stats}")
+
+try:
+    event_root = json.loads(event["event_json"])
+except (KeyError, json.JSONDecodeError) as exc:
+    raise SystemExit(f"unable to parse event_json payload: {exc}")
+
+logon = event_root.get("Logon", {})
+new_logon = event_root.get("NewLogon", {})
+network = event_root.get("Network", {})
+auth = event_root.get("Authentication", {})
+
+placeholder_checks = [
+    (logon, "RemoteCredentialGuard", "Logon"),
+    (new_logon, "NetworkAccountName", "NewLogon"),
+    (new_logon, "NetworkAccountDomain", "NewLogon"),
+    (network, "SourceNetworkAddress", "Network"),
+    (network, "SourcePort", "Network"),
+    (auth, "TransitedServices", "Authentication"),
+    (auth, "PackageName", "Authentication"),
+]
+
+for container_obj, field_name, container_name in placeholder_checks:
+    if field_name in container_obj:
+        raise SystemExit(
+            f"placeholder field {container_name}.{field_name} should be absent but was present: {container_obj[field_name]}"
+        )
 PY
 
 exit_test


### PR DESCRIPTION
Non-technical: improve data cleanliness for the unfinished module so
downstream JSON consumers see only meaningful values.

Before: placeholder-valued fields were emitted into $!win JSON.  
After: placeholders are ignored (not stored), while parse stats are
unchanged.

Impact: JSON content shrinks where placeholders existed; dashboards
relying on presence of placeholder keys may see fewer fields.

In parse_field_value_enhanced(), treat placeholder tokens as "unstored"
and skip adding them to the JSON output. Keep parsing statistics
unchanged to preserve existing test expectations and monitoring baselines.
Remove a duplicate initialize_observability() call in the Snare text
path to avoid redundant setup. Extend the enhanced-validation test to
verify placeholders are absent under Logon, NewLogon, Network, and
Authentication, while still asserting the same total/success/failed
counters.

Refs: https://github.com/alorbach/rsyslog/pull/29