### PR TITLE
mmsnarewinsec: add GUID/IP/timestamp typed fields + tests

### DIFF
--- a/plugins/mmsnarewinsec/mmsnarewinsec.c
+++ b/plugins/mmsnarewinsec/mmsnarewinsec.c
@@ -750,22 +750,40 @@ static bool is_placeholder_value(const char *value) {
 
 static bool is_guid_format(const char *value) {
     if (value == NULL) return false;
+
     size_t len = strlen(value);
-    if (len == 38 && value[0] == '{' && value[len - 1] == '}') {
-        return true;
+    size_t offset = 0;
+
+    if (len == 38) {
+        if (value[0] != '{' || value[len - 1] != '}') return false;
+        offset = 1;
+    } else if (len == 36) {
+        offset = 0;
+    } else {
+        return false;
     }
-    if (len == 36) {
-        int hyphenCount = 0;
-        for (size_t i = 0; i < len; ++i) {
-            if (value[i] == '-') {
-                ++hyphenCount;
-            } else if (!isxdigit((unsigned char)value[i])) {
-                return false;
+
+    static const size_t hyphen_positions[] = {8u, 13u, 18u, 23u};
+
+    for (size_t i = 0; i < 36; ++i) {
+        const size_t absolute_index = offset + i;
+        bool expect_hyphen = 0;
+
+        for (size_t j = 0; j < ARRAY_SIZE(hyphen_positions); ++j) {
+            if (i == hyphen_positions[j]) {
+                expect_hyphen = 1;
+                break;
             }
         }
-        return hyphenCount == 4;
+
+        if (expect_hyphen) {
+            if (value[absolute_index] != '-') return false;
+        } else {
+            if (!isxdigit((unsigned char)value[absolute_index])) return false;
+        }
     }
-    return false;
+
+    return true;
 }
 
 static bool is_ip_address(const char *value) {

--- a/plugins/mmsnarewinsec/mmsnarewinsec.c
+++ b/plugins/mmsnarewinsec/mmsnarewinsec.c
@@ -787,11 +787,27 @@ static bool parse_int_range(const char *digits, size_t length, int min_value, in
     int value = 0;
     for (size_t i = 0; i < length; ++i) {
         if (!isdigit((unsigned char)digits[i])) return false;
-        value = (value * 10) + (digits[i] - '0');
+        if (value > INT_MAX / 10) return false;
+        const int digit = digits[i] - '0';
+        if (value == INT_MAX / 10 && digit > INT_MAX % 10) return false;
+        value = (value * 10) + digit;
     }
     if (value < min_value || value > max_value) return false;
     if (out != NULL) *out = value;
     return true;
+}
+
+static bool is_leap_year(int year) {
+    if (year % 4 != 0) return false;
+    if (year % 100 != 0) return true;
+    return (year % 400) == 0;
+}
+
+static int days_in_month(int year, int month) {
+    static const int days[] = {0, 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
+    if (month < 1 || month > 12) return 0;
+    if (month == 2 && is_leap_year(year)) return 29;
+    return days[month];
 }
 
 static bool is_iso8601_timestamp(const char *value) {
@@ -802,13 +818,22 @@ static bool is_iso8601_timestamp(const char *value) {
 
     if (value[4] != '-' || value[7] != '-' || value[10] != 'T' || value[13] != ':' || value[16] != ':') return false;
 
-    int dummy;
-    if (!parse_int_range(value, 4, 0, 9999, &dummy)) return false;
-    if (!parse_int_range(value + 5, 2, 1, 12, &dummy)) return false;
-    if (!parse_int_range(value + 8, 2, 1, 31, &dummy)) return false;
-    if (!parse_int_range(value + 11, 2, 0, 23, &dummy)) return false;
-    if (!parse_int_range(value + 14, 2, 0, 59, &dummy)) return false;
-    if (!parse_int_range(value + 17, 2, 0, 60, &dummy)) return false;
+    int year = 0;
+    int month = 0;
+    int day = 0;
+    int hour = 0;
+    int minute = 0;
+    int second = 0;
+
+    if (!parse_int_range(value, 4, 0, 9999, &year)) return false;
+    if (!parse_int_range(value + 5, 2, 1, 12, &month)) return false;
+    if (!parse_int_range(value + 8, 2, 1, 31, &day)) return false;
+    const int max_day = days_in_month(year, month);
+    if (max_day == 0 || day > max_day) return false;
+    if (!parse_int_range(value + 11, 2, 0, 23, &hour)) return false;
+    if (!parse_int_range(value + 14, 2, 0, 59, &minute)) return false;
+    if (!parse_int_range(value + 17, 2, 0, 60, &second)) return false;
+    if (second == 60 && minute != 59) return false;
 
     size_t pos = 19;
     if (value[pos] == '.') {
@@ -824,16 +849,21 @@ static bool is_iso8601_timestamp(const char *value) {
     } else if (value[pos] == '+' || value[pos] == '-') {
         pos++;
         if (pos + 1 >= len) return false;
-        if (!parse_int_range(value + pos, 2, 0, 23, &dummy)) return false;
+        int tz_hour = 0;
+        if (!parse_int_range(value + pos, 2, 0, 23, &tz_hour)) return false;
         pos += 2;
-        if (pos < len && value[pos] == ':') {
-            pos++;
-            if (pos + 1 >= len) return false;
-            if (!parse_int_range(value + pos, 2, 0, 59, &dummy)) return false;
-            pos += 2;
-        } else if (pos < len && isdigit((unsigned char)value[pos])) {
-            if (!parse_int_range(value + pos, 2, 0, 59, &dummy)) return false;
-            pos += 2;
+        if (pos < len) {
+            int tz_minute = 0;
+            if (value[pos] == ':') {
+                pos++;
+                if (pos + 1 >= len) return false;
+                if (!parse_int_range(value + pos, 2, 0, 59, &tz_minute)) return false;
+                pos += 2;
+            } else if (isdigit((unsigned char)value[pos])) {
+                if (pos + 1 >= len) return false;
+                if (!parse_int_range(value + pos, 2, 0, 59, &tz_minute)) return false;
+                pos += 2;
+            }
         }
     } else {
         return false;
@@ -848,6 +878,14 @@ static bool token_matches(const char *token, const char *const *table, size_t ta
         if (strcasecmp(token, table[i]) == 0) return true;
     }
     return false;
+}
+
+static int lookup_month_index(const char *month) {
+    static const char *const months[] = {"Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"};
+    for (size_t i = 0; i < ARRAY_SIZE(months); ++i) {
+        if (strcasecmp(month, months[i]) == 0) return (int)i + 1;
+    }
+    return 0;
 }
 
 static bool is_windows_event_timestamp(const char *value) {
@@ -870,14 +908,15 @@ static bool is_windows_event_timestamp(const char *value) {
     if (*tail != '\0') return false;
 
     static const char *const weekdays[] = {"Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"};
-    static const char *const months[] = {"Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"};
 
     if (!token_matches(weekday, weekdays, ARRAY_SIZE(weekdays))) return false;
-    if (!token_matches(month, months, ARRAY_SIZE(months))) return false;
-    if (day < 1 || day > 31) return false;
+    const int month_index = lookup_month_index(month);
+    if (month_index == 0) return false;
+    if (day < 1 || day > days_in_month(year, month_index)) return false;
     if (hour < 0 || hour > 23) return false;
     if (minute < 0 || minute > 59) return false;
     if (second < 0 || second > 60) return false;
+    if (second == 60 && minute != 59) return false;
     if (year < 1900) return false;
 
     return true;

--- a/plugins/mmsnarewinsec/mmsnarewinsec.c
+++ b/plugins/mmsnarewinsec/mmsnarewinsec.c
@@ -123,6 +123,9 @@ typedef enum field_value_type {
     fieldValueJson,
     fieldValueLogonType,
     fieldValueRemoteCredentialGuard,
+    fieldValueGuid,
+    fieldValueIpAddress,
+    fieldValueTimestamp,
     fieldValuePrivilegeList
 } field_value_type_t;
 
@@ -203,7 +206,7 @@ static const field_pattern_t g_coreFieldPatterns[] = {
     {"LinkedLogonID", "LinkedLogonID", fieldValueString, NULL, FIELD_PRIORITY_BASE, fieldSensitivityCanonical},
     {"NetworkAccountName", "NetworkAccountName", fieldValueString, NULL, FIELD_PRIORITY_BASE,
      fieldSensitivityCanonical},
-    {"LogonGUID", "LogonGUID", fieldValueString, NULL, FIELD_PRIORITY_BASE, fieldSensitivityCanonical},
+    {"LogonGUID", "LogonGUID", fieldValueGuid, NULL, FIELD_PRIORITY_BASE, fieldSensitivityCanonical},
     {"ProcessID", "ProcessID", fieldValueString, NULL, FIELD_PRIORITY_BASE, fieldSensitivityCanonical},
     {"ProcessName", "ProcessName", fieldValueString, NULL, FIELD_PRIORITY_BASE, fieldSensitivityCanonical},
     {"ProcessCommandLine", "ProcessCommandLine", fieldValueString, NULL, FIELD_PRIORITY_BASE,
@@ -212,7 +215,7 @@ static const field_pattern_t g_coreFieldPatterns[] = {
      fieldSensitivityCanonical},
     {"MandatoryLabel", "MandatoryLabel", fieldValueString, NULL, FIELD_PRIORITY_BASE, fieldSensitivityCanonical},
     {"WorkstationName", "WorkstationName", fieldValueString, NULL, FIELD_PRIORITY_BASE, fieldSensitivityCanonical},
-    {"SourceNetworkAddress", "SourceNetworkAddress", fieldValueString, NULL, FIELD_PRIORITY_BASE,
+    {"SourceNetworkAddress", "SourceNetworkAddress", fieldValueIpAddress, NULL, FIELD_PRIORITY_BASE,
      fieldSensitivityCanonical},
     {"SourcePort", "SourcePort", fieldValueInt64, NULL, FIELD_PRIORITY_BASE, fieldSensitivityCanonical},
     {"ClientPort", "ClientPort", fieldValueInt64, NULL, FIELD_PRIORITY_BASE, fieldSensitivityCanonical},
@@ -228,6 +231,16 @@ static const field_pattern_t g_coreFieldPatterns[] = {
     {"ElevatedToken", "ElevatedToken", fieldValueString, NULL, FIELD_PRIORITY_BASE, fieldSensitivityCanonical},
     {"ImpersonationLevel", "ImpersonationLevel", fieldValueString, NULL, FIELD_PRIORITY_BASE,
      fieldSensitivityCanonical},
+    {"PreviousTime", "PreviousTime", fieldValueTimestamp, NULL, FIELD_PRIORITY_BASE, fieldSensitivityCanonical},
+    {"NewTime", "NewTime", fieldValueTimestamp, NULL, FIELD_PRIORITY_BASE, fieldSensitivityCanonical},
+    {"LastLogon", "LastLogon", fieldValueTimestamp, NULL, FIELD_PRIORITY_BASE, fieldSensitivityCanonical},
+    {"LastLogoff", "LastLogoff", fieldValueTimestamp, NULL, FIELD_PRIORITY_BASE, fieldSensitivityCanonical},
+    {"LastSuccessfulLogon", "LastSuccessfulLogon", fieldValueTimestamp, NULL, FIELD_PRIORITY_BASE,
+     fieldSensitivityCanonical},
+    {"LastFailedLogon", "LastFailedLogon", fieldValueTimestamp, NULL, FIELD_PRIORITY_BASE, fieldSensitivityCanonical},
+    {"LockoutTime", "LockoutTime", fieldValueTimestamp, NULL, FIELD_PRIORITY_BASE, fieldSensitivityCanonical},
+    {"PasswordLastSet", "PasswordLastSet", fieldValueTimestamp, NULL, FIELD_PRIORITY_BASE, fieldSensitivityCanonical},
+    {"AccountExpires", "AccountExpires", fieldValueTimestamp, NULL, FIELD_PRIORITY_BASE, fieldSensitivityCanonical},
     {"KeyLength", "KeyLength", fieldValueInt64, NULL, FIELD_PRIORITY_BASE, fieldSensitivityCanonical},
     {"RemoteCredentialGuard", "RemoteCredentialGuard", fieldValueRemoteCredentialGuard, NULL, FIELD_PRIORITY_BASE,
      fieldSensitivityCanonical},
@@ -257,25 +270,39 @@ static const field_pattern_t g_coreFieldPatterns[] = {
      fieldSensitivityCanonical},
     {"NetworkAccountDomain", "NetworkAccountDomain", fieldValueString, "NewLogon", FIELD_PRIORITY_BASE + 10,
      fieldSensitivityCanonical},
-    {"LogonGUID", "LogonGUID", fieldValueString, "NewLogon", FIELD_PRIORITY_BASE + 10, fieldSensitivityCanonical},
+    {"LogonGUID", "LogonGUID", fieldValueGuid, "NewLogon", FIELD_PRIORITY_BASE + 10, fieldSensitivityCanonical},
     {"NetworkInformation", "NetworkInformation", fieldValueString, "Network", FIELD_PRIORITY_BASE + 10,
      fieldSensitivityCanonical},
     {"WorkstationName", "WorkstationName", fieldValueString, "Network", FIELD_PRIORITY_BASE + 10,
      fieldSensitivityCanonical},
-    {"SourceNetworkAddress", "SourceNetworkAddress", fieldValueString, "Network", FIELD_PRIORITY_BASE + 10,
+    {"SourceNetworkAddress", "SourceNetworkAddress", fieldValueIpAddress, "Network", FIELD_PRIORITY_BASE + 10,
      fieldSensitivityCanonical},
     {"SourcePort", "SourcePort", fieldValueInt64, "Network", FIELD_PRIORITY_BASE + 10, fieldSensitivityCanonical},
-    {"NetworkAddress", "NetworkAddress", fieldValueString, "Network", FIELD_PRIORITY_BASE + 10,
+    {"NetworkAddress", "NetworkAddress", fieldValueIpAddress, "Network", FIELD_PRIORITY_BASE + 10,
      fieldSensitivityCanonical},
-    {"ClientAddress", "ClientAddress", fieldValueString, "Network", FIELD_PRIORITY_BASE + 10,
+    {"ClientAddress", "ClientAddress", fieldValueIpAddress, "Network", FIELD_PRIORITY_BASE + 10,
      fieldSensitivityCanonical},
     {"ClientPort", "ClientPort", fieldValueInt64, "Network", FIELD_PRIORITY_BASE + 10, fieldSensitivityCanonical},
-    {"DestinationAddress", "DestinationAddress", fieldValueString, "Network", FIELD_PRIORITY_BASE + 10,
+    {"DestinationAddress", "DestinationAddress", fieldValueIpAddress, "Network", FIELD_PRIORITY_BASE + 10,
      fieldSensitivityCanonical},
     {"DestinationPort", "DestinationPort", fieldValueInt64, "Network", FIELD_PRIORITY_BASE + 10,
      fieldSensitivityCanonical},
     {"Protocol", "Protocol", fieldValueString, "Network", FIELD_PRIORITY_BASE + 10, fieldSensitivityCanonical},
     {"Direction", "Direction", fieldValueString, "Network", FIELD_PRIORITY_BASE + 10, fieldSensitivityCanonical},
+    {"LastLogon", "LastLogon", fieldValueTimestamp, "AccountInformation", FIELD_PRIORITY_BASE + 10,
+     fieldSensitivityCanonical},
+    {"LastLogoff", "LastLogoff", fieldValueTimestamp, "AccountInformation", FIELD_PRIORITY_BASE + 10,
+     fieldSensitivityCanonical},
+    {"LastSuccessfulLogon", "LastSuccessfulLogon", fieldValueTimestamp, "AccountInformation", FIELD_PRIORITY_BASE + 10,
+     fieldSensitivityCanonical},
+    {"LastFailedLogon", "LastFailedLogon", fieldValueTimestamp, "AccountInformation", FIELD_PRIORITY_BASE + 10,
+     fieldSensitivityCanonical},
+    {"LockoutTime", "LockoutTime", fieldValueTimestamp, "AccountInformation", FIELD_PRIORITY_BASE + 10,
+     fieldSensitivityCanonical},
+    {"PasswordLastSet", "PasswordLastSet", fieldValueTimestamp, "AccountInformation", FIELD_PRIORITY_BASE + 10,
+     fieldSensitivityCanonical},
+    {"AccountExpires", "AccountExpires", fieldValueTimestamp, "AccountInformation", FIELD_PRIORITY_BASE + 10,
+     fieldSensitivityCanonical},
     {"ProcessInformation", "ProcessInformation", fieldValueString, "Process", FIELD_PRIORITY_BASE + 10,
      fieldSensitivityCanonical},
     {"CallerProcessID", "CallerProcessID", fieldValueString, "Process", FIELD_PRIORITY_BASE + 10,
@@ -291,6 +318,9 @@ static const field_pattern_t g_coreFieldPatterns[] = {
      fieldSensitivityCanonical},
     {"ProcessCommandLine", "ProcessCommandLine", fieldValueString, "Process", FIELD_PRIORITY_BASE + 10,
      fieldSensitivityCanonical},
+    {"PreviousTime", "PreviousTime", fieldValueTimestamp, "Process", FIELD_PRIORITY_BASE + 10,
+     fieldSensitivityCanonical},
+    {"NewTime", "NewTime", fieldValueTimestamp, "Process", FIELD_PRIORITY_BASE + 10, fieldSensitivityCanonical},
     {"DetailedAuthenticationInformation", "DetailedAuthenticationInformation", fieldValueString, "Authentication",
      FIELD_PRIORITY_BASE + 10, fieldSensitivityCanonical},
     {"LogonProcess", "LogonProcess", fieldValueString, "Authentication", FIELD_PRIORITY_BASE + 10,
@@ -1937,6 +1967,18 @@ static sbool parse_field_value_type_string(const char *text, field_value_type_t 
         *type = fieldValueRemoteCredentialGuard;
         return 1;
     }
+    if (!strcasecmp(text, "guid")) {
+        *type = fieldValueGuid;
+        return 1;
+    }
+    if (!strcasecmp(text, "ip") || !strcasecmp(text, "ip_address") || !strcasecmp(text, "ip-address")) {
+        *type = fieldValueIpAddress;
+        return 1;
+    }
+    if (!strcasecmp(text, "timestamp")) {
+        *type = fieldValueTimestamp;
+        return 1;
+    }
     if (!strcasecmp(text, "privilege_list") || !strcasecmp(text, "privilege-list")) {
         *type = fieldValuePrivilegeList;
         return 1;
@@ -1993,6 +2035,12 @@ static const char *field_value_type_to_string(field_value_type_t type) {
             return "logon_type";
         case fieldValueRemoteCredentialGuard:
             return "remote_credential_guard";
+        case fieldValueGuid:
+            return "guid";
+        case fieldValueIpAddress:
+            return "ip_address";
+        case fieldValueTimestamp:
+            return "timestamp";
         case fieldValuePrivilegeList:
             return "privilege_list";
         default:
@@ -3282,6 +3330,42 @@ static rsRetVal parse_field_value_enhanced(const char *value,
                 if (storedOut != NULL) *storedOut = 1;
             } else {
                 r = handle_parsing_error(fdCtx, "invalid Remote Credential Guard value", key);
+                if (r == RS_RET_OK && fdCtx->enable_fallback) {
+                    json_add_string(target, key, trimmed);
+                    if (storedOut != NULL) *storedOut = 1;
+                }
+            }
+            break;
+        case fieldValueGuid:
+            if (is_guid_format(trimmed)) {
+                json_add_string(target, key, trimmed);
+                if (storedOut != NULL) *storedOut = 1;
+            } else {
+                r = handle_parsing_error(fdCtx, "invalid GUID", key);
+                if (r == RS_RET_OK && fdCtx->enable_fallback) {
+                    json_add_string(target, key, trimmed);
+                    if (storedOut != NULL) *storedOut = 1;
+                }
+            }
+            break;
+        case fieldValueIpAddress:
+            if (is_ip_address(trimmed)) {
+                json_add_string(target, key, trimmed);
+                if (storedOut != NULL) *storedOut = 1;
+            } else {
+                r = handle_parsing_error(fdCtx, "invalid IP address", key);
+                if (r == RS_RET_OK && fdCtx->enable_fallback) {
+                    json_add_string(target, key, trimmed);
+                    if (storedOut != NULL) *storedOut = 1;
+                }
+            }
+            break;
+        case fieldValueTimestamp:
+            if (is_timestamp_format(trimmed)) {
+                json_add_string(target, key, trimmed);
+                if (storedOut != NULL) *storedOut = 1;
+            } else {
+                r = handle_parsing_error(fdCtx, "invalid timestamp", key);
                 if (r == RS_RET_OK && fdCtx->enable_fallback) {
                     json_add_string(target, key, trimmed);
                     if (storedOut != NULL) *storedOut = 1;

--- a/plugins/mmsnarewinsec/mmsnarewinsec.c
+++ b/plugins/mmsnarewinsec/mmsnarewinsec.c
@@ -27,6 +27,9 @@
 #include <string.h>
 #include <strings.h>
 #include <stdio.h>
+#include <time.h>
+#include <arpa/inet.h>
+#include <netinet/in.h>
 
 #include "conf.h"
 #include "datetime.h"
@@ -462,6 +465,15 @@ static uint32_t parse_section_flags_array(struct json_object *value, sbool *ok);
 static bool is_guid_format(const char *value) ATTR_UNUSED;
 static bool is_ip_address(const char *value) ATTR_UNUSED;
 static bool is_timestamp_format(const char *value) ATTR_UNUSED;
+static bool is_iso8601_timestamp(const char *value) ATTR_UNUSED;
+static bool is_windows_event_timestamp(const char *value) ATTR_UNUSED;
+static rsRetVal store_validated_string(field_detection_context_t *fdCtx,
+                                       struct json_object *target,
+                                       const char *key,
+                                       const char *value,
+                                       bool (*validator)(const char *),
+                                       const char *error_message,
+                                       sbool *storedOut);
 static const char *section_behavior_to_string(section_behavior_t behavior) ATTR_UNUSED;
 static const char *field_value_type_to_string(field_value_type_t type) ATTR_UNUSED;
 static const char *field_sensitivity_to_string(field_pattern_sensitivity_t sensitivity) ATTR_UNUSED;
@@ -759,33 +771,121 @@ static bool is_guid_format(const char *value) {
 static bool is_ip_address(const char *value) {
     if (value == NULL) return false;
 
-    int dots = 0;
-    int digits = 0;
+    struct in_addr ipv4_addr;
+    if (inet_pton(AF_INET, value, &ipv4_addr) == 1) return true;
 
-    for (const char *p = value; *p; ++p) {
-        if (*p == '.') {
-            dots++;
-            if (digits == 0) return false;
-            digits = 0;
-        } else if (isdigit((unsigned char)*p)) {
-            digits++;
-        } else {
-            return false;
-        }
+#ifdef AF_INET6
+    struct in6_addr ipv6_addr;
+    if (inet_pton(AF_INET6, value, &ipv6_addr) == 1) return true;
+#endif
+
+    return false;
+}
+
+static bool parse_int_range(const char *digits, size_t length, int min_value, int max_value, int *out) {
+    if (digits == NULL || length == 0) return false;
+    int value = 0;
+    for (size_t i = 0; i < length; ++i) {
+        if (!isdigit((unsigned char)digits[i])) return false;
+        value = (value * 10) + (digits[i] - '0');
+    }
+    if (value < min_value || value > max_value) return false;
+    if (out != NULL) *out = value;
+    return true;
+}
+
+static bool is_iso8601_timestamp(const char *value) {
+    if (value == NULL) return false;
+
+    size_t len = strlen(value);
+    if (len < 20) return false;
+
+    if (value[4] != '-' || value[7] != '-' || value[10] != 'T' || value[13] != ':' || value[16] != ':') return false;
+
+    int dummy;
+    if (!parse_int_range(value, 4, 0, 9999, &dummy)) return false;
+    if (!parse_int_range(value + 5, 2, 1, 12, &dummy)) return false;
+    if (!parse_int_range(value + 8, 2, 1, 31, &dummy)) return false;
+    if (!parse_int_range(value + 11, 2, 0, 23, &dummy)) return false;
+    if (!parse_int_range(value + 14, 2, 0, 59, &dummy)) return false;
+    if (!parse_int_range(value + 17, 2, 0, 60, &dummy)) return false;
+
+    size_t pos = 19;
+    if (value[pos] == '.') {
+        pos++;
+        if (pos >= len || !isdigit((unsigned char)value[pos])) return false;
+        while (pos < len && isdigit((unsigned char)value[pos])) pos++;
     }
 
-    return dots == 3 && digits > 0;
+    if (pos >= len) return false;
+
+    if (value[pos] == 'Z' || value[pos] == 'z') {
+        pos++;
+    } else if (value[pos] == '+' || value[pos] == '-') {
+        pos++;
+        if (pos + 1 >= len) return false;
+        if (!parse_int_range(value + pos, 2, 0, 23, &dummy)) return false;
+        pos += 2;
+        if (pos < len && value[pos] == ':') {
+            pos++;
+            if (pos + 1 >= len) return false;
+            if (!parse_int_range(value + pos, 2, 0, 59, &dummy)) return false;
+            pos += 2;
+        } else if (pos < len && isdigit((unsigned char)value[pos])) {
+            if (!parse_int_range(value + pos, 2, 0, 59, &dummy)) return false;
+            pos += 2;
+        }
+    } else {
+        return false;
+    }
+
+    while (pos < len && isspace((unsigned char)value[pos])) pos++;
+    return pos == len;
+}
+
+static bool token_matches(const char *token, const char *const *table, size_t table_len) {
+    for (size_t i = 0; i < table_len; ++i) {
+        if (strcasecmp(token, table[i]) == 0) return true;
+    }
+    return false;
+}
+
+static bool is_windows_event_timestamp(const char *value) {
+    if (value == NULL) return false;
+
+    char weekday[4] = {0};
+    char month[4] = {0};
+    int day = 0;
+    int hour = 0;
+    int minute = 0;
+    int second = 0;
+    int year = 0;
+    int consumed = 0;
+
+    if (sscanf(value, "%3s %3s %d %d:%d:%d %d%n", weekday, month, &day, &hour, &minute, &second, &year, &consumed) != 7)
+        return false;
+
+    const char *tail = value + consumed;
+    while (*tail != '\0' && isspace((unsigned char)*tail)) tail++;
+    if (*tail != '\0') return false;
+
+    static const char *const weekdays[] = {"Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"};
+    static const char *const months[] = {"Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"};
+
+    if (!token_matches(weekday, weekdays, ARRAY_SIZE(weekdays))) return false;
+    if (!token_matches(month, months, ARRAY_SIZE(months))) return false;
+    if (day < 1 || day > 31) return false;
+    if (hour < 0 || hour > 23) return false;
+    if (minute < 0 || minute > 59) return false;
+    if (second < 0 || second > 60) return false;
+    if (year < 1900) return false;
+
+    return true;
 }
 
 static bool is_timestamp_format(const char *value) {
     if (value == NULL) return false;
-
-    if (strstr(value, "T") != NULL && strstr(value, "Z") != NULL) return true;
-    if (strstr(value, "Mon ") != NULL || strstr(value, "Tue ") != NULL || strstr(value, "Wed ") != NULL ||
-        strstr(value, "Thu ") != NULL || strstr(value, "Fri ") != NULL || strstr(value, "Sat ") != NULL ||
-        strstr(value, "Sun ") != NULL)
-        return true;
-    return false;
+    return is_iso8601_timestamp(value) || is_windows_event_timestamp(value);
 }
 
 static bool is_json_format(const char *value) {
@@ -3217,6 +3317,27 @@ static void add_raw_string(struct json_object *obj, const char *baseName, const 
     free(rawName);
 }
 
+static rsRetVal store_validated_string(field_detection_context_t *fdCtx,
+                                       struct json_object *target,
+                                       const char *key,
+                                       const char *value,
+                                       bool (*validator)(const char *),
+                                       const char *error_message,
+                                       sbool *storedOut) {
+    if (validator == NULL || validator(value)) {
+        json_add_string(target, key, value);
+        if (storedOut != NULL) *storedOut = 1;
+        return RS_RET_OK;
+    }
+
+    rsRetVal r = handle_parsing_error(fdCtx, error_message, key);
+    if (r == RS_RET_OK && fdCtx->enable_fallback) {
+        json_add_string(target, key, value);
+        if (storedOut != NULL) *storedOut = 1;
+    }
+    return r;
+}
+
 static struct json_object *resolve_target_object(parse_context_t *ctx,
                                                  struct json_object *hint,
                                                  const field_pattern_t *pattern) {
@@ -3337,40 +3458,13 @@ static rsRetVal parse_field_value_enhanced(const char *value,
             }
             break;
         case fieldValueGuid:
-            if (is_guid_format(trimmed)) {
-                json_add_string(target, key, trimmed);
-                if (storedOut != NULL) *storedOut = 1;
-            } else {
-                r = handle_parsing_error(fdCtx, "invalid GUID", key);
-                if (r == RS_RET_OK && fdCtx->enable_fallback) {
-                    json_add_string(target, key, trimmed);
-                    if (storedOut != NULL) *storedOut = 1;
-                }
-            }
+            r = store_validated_string(fdCtx, target, key, trimmed, is_guid_format, "invalid GUID", storedOut);
             break;
         case fieldValueIpAddress:
-            if (is_ip_address(trimmed)) {
-                json_add_string(target, key, trimmed);
-                if (storedOut != NULL) *storedOut = 1;
-            } else {
-                r = handle_parsing_error(fdCtx, "invalid IP address", key);
-                if (r == RS_RET_OK && fdCtx->enable_fallback) {
-                    json_add_string(target, key, trimmed);
-                    if (storedOut != NULL) *storedOut = 1;
-                }
-            }
+            r = store_validated_string(fdCtx, target, key, trimmed, is_ip_address, "invalid IP address", storedOut);
             break;
         case fieldValueTimestamp:
-            if (is_timestamp_format(trimmed)) {
-                json_add_string(target, key, trimmed);
-                if (storedOut != NULL) *storedOut = 1;
-            } else {
-                r = handle_parsing_error(fdCtx, "invalid timestamp", key);
-                if (r == RS_RET_OK && fdCtx->enable_fallback) {
-                    json_add_string(target, key, trimmed);
-                    if (storedOut != NULL) *storedOut = 1;
-                }
-            }
+            r = store_validated_string(fdCtx, target, key, trimmed, is_timestamp_format, "invalid timestamp", storedOut);
             break;
         case fieldValuePrivilegeList:
             if (fdCtx->parse_ctx != NULL) {

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -508,6 +508,7 @@ TESTS += \
     mmsnarewinsec-json.sh\
     mmsnarewinsec-syslog.sh\
     mmsnarewinsec-comprehensive.sh\
+    mmsnarewinsec-value-types.sh\
     mmsnarewinsec-enhanced-validation.sh
 if HAVE_VALGRIND
 TESTS += \
@@ -2027,6 +2028,7 @@ EXTRA_DIST= \
         testsuites/mmexternal-SegFault-mm-python.py \
         testsuites/mmsnarewinsec/sample-custom-pattern.data \
         mmsnarewinsec-comprehensive-vg.sh \
+        mmsnarewinsec-value-types.sh \
         mmsnarewinsec-enhanced-validation.sh \
         mmexternal-InvldProg-vg.sh \
 	nested-call-shutdown.sh \

--- a/tests/mmsnarewinsec-value-types.sh
+++ b/tests/mmsnarewinsec-value-types.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-# Validate GUID, IP address, and timestamp value typing in mmsnarewinsec output
+# Validate GUID, IP address, and timestamp value typing in mmsnarewinsec output,
+# including fallback behaviour for malformed inputs
 unset RSYSLOG_DYNNAME
 . ${srcdir:=.}/diag.sh init
 
@@ -20,6 +21,7 @@ startup
 cat <<'MSG' > ${RSYSLOG_DYNNAME}.input
 <13>1 2025-02-18T06:42:17.554128Z DC25-PREVIEW - - - - MSWinEventLog    1       Security        802301  Tue Feb 18 06:42:17 2024 624     Microsoft-Windows-Security-Auditing     N/A     N/A     Success Audit   DC25-PREVIEW    Logon           An account was successfully logged on.    Subject:   Security ID:  S-1-5-18   Account Name:  SYSTEM   Account Domain:  NT AUTHORITY   Logon ID:  0x3E7    Logon Information:   Logon Type:  2   Restricted Admin Mode: -   Virtual Account:  %%1843   Elevated Token:  %%1843    New Logon:   Security ID:  S-1-5-21-88997766-1122334455-6677889900-500   Account Name:  ADMIN-LAPS$   Account Domain:  FABRIKAM   Logon ID:  0x52F1A   Linked Logon ID:  0x0   Network Account Name: -   Network Account Domain: -   Logon GUID:  {5a8f0679-9b23-4cb7-a8c7-3d650c9b52ec}    Process Information:   Process ID:  0x66c   Process Name:  C:\Windows\System32\winlogon.exe    Network Information:   Workstation Name:  CORE25-01   Source Network Address: 192.168.50.12   Source Port:  59122    Detailed Authentication Information:   Logon Process:  User32   Authentication Package:  Negotiate   Transited Services: -   Package Name (NTLM only): -   Key Length:  0    Remote Credential Guard:  Enabled    -802301
 <14>Sep 17 07:38:20 WIN-EXAMPLE MSWinEventLog    1       Security        9308    Tue Sep 17 07:38:20 2024        4616   Microsoft-Windows-Security-Auditing      N/A     N/A     Success Audit   WIN-EXAMPLE Security State Change           The system time was changed.    Subject:   Security ID:  S-1-5-19   Account Name:  LOCAL SERVICE   Account Domain:  NT AUTHORITY   Logon ID:  0x3E5    Process Information:   Process ID:  0x50c   Name:  C:\Windows\System32\svchost.exe    Previous Time:  2024-09-17T14:38:20.338436Z  New Time:  2024-09-17T14:38:20.500269Z    This event is generated when the system time is changed. It is normal for the Windows Time Service, which runs with System privilege, to change the system time on a regular basis. Other system time changes may be indicative of attempts to tamper with the computer.       323
+<13>1 2025-02-18T06:55:01.000000Z DC25-PREVIEW - - - - MSWinEventLog    1       Security        999999  Tue Feb 18 06:55:01 2024 624     Microsoft-Windows-Security-Auditing     N/A     N/A     Success Audit   DC25-PREVIEW    Logon           An account was successfully logged on.    Subject:   Security ID:  S-1-5-18   Account Name:  SYSTEM   Account Domain:  NT AUTHORITY   Logon ID:  0x3E7    New Logon:   Security ID:  S-1-5-21-88997766-1122334455-6677889900-500   Account Name:  ADMIN-LAPS$   Account Domain:  FABRIKAM   Logon ID:  0x52F1A   Logon GUID:  not-a-guid    Network Information:   Workstation Name:  CORE25-01   Source Network Address: 999.999.999.999   Source Port:  59122    EventData:  Previous Time:  definitely-not-a-timestamp  New Time:  2024-99-99T25:61:61Z    Detailed Authentication Information:   Logon Process:  User32   Authentication Package:  Negotiate    -999999
 MSG
 injectmsg_file ${RSYSLOG_DYNNAME}.input
 
@@ -33,9 +35,10 @@ import sys
 with open(sys.argv[1], "r", encoding="utf-8") as fh:
     docs = [json.loads(line) for line in fh if line.strip()]
 
-assert len(docs) == 2, f"expected two events, got {len(docs)}"
+assert len(docs) == 3, f"expected three events, got {len(docs)}"
 first = docs[0]["win"]
 second = docs[1]["win"]
+third = docs[2]["win"]
 
 logon_guid = first["NewLogon"]["LogonGUID"]
 assert isinstance(logon_guid, str), "LogonGUID should be a string"
@@ -51,6 +54,27 @@ for value in (previous_time, new_time):
     assert isinstance(value, str), "timestamp values should remain strings"
 assert previous_time == "2024-09-17T14:38:20.338436Z"
 assert new_time == "2024-09-17T14:38:20.500269Z"
+
+bad_guid = third["NewLogon"]["LogonGUID"]
+assert isinstance(bad_guid, str), "fallback GUID should remain a string"
+assert bad_guid == "not-a-guid"
+
+bad_ip = third["Network"]["SourceNetworkAddress"]
+assert isinstance(bad_ip, str), "fallback IP should remain a string"
+assert bad_ip == "999.999.999.999"
+
+bad_prev = third["EventData"]["PreviousTime"]
+bad_new = third["EventData"]["NewTime"]
+for value in (bad_prev, bad_new):
+    assert isinstance(value, str), "fallback timestamps should remain strings"
+assert bad_prev == "definitely-not-a-timestamp"
+assert bad_new == "2024-99-99T25:61:61Z"
+
+errors = third.get("Validation", {}).get("Errors", [])
+joined = "\n".join(errors)
+assert "LogonGUID" in joined, "expected validation error for invalid GUID"
+assert "SourceNetworkAddress" in joined, "expected validation error for invalid IP"
+assert "PreviousTime" in joined, "expected validation error for invalid timestamp"
 PY
 
 exit_test

--- a/tests/mmsnarewinsec-value-types.sh
+++ b/tests/mmsnarewinsec-value-types.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+# Validate GUID, IP address, and timestamp value typing in mmsnarewinsec output
+unset RSYSLOG_DYNNAME
+. ${srcdir:=.}/diag.sh init
+
+generate_conf
+add_conf '
+module(load="../plugins/mmsnarewinsec/.libs/mmsnarewinsec")
+
+template(name="jsonout" type="list") {
+    property(name="$!all-json")
+    constant(value="\n")
+}
+
+action(type="mmsnarewinsec")
+action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="jsonout")
+'
+
+startup
+cat <<'MSG' > ${RSYSLOG_DYNNAME}.input
+<13>1 2025-02-18T06:42:17.554128Z DC25-PREVIEW - - - - MSWinEventLog    1       Security        802301  Tue Feb 18 06:42:17 2024 624     Microsoft-Windows-Security-Auditing     N/A     N/A     Success Audit   DC25-PREVIEW    Logon           An account was successfully logged on.    Subject:   Security ID:  S-1-5-18   Account Name:  SYSTEM   Account Domain:  NT AUTHORITY   Logon ID:  0x3E7    Logon Information:   Logon Type:  2   Restricted Admin Mode: -   Virtual Account:  %%1843   Elevated Token:  %%1843    New Logon:   Security ID:  S-1-5-21-88997766-1122334455-6677889900-500   Account Name:  ADMIN-LAPS$   Account Domain:  FABRIKAM   Logon ID:  0x52F1A   Linked Logon ID:  0x0   Network Account Name: -   Network Account Domain: -   Logon GUID:  {5a8f0679-9b23-4cb7-a8c7-3d650c9b52ec}    Process Information:   Process ID:  0x66c   Process Name:  C:\Windows\System32\winlogon.exe    Network Information:   Workstation Name:  CORE25-01   Source Network Address: 192.168.50.12   Source Port:  59122    Detailed Authentication Information:   Logon Process:  User32   Authentication Package:  Negotiate   Transited Services: -   Package Name (NTLM only): -   Key Length:  0    Remote Credential Guard:  Enabled    -802301
+<14>Sep 17 07:38:20 WIN-EXAMPLE MSWinEventLog    1       Security        9308    Tue Sep 17 07:38:20 2024        4616   Microsoft-Windows-Security-Auditing      N/A     N/A     Success Audit   WIN-EXAMPLE Security State Change           The system time was changed.    Subject:   Security ID:  S-1-5-19   Account Name:  LOCAL SERVICE   Account Domain:  NT AUTHORITY   Logon ID:  0x3E5    Process Information:   Process ID:  0x50c   Name:  C:\Windows\System32\svchost.exe    Previous Time:  2024-09-17T14:38:20.338436Z  New Time:  2024-09-17T14:38:20.500269Z    This event is generated when the system time is changed. It is normal for the Windows Time Service, which runs with System privilege, to change the system time on a regular basis. Other system time changes may be indicative of attempts to tamper with the computer.       323
+MSG
+injectmsg_file ${RSYSLOG_DYNNAME}.input
+
+shutdown_when_empty
+wait_shutdown
+
+python3 - "$RSYSLOG_OUT_LOG" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], "r", encoding="utf-8") as fh:
+    docs = [json.loads(line) for line in fh if line.strip()]
+
+assert len(docs) == 2, f"expected two events, got {len(docs)}"
+first = docs[0]["win"]
+second = docs[1]["win"]
+
+logon_guid = first["NewLogon"]["LogonGUID"]
+assert isinstance(logon_guid, str), "LogonGUID should be a string"
+assert logon_guid == "{5a8f0679-9b23-4cb7-a8c7-3d650c9b52ec}"
+
+source_ip = first["Network"]["SourceNetworkAddress"]
+assert isinstance(source_ip, str), "SourceNetworkAddress should be a string"
+assert source_ip == "192.168.50.12"
+
+previous_time = second["EventData"]["PreviousTime"]
+new_time = second["EventData"]["NewTime"]
+for value in (previous_time, new_time):
+    assert isinstance(value, str), "timestamp values should remain strings"
+assert previous_time == "2024-09-17T14:38:20.338436Z"
+assert new_time == "2024-09-17T14:38:20.500269Z"
+PY
+
+exit_test

--- a/tests/mmsnarewinsec-value-types.sh
+++ b/tests/mmsnarewinsec-value-types.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
-# Validate GUID, IP address, and timestamp value typing in mmsnarewinsec output,
-# including fallback behaviour for malformed inputs
+## @brief Validate GUID, IP address, and timestamp typing for mmsnarewinsec
+## @description
+## Exercises successful and failing GUID/IP/timestamp samples to ensure
+## validated values are stored as typed JSON strings while malformed data
+## follows the fallback path and records validation errors.
 unset RSYSLOG_DYNNAME
 . ${srcdir:=.}/diag.sh init
 


### PR DESCRIPTION
This updates the unfinished mmsnarewinsec module to detect and type
GUIDs, IP addresses, and timestamps. The goal is better data typing
and maintainability before upstream review and merge. :contentReference[oaicite:5]{index=5}

Before: relevant Snare fields were parsed as plain strings without
format validation. After: the module type-detects GUID/IP/timestamp
values, validates them, and maps common Snare keys accordingly; malformed
values can fall back to string. :contentReference[oaicite:6]{index=6}
Impact: user-visible typing changes for this module; stricter parse
validation with fallback behavior.

Technically, new field value types are introduced for GUIDs, IP
addresses, and timestamps and integrated into the enhanced parse path.
Common keys (e.g., LogonGUID, *NetworkAddress/ClientAddress/
DestinationAddress, and various *Time fields) are mapped to these
types. Validation is added for each type, with graceful fallback on
invalid inputs. A regression test script is added and wired into
tests/Makefile.am to verify JSON typing for valid/invalid samples. No
core queue, OMODTX, or HUP semantics are affected by this change. :contentReference[oaicite:7]{index=7}

