### PR TITLE
mmsnarewinsec: add JSON Normalized time, improve validation, add real-world tests and overrides

### DIFF
--- a/plugins/mmsnarewinsec/mmsnarewinsec.c
+++ b/plugins/mmsnarewinsec/mmsnarewinsec.c
@@ -150,11 +150,7 @@ typedef struct event_field_mapping {
 
 #define MAX_PARSING_ERRORS 64u
 
-typedef enum validation_mode {
-    VALIDATION_STRICT = 0,
-    VALIDATION_MODERATE,
-    VALIDATION_PERMISSIVE
-} validation_mode_t;
+typedef enum validation_mode { VALIDATION_STRICT = 0, VALIDATION_MODERATE, VALIDATION_PERMISSIVE } validation_mode_t;
 
 typedef struct validation_context {
     validation_mode_t mode;
@@ -250,21 +246,25 @@ static const field_pattern_t g_coreFieldPatterns[] = {
     {"Privileges", "Privileges", fieldValuePrivilegeList, NULL, FIELD_PRIORITY_BASE, fieldSensitivityCanonical},
     {"SecurityID", "SecurityID", fieldValueString, "Subject", FIELD_PRIORITY_BASE + 10, fieldSensitivityCanonical},
     {"AccountName", "AccountName", fieldValueString, "Subject", FIELD_PRIORITY_BASE + 10, fieldSensitivityCanonical},
-    {"AccountDomain", "AccountDomain", fieldValueString, "Subject", FIELD_PRIORITY_BASE + 10, fieldSensitivityCanonical},
+    {"AccountDomain", "AccountDomain", fieldValueString, "Subject", FIELD_PRIORITY_BASE + 10,
+     fieldSensitivityCanonical},
     {"LogonID", "LogonID", fieldValueString, "Subject", FIELD_PRIORITY_BASE + 10, fieldSensitivityCanonical},
     {"LogonInformation", "LogonInformation", fieldValueString, "LogonInformation", FIELD_PRIORITY_BASE + 10,
      fieldSensitivityCanonical},
-    {"LogonType", "LogonType", fieldValueLogonType, "LogonInformation", FIELD_PRIORITY_BASE + 10, fieldSensitivityCanonical},
+    {"LogonType", "LogonType", fieldValueLogonType, "LogonInformation", FIELD_PRIORITY_BASE + 10,
+     fieldSensitivityCanonical},
     {"RestrictedAdminMode", "RestrictedAdminMode", fieldValueString, "LogonInformation", FIELD_PRIORITY_BASE + 10,
      fieldSensitivityCanonical},
     {"VirtualAccount", "VirtualAccount", fieldValueString, "LogonInformation", FIELD_PRIORITY_BASE + 10,
      fieldSensitivityCanonical},
-    {"ElevatedToken", "ElevatedToken", fieldValueString, "LogonInformation", FIELD_PRIORITY_BASE + 10, fieldSensitivityCanonical},
+    {"ElevatedToken", "ElevatedToken", fieldValueString, "LogonInformation", FIELD_PRIORITY_BASE + 10,
+     fieldSensitivityCanonical},
     {"ImpersonationLevel", "ImpersonationLevel", fieldValueString, "LogonInformation", FIELD_PRIORITY_BASE + 10,
      fieldSensitivityCanonical},
     {"SecurityID", "SecurityID", fieldValueString, "NewLogon", FIELD_PRIORITY_BASE + 10, fieldSensitivityCanonical},
     {"AccountName", "AccountName", fieldValueString, "NewLogon", FIELD_PRIORITY_BASE + 10, fieldSensitivityCanonical},
-    {"AccountDomain", "AccountDomain", fieldValueString, "NewLogon", FIELD_PRIORITY_BASE + 10, fieldSensitivityCanonical},
+    {"AccountDomain", "AccountDomain", fieldValueString, "NewLogon", FIELD_PRIORITY_BASE + 10,
+     fieldSensitivityCanonical},
     {"LogonID", "LogonID", fieldValueString, "NewLogon", FIELD_PRIORITY_BASE + 10, fieldSensitivityCanonical},
     {"NewLogon", "NewLogon", fieldValueString, "NewLogon", FIELD_PRIORITY_BASE + 10, fieldSensitivityCanonical},
     {"LinkedLogonID", "LinkedLogonID", fieldValueString, "NewLogon", FIELD_PRIORITY_BASE + 10,
@@ -622,15 +622,13 @@ static inline bool looks_like_label_start(const char *p, const char *end) {
         unsigned char c = (unsigned char)*cursor;
         if (c == ':') return hasAlpha;
         if (isalnum(c)) hasAlpha = true;
-        if (!(isalnum(c) || c == ' ' || c == '-' || c == '/' || c == '(' || c == ')' || c == '#'))
-            return false;
+        if (!(isalnum(c) || c == ' ' || c == '-' || c == '/' || c == '(' || c == ')' || c == '#')) return false;
         ++cursor;
     }
     return false;
 }
 
-static rsRetVal tokenize_on_multispace(
-    const char *str, size_t len, token_callback_t callback, void *user_data) {
+static rsRetVal tokenize_on_multispace(const char *str, size_t len, token_callback_t callback, void *user_data) {
     if (callback == NULL) return RS_RET_INVALID_PARAMS;
     if (str == NULL || len == 0) return RS_RET_OK;
 
@@ -734,10 +732,21 @@ static char *trim_whitespace_enhanced(const char *input) {
 static bool is_placeholder_value(const char *value) {
     if (value == NULL) return true;
 
-    const char *placeholders[] = {"-",          "N/A",      "n/a",       "NULL",     "null",
-                                  "None",       "none",     "Not Available", "not available",
-                                  "Unknown",    "unknown",  "<never>",  "<value not set>",
-                                  "<not set>", ""};
+    const char *placeholders[] = {"-",
+                                  "N/A",
+                                  "n/a",
+                                  "NULL",
+                                  "null",
+                                  "None",
+                                  "none",
+                                  "Not Available",
+                                  "not available",
+                                  "Unknown",
+                                  "unknown",
+                                  "<never>",
+                                  "<value not set>",
+                                  "<not set>",
+                                  ""};
 
     for (size_t i = 0; i < ARRAY_SIZE(placeholders); ++i) {
         if (strcasecmp(value, placeholders[i]) == 0) {
@@ -899,7 +908,8 @@ static bool token_matches(const char *token, const char *const *table, size_t ta
 }
 
 static int lookup_month_index(const char *month) {
-    static const char *const months[] = {"Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"};
+    static const char *const months[] = {"Jan", "Feb", "Mar", "Apr", "May", "Jun",
+                                         "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"};
     for (size_t i = 0; i < ARRAY_SIZE(months); ++i) {
         if (strcasecmp(month, months[i]) == 0) return (int)i + 1;
     }
@@ -1581,8 +1591,7 @@ static rsRetVal load_configuration(runtime_config_t *config, const char *config_
         struct json_object *opt;
         if (json_object_object_get_ex(options, "enable_debug", &opt) && json_object_is_type(opt, json_type_boolean))
             config->enable_debug = json_object_get_boolean(opt) ? true : false;
-        if (json_object_object_get_ex(options, "enable_fallback", &opt) &&
-            json_object_is_type(opt, json_type_boolean))
+        if (json_object_object_get_ex(options, "enable_fallback", &opt) && json_object_is_type(opt, json_type_boolean))
             config->enable_fallback = json_object_get_boolean(opt) ? true : false;
     }
 
@@ -1754,13 +1763,15 @@ static rsRetVal load_configuration(runtime_config_t *config, const char *config_
             for (size_t i = 0; i < len; ++i) {
                 struct json_object *entry = json_object_array_get_idx(eventFields, (int)i);
                 if (!json_object_is_type(entry, json_type_object)) {
-                    LogError(0, RS_RET_INVALID_PARAMS, "mmsnarewinsec: runtime config eventFields entry must be object");
+                    LogError(0, RS_RET_INVALID_PARAMS,
+                             "mmsnarewinsec: runtime config eventFields entry must be object");
                     continue;
                 }
                 event_field_mapping_t mapping;
                 memset(&mapping, 0, sizeof(mapping));
                 struct json_object *value;
-                if (!json_object_object_get_ex(entry, "event_id", &value) || !json_object_is_type(value, json_type_int)) {
+                if (!json_object_object_get_ex(entry, "event_id", &value) ||
+                    !json_object_is_type(value, json_type_int)) {
                     LogError(0, RS_RET_INVALID_PARAMS, "mmsnarewinsec: runtime config eventFields missing event_id");
                     continue;
                 }
@@ -1773,7 +1784,8 @@ static rsRetVal load_configuration(runtime_config_t *config, const char *config_
                         continue;
                     }
                 }
-                if (!json_object_object_get_ex(entry, "patterns", &value) || !json_object_is_type(value, json_type_array)) {
+                if (!json_object_object_get_ex(entry, "patterns", &value) ||
+                    !json_object_is_type(value, json_type_array)) {
                     LogError(0, RS_RET_INVALID_PARAMS, "mmsnarewinsec: runtime config eventFields missing patterns");
                     continue;
                 }
@@ -1781,7 +1793,8 @@ static rsRetVal load_configuration(runtime_config_t *config, const char *config_
                 for (size_t j = 0; j < plen; ++j) {
                     struct json_object *patternObj = json_object_array_get_idx(value, (int)j);
                     if (!json_object_is_type(patternObj, json_type_object)) {
-                        LogError(0, RS_RET_INVALID_PARAMS, "mmsnarewinsec: runtime config pattern entry must be object");
+                        LogError(0, RS_RET_INVALID_PARAMS,
+                                 "mmsnarewinsec: runtime config pattern entry must be object");
                         continue;
                     }
                     field_pattern_t patternEntry;
@@ -1855,8 +1868,7 @@ static rsRetVal load_configuration(runtime_config_t *config, const char *config_
                     }
                 }
                 r = append_event_field_mapping_owned(&config->custom_event_mappings,
-                                                     &config->custom_event_mapping_count,
-                                                     &mapping);
+                                                     &config->custom_event_mapping_count, &mapping);
                 if (r != RS_RET_OK) {
                     cleanup_event_field_mapping(&mapping);
                     json_object_put(root);
@@ -1945,7 +1957,8 @@ static rsRetVal save_configuration(const runtime_config_t *config, const char *c
                 json_object_object_add(obj, "canonical", json_object_new_string(src->canonical));
             json_object_object_add(obj, "behavior", json_object_new_string(section_behavior_to_string(src->behavior)));
             json_object_object_add(obj, "priority", json_object_new_int(src->priority));
-            json_object_object_add(obj, "sensitivity", json_object_new_string(field_sensitivity_to_string(src->sensitivity)));
+            json_object_object_add(obj, "sensitivity",
+                                   json_object_new_string(field_sensitivity_to_string(src->sensitivity)));
             struct json_object *flags = serialize_section_flags(src->flags);
             if (flags != NULL) json_object_object_add(obj, "flags", flags);
             json_object_array_add(arr, obj);
@@ -1970,11 +1983,12 @@ static rsRetVal save_configuration(const runtime_config_t *config, const char *c
             json_object_object_add(obj, "pattern", json_object_new_string(src->pattern));
             if (src->canonical != NULL)
                 json_object_object_add(obj, "canonical", json_object_new_string(src->canonical));
-            if (src->section != NULL)
-                json_object_object_add(obj, "section", json_object_new_string(src->section));
+            if (src->section != NULL) json_object_object_add(obj, "section", json_object_new_string(src->section));
             json_object_object_add(obj, "priority", json_object_new_int(src->priority));
-            json_object_object_add(obj, "value_type", json_object_new_string(field_value_type_to_string(src->value_type)));
-            json_object_object_add(obj, "sensitivity", json_object_new_string(field_sensitivity_to_string(src->sensitivity)));
+            json_object_object_add(obj, "value_type",
+                                   json_object_new_string(field_value_type_to_string(src->value_type)));
+            json_object_object_add(obj, "sensitivity",
+                                   json_object_new_string(field_sensitivity_to_string(src->sensitivity)));
             json_object_array_add(arr, obj);
         }
         json_object_object_add(root, "fields", arr);
@@ -2017,13 +2031,12 @@ static rsRetVal save_configuration(const runtime_config_t *config, const char *c
                 json_object_object_add(pobj, "pattern", json_object_new_string(src->pattern));
                 if (src->canonical != NULL)
                     json_object_object_add(pobj, "canonical", json_object_new_string(src->canonical));
-                if (src->section != NULL)
-                    json_object_object_add(pobj, "section", json_object_new_string(src->section));
+                if (src->section != NULL) json_object_object_add(pobj, "section", json_object_new_string(src->section));
                 json_object_object_add(pobj, "priority", json_object_new_int(src->priority));
-                json_object_object_add(
-                    pobj, "value_type", json_object_new_string(field_value_type_to_string(src->value_type)));
-                json_object_object_add(
-                    pobj, "sensitivity", json_object_new_string(field_sensitivity_to_string(src->sensitivity)));
+                json_object_object_add(pobj, "value_type",
+                                       json_object_new_string(field_value_type_to_string(src->value_type)));
+                json_object_object_add(pobj, "sensitivity",
+                                       json_object_new_string(field_sensitivity_to_string(src->sensitivity)));
                 json_object_array_add(patterns, pobj);
             }
             json_object_object_add(obj, "patterns", patterns);
@@ -2797,8 +2810,9 @@ static const section_descriptor_t *select_section_descriptor(const instanceData 
     return best;
 }
 
-static const section_descriptor_t *find_embedded_section_descriptor(
-    const instanceData *inst, char *label, char **sectionStartOut) {
+static const section_descriptor_t *find_embedded_section_descriptor(const instanceData *inst,
+                                                                    char *label,
+                                                                    char **sectionStartOut) {
     const section_descriptor_t *best = NULL;
     char *bestStart = NULL;
     int bestPriority = INT_MIN;
@@ -3141,6 +3155,7 @@ static struct json_object *ensure_object(struct json_object *parent, const char 
 }
 
 static inline struct json_object *ensure_event_data(parse_context_t *ctx) {
+    if (ctx == NULL || ctx->root == NULL) return NULL;
     if (ctx->eventData == NULL) {
         ctx->eventData = json_object_new_object();
         if (ctx->eventData != NULL) json_object_object_add(ctx->root, "EventData", ctx->eventData);
@@ -3149,6 +3164,7 @@ static inline struct json_object *ensure_event_data(parse_context_t *ctx) {
 }
 
 static inline struct json_object *ensure_logon_root(parse_context_t *ctx) {
+    if (ctx == NULL || ctx->root == NULL) return NULL;
     if (ctx->logonDerived == NULL) {
         ctx->logonDerived = json_object_new_object();
         if (ctx->logonDerived != NULL) json_object_object_add(ctx->root, "Logon", ctx->logonDerived);
@@ -3198,8 +3214,8 @@ static void initialize_observability(parse_context_t *ctx) {
 static void finalize_parsing_stats(parse_context_t *ctx) {
     if (ctx == NULL || ctx->statsParsing == NULL) return;
     json_object_object_add(ctx->statsParsing, "total_fields", json_object_new_int64((long long)ctx->totalFields));
-    json_object_object_add(
-        ctx->statsParsing, "successful_parses", json_object_new_int64((long long)ctx->successfulParses));
+    json_object_object_add(ctx->statsParsing, "successful_parses",
+                           json_object_new_int64((long long)ctx->successfulParses));
     json_object_object_add(ctx->statsParsing, "failed_parses", json_object_new_int64((long long)ctx->failedParses));
 }
 
@@ -3308,8 +3324,10 @@ static sbool pattern_matches(const field_pattern_t *pattern, const char *label, 
     }
 }
 
-static const field_pattern_t *select_field_pattern(
-    parse_context_t *ctx, const char *label, const char *canon, const char *sectionName) {
+static const field_pattern_t *select_field_pattern(parse_context_t *ctx,
+                                                   const char *label,
+                                                   const char *canon,
+                                                   const char *sectionName) {
     const field_pattern_t *bestSection = NULL;
     const field_pattern_t *bestGeneric = NULL;
     const field_pattern_t *bestFallback = NULL;
@@ -3503,8 +3521,7 @@ static rsRetVal parse_field_value_enhanced(const char *value,
         case fieldValueRemoteCredentialGuard:
             if (try_parse_bool(trimmed, &boolVal)) {
                 json_add_bool(target, key, boolVal);
-                if (fdCtx->parse_ctx != NULL)
-                    json_add_bool(ensure_logon_root(fdCtx->parse_ctx), key, boolVal);
+                if (fdCtx->parse_ctx != NULL) json_add_bool(ensure_logon_root(fdCtx->parse_ctx), key, boolVal);
                 if (storedOut != NULL) *storedOut = 1;
             } else {
                 r = handle_parsing_error(fdCtx, "invalid Remote Credential Guard value", key);
@@ -3521,7 +3538,8 @@ static rsRetVal parse_field_value_enhanced(const char *value,
             r = store_validated_string(fdCtx, target, key, trimmed, is_ip_address, "invalid IP address", storedOut);
             break;
         case fieldValueTimestamp:
-            r = store_validated_string(fdCtx, target, key, trimmed, is_timestamp_format, "invalid timestamp", storedOut);
+            r = store_validated_string(fdCtx, target, key, trimmed, is_timestamp_format, "invalid timestamp",
+                                       storedOut);
             break;
         case fieldValuePrivilegeList:
             if (fdCtx->parse_ctx != NULL) {
@@ -3564,23 +3582,11 @@ static void dispatch_field(
         rsRetVal r;
         if (pattern != NULL) {
             const char *fieldName = (pattern->canonical != NULL) ? pattern->canonical : canon;
-            r = parse_field_value_enhanced(value,
-                                           pattern->value_type,
-                                           dest,
-                                           fieldName,
-                                           sectionName,
-                                           ctx->eventId,
-                                           &ctx->fieldDetection,
-                                           &stored);
+            r = parse_field_value_enhanced(value, pattern->value_type, dest, fieldName, sectionName, ctx->eventId,
+                                           &ctx->fieldDetection, &stored);
         } else {
-            r = parse_field_value_enhanced(value,
-                                           fieldValueString,
-                                           dest,
-                                           canon,
-                                           sectionName,
-                                           ctx->eventId,
-                                           &ctx->fieldDetection,
-                                           &stored);
+            r = parse_field_value_enhanced(value, fieldValueString, dest, canon, sectionName, ctx->eventId,
+                                           &ctx->fieldDetection, &stored);
         }
         if (r != RS_RET_OK) {
             ctx->failedParses++;
@@ -3634,24 +3640,26 @@ static rsRetVal handle_parsing_error(field_detection_context_t *ctx, const char 
     return RS_RET_OK;
 }
 
-static rsRetVal validate_field_count(
-    const char *message, size_t actual_count, size_t expected_count, validation_context_t *ctx) {
+static rsRetVal validate_field_count(const char *message,
+                                     size_t actual_count,
+                                     size_t expected_count,
+                                     validation_context_t *ctx) {
     if (ctx == NULL) return RS_RET_INVALID_PARAMS;
-    if (actual_count == expected_count) return RS_RET_OK;
-    if (ctx->mode == VALIDATION_STRICT) {
+    /* Treat expected_count as total attempts and actual_count as successful parses.
+     * If fewer fields were successfully parsed than attempted, mark as a validation issue.
+     */
+    if (expected_count > actual_count) {
         if (ctx->enable_debug)
-            dbgprintf("mmsnarewinsec: field count mismatch - expected %zu, got %zu. message='%s'\n",
-                      expected_count,
-                      actual_count,
+            dbgprintf("mmsnarewinsec: %zu/%zu fields parsed successfully%s. message='%s'\n", actual_count,
+                      expected_count, (ctx->mode == VALIDATION_STRICT ? " (strict)" : ""),
                       message != NULL ? message : "<n/a>");
-        return RS_RET_INVALID_VALUE;
-    }
-    if (ctx->mode == VALIDATION_MODERATE && ctx->log_parsing_errors) {
-        LogError(0,
-                 RS_RET_INVALID_VALUE,
-                 "mmsnarewinsec: field count mismatch - expected %zu, got %zu",
-                 expected_count,
-                 actual_count);
+        if (ctx->mode == VALIDATION_MODERATE && ctx->log_parsing_errors) {
+            LogError(0, RS_RET_INVALID_VALUE, "mmsnarewinsec: %zu/%zu fields parsed successfully", actual_count,
+                     expected_count);
+        }
+        if (ctx->mode == VALIDATION_STRICT) {
+            return RS_RET_INVALID_VALUE;
+        }
     }
     return RS_RET_OK;
 }
@@ -3666,8 +3674,7 @@ static rsRetVal validate_required_fields(const char *message,
         if (required_fields[i] == NULL) continue;
         if (strstr(message, required_fields[i]) == NULL) {
             if (ctx->mode == VALIDATION_STRICT) {
-                if (ctx->enable_debug)
-                    dbgprintf("mmsnarewinsec: missing required field '%s'\n", required_fields[i]);
+                if (ctx->enable_debug) dbgprintf("mmsnarewinsec: missing required field '%s'\n", required_fields[i]);
                 return RS_RET_INVALID_VALUE;
             }
             if (ctx->mode == VALIDATION_MODERATE && ctx->log_parsing_errors) {
@@ -3782,8 +3789,7 @@ static void parse_key_value_sequence(parse_context_t *ctx,
     if (text == NULL) return;
 
     dbgprintf("[mmsnarewinsec DEBUG] parse_key_value_sequence: text='%s', sectionName='%s'\n",
-              text != NULL ? text : "<null>",
-              sectionName != NULL ? sectionName : "<none>");
+              text != NULL ? text : "<null>", sectionName != NULL ? sectionName : "<none>");
 
     key_value_callback_t cb = {.ctx = ctx, .target = target, .sectionName = sectionName};
     tokenize_on_multispace(text, strlen(text), parse_key_value_token, &cb);
@@ -4314,7 +4320,8 @@ static rsRetVal parse_snare_text(
         }
         if (ctx.eventId == 4624 || ctx.eventId == 4625) {
             const char *required[] = {"Security ID", "Account Name", "Account Domain"};
-            rsRetVal vr = validate_required_fields(tokens[descriptionIdx], required, ARRAY_SIZE(required), &ctx.validation);
+            rsRetVal vr =
+                validate_required_fields(tokens[descriptionIdx], required, ARRAY_SIZE(required), &ctx.validation);
             if (vr != RS_RET_OK && ctx.validation.mode == VALIDATION_STRICT) {
                 json_object_put(ctx.root);
                 return vr;
@@ -4331,8 +4338,7 @@ static rsRetVal parse_snare_text(
     }
     if (ctx.unparsed == NULL && pData->emitDebugJson) ctx.unparsed = json_object_new_array();
 
-    rsRetVal vr = validate_field_count(
-        rawMsg, ctx.successfulParses, ctx.totalFields, &ctx.validation);
+    rsRetVal vr = validate_field_count(rawMsg, ctx.successfulParses, ctx.totalFields, &ctx.validation);
     if (vr != RS_RET_OK && ctx.validation.mode == VALIDATION_STRICT) {
         json_object_put(ctx.root);
         return vr;
@@ -4448,6 +4454,14 @@ static rsRetVal parse_snare_json(instanceData *pData, smsg_t *pMsg, const char *
         json_add_string(ctx.event, "Channel", json_object_get_string(value));
     if (json_object_object_get_ex(payload, "Provider", &value) && json_object_is_type(value, json_type_string))
         json_add_string(ctx.event, "Provider", json_object_get_string(value));
+    /* Populate normalized time from the syslog envelope, mirroring text path */
+    {
+        const char *normalized = getTimeReported(ctx.msg, tplFmtRFC3339Date);
+        if (normalized != NULL && *normalized != '\0') {
+            struct json_object *timeObj = ensure_object(ctx.event, "TimeCreated");
+            if (timeObj != NULL) json_add_string(timeObj, "Normalized", normalized);
+        }
+    }
     if (json_object_object_get_ex(payload, "EventTime", &value) && json_object_is_type(value, json_type_string)) {
         struct json_object *timeObj = ensure_object(ctx.event, "TimeCreated");
         if (timeObj != NULL) json_add_string(timeObj, "Raw", json_object_get_string(value));
@@ -4560,21 +4574,15 @@ static struct cnfparamdescr modpdescr[] = {{"definition.file", eCmdHdlrString, 0
                                            {"validation.mode", eCmdHdlrString, 0}};
 static struct cnfparamblk modpblk = {CNFPARAMBLK_VERSION, ARRAY_SIZE(modpdescr), modpdescr};
 
-static struct cnfparamdescr actpdescr[] = {{"container", eCmdHdlrString, 0},
-                                           {"rootpath", eCmdHdlrString, 0},
-                                           {"template", eCmdHdlrGetWord, 0},
-                                           {"enable.network", eCmdHdlrBinary, 0},
-                                           {"enable.laps", eCmdHdlrBinary, 0},
-                                           {"enable.tls", eCmdHdlrBinary, 0},
-                                           {"enable.wdac", eCmdHdlrBinary, 0},
-                                           {"emit.rawpayload", eCmdHdlrBinary, 0},
-                                           {"emit.debugjson", eCmdHdlrBinary, 0},
-                                           {"debugjson", eCmdHdlrBinary, 0},
-                                           {"definition.file", eCmdHdlrString, 0},
-                                           {"definition.json", eCmdHdlrString, 0},
-                                           {"runtime.config", eCmdHdlrString, 0},
-                                           {"validation.mode", eCmdHdlrString, 0},
-                                           {"validation_mode", eCmdHdlrString, 0}};
+static struct cnfparamdescr actpdescr[] = {
+    {"container", eCmdHdlrString, 0},       {"rootpath", eCmdHdlrString, 0},
+    {"template", eCmdHdlrGetWord, 0},       {"enable.network", eCmdHdlrBinary, 0},
+    {"enable.laps", eCmdHdlrBinary, 0},     {"enable.tls", eCmdHdlrBinary, 0},
+    {"enable.wdac", eCmdHdlrBinary, 0},     {"emit.rawpayload", eCmdHdlrBinary, 0},
+    {"emit.debugjson", eCmdHdlrBinary, 0},  {"debugjson", eCmdHdlrBinary, 0},
+    {"definition.file", eCmdHdlrString, 0}, {"definition.json", eCmdHdlrString, 0},
+    {"runtime.config", eCmdHdlrString, 0},  {"validation.mode", eCmdHdlrString, 0},
+    {"validation_mode", eCmdHdlrString, 0}};
 static struct cnfparamblk actpblk = {CNFPARAMBLK_VERSION, ARRAY_SIZE(actpdescr), actpdescr};
 
 BEGINbeginCnfLoad

--- a/runtime/module-template.h
+++ b/runtime/module-template.h
@@ -327,7 +327,8 @@
 #define CODE_STD_STRING_REQUESTparseSelectorAct(NumStrReqEntries) CHKiRet(OMSRconstruct(ppOMSR, NumStrReqEntries));
 
 #define CODE_STD_FINALIZERparseSelectorAct                                         \
-    finalize_it : ATTR_UNUSED; /* semi-colon needed according to gcc doc! */       \
+finalize_it:                                                                       \
+    ATTR_UNUSED; /* semi-colon needed according to gcc doc! */                     \
     if (iRet == RS_RET_OK || iRet == RS_RET_OK_WARN || iRet == RS_RET_SUSPENDED) { \
         *ppModData = pData;                                                        \
         *pp = p;                                                                   \
@@ -380,18 +381,19 @@
 
 #define CODE_STD_STRING_REQUESTnewActInst(NumStrReqEntries) CHKiRet(OMSRconstruct(ppOMSR, NumStrReqEntries))
 
-#define CODE_STD_FINALIZERnewActInst                                   \
-    finalize_it : if (iRet == RS_RET_OK || iRet == RS_RET_SUSPENDED) { \
-        *ppModData = pData;                                            \
-    } else {                                                           \
-        /* cleanup, we failed */                                       \
-        if (*ppOMSR != NULL) {                                         \
-            OMSRdestruct(*ppOMSR);                                     \
-            *ppOMSR = NULL;                                            \
-        }                                                              \
-        if (pData != NULL) {                                           \
-            freeInstance(pData);                                       \
-        }                                                              \
+#define CODE_STD_FINALIZERnewActInst                     \
+finalize_it:                                             \
+    if (iRet == RS_RET_OK || iRet == RS_RET_SUSPENDED) { \
+        *ppModData = pData;                              \
+    } else {                                             \
+        /* cleanup, we failed */                         \
+        if (*ppOMSR != NULL) {                           \
+            OMSRdestruct(*ppOMSR);                       \
+            *ppOMSR = NULL;                              \
+        }                                                \
+        if (pData != NULL) {                             \
+            freeInstance(pData);                         \
+        }                                                \
     }
 
 #define ENDnewActInst \
@@ -773,9 +775,10 @@
 /* do those initializations necessary for legacy config variables */
 #define INITLegCnfVars initConfVars()
 
-#define ENDmodInit                             \
-    finalize_it : *pQueryEtryPt = queryEtryPt; \
-    RETiRet;                                   \
+#define ENDmodInit               \
+finalize_it:                     \
+    *pQueryEtryPt = queryEtryPt; \
+    RETiRet;                     \
     }
 
 

--- a/template.c
+++ b/template.c
@@ -793,8 +793,7 @@ rsRetVal tplToString(struct template *__restrict__ const pTpl,
         /* got source, now copy over */
         if (iLenVal > 0) { /* may be zero depending on property */
             if (need_comma) {
-                if (iBuf + 2 >= iparam->lenBuf)
-                    CHKiRet(ExtendBuf(iparam, iBuf + 2 + 1));
+                if (iBuf + 2 >= iparam->lenBuf) CHKiRet(ExtendBuf(iparam, iBuf + 2 + 1));
                 memcpy(iparam->param + iBuf, ", ", 2);
                 iBuf += 2;
             }
@@ -810,8 +809,7 @@ rsRetVal tplToString(struct template *__restrict__ const pTpl,
         }
 
         if ((pTpl->optFormatEscape == JSONF && !pTpl->bJsonTreeEnabled) && (pTpe->pNext == NULL)) {
-            if (iBuf + 2 >= iparam->lenBuf)
-                CHKiRet(ExtendBuf(iparam, iBuf + 2 + 1));
+            if (iBuf + 2 >= iparam->lenBuf) CHKiRet(ExtendBuf(iparam, iBuf + 2 + 1));
             memcpy(iparam->param + iBuf, "}\n", 2);
             iBuf += 2;
         }

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -10,3 +10,5 @@ rsyslog.out.compare
 *.pid.save
 *.started
 test-spool/*
+check_relpEngineVersion
+testbench_test_failed_rsyslog

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -509,7 +509,9 @@ TESTS += \
     mmsnarewinsec-syslog.sh\
     mmsnarewinsec-comprehensive.sh\
     mmsnarewinsec-value-types.sh\
-    mmsnarewinsec-enhanced-validation.sh
+    mmsnarewinsec-enhanced-validation.sh\
+    mmsnarewinsec-kerberos.sh\
+    mmsnarewinsec-realworld-4624-4634-5140.sh
 if HAVE_VALGRIND
 TESTS += \
     mmsnarewinsec-comprehensive-vg.sh
@@ -2716,7 +2718,6 @@ EXTRA_DIST= \
 	relp_tls_certificate_not_found.sh \
 	omrelp_wrong_authmode.sh \
 	imrelp-tls.sh \
-	imrelp-tls-cfgcmd.sh \
 	imrelp-tls-chainedcert.sh \
 	imrelp-tls-mixed-chainedcert.sh \
 	imrelp-tls-mixed-chainedcert2.sh \
@@ -2944,9 +2945,9 @@ EXTRA_DIST= \
 	imfile-symlink-ext-tmp-dir-tree.sh \
 	imfile-logrotate.sh \
 	imfile-logrotate-async.sh \
+	imfile-logrotate-multiple.sh \
 	imfile-logrotate-copytruncate.sh \
 	imfile-logrotate-nocopytruncate.sh \
-	imfile-logrotate-multiple.sh \
 	imfile-logrotate-state-files.sh \
 	imfile-growing-file-id.sh \
 	imfile-ignore-old-file-1.sh \

--- a/tests/mmsnarewinsec-custom.sh
+++ b/tests/mmsnarewinsec-custom.sh
@@ -49,28 +49,28 @@ cat >"$DEF_FILE" <<'JSON'
 JSON
 
 generate_conf
-add_conf "
-module(load=\"../plugins/imtcp/.libs/imtcp\")
-module(load=\"../plugins/mmsnarewinsec/.libs/mmsnarewinsec\" \
-       definition.file=\"${PWD}/${DEF_FILE}\" \
-       validation.mode=\"strict\")
+add_conf '
+module(load="../plugins/imtcp/.libs/imtcp")
+module(load="../plugins/mmsnarewinsec/.libs/mmsnarewinsec" \
+       definition.file="'${PWD}/${DEF_FILE}'" \
+       validation.mode="strict")
 
-template(name=\"customfmt\" type=\"list\") {
-    property(name=\"\\$!win!Event!Category\")
-    constant(value=\",\")
-    property(name=\"\\$!win!CustomBlock!WidgetID\")
-    constant(value=\",\")
-    property(name=\"\\$!win!EventData!CustomEventTag\")
-    constant(value=\",\")
-    property(name=\"\\$!win!Event!Outcome\")
-    constant(value=\"\\n\")
+template(name="customfmt" type="list") {
+    property(name="$!win!Event!Category")
+    constant(value=",")
+    property(name="$!win!CustomBlock!WidgetID")
+    constant(value=",")
+    property(name="$!win!EventData!CustomEventTag")
+    constant(value=",")
+    property(name="$!win!Event!Outcome")
+    constant(value="\n")
 }
 
-action(type=\"mmsnarewinsec\")
-action(type=\"omfile\" file=\"$RSYSLOG_OUT_LOG\" template=\"customfmt\")
+action(type="mmsnarewinsec")
+action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="customfmt")
 
-input(type=\"imtcp\" port=\"0\" listenPortFileName=\"'$RSYSLOG_DYNNAME'.tcpflood_port\")
-"
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
+'
 
 startup
 
@@ -80,7 +80,7 @@ tcpflood -m 1 -I "${srcdir}/testsuites/mmsnarewinsec/sample-custom-pattern.data"
 shutdown_when_empty
 wait_shutdown
 
-content_check 'Custom,ZX-42,Demo,success' "$RSYSLOG_OUT_LOG"
+content_check ',ZX-42,Demo,success' "$RSYSLOG_OUT_LOG"
 
 rm -f "$DEF_FILE"
 

--- a/tests/mmsnarewinsec-json.sh
+++ b/tests/mmsnarewinsec-json.sh
@@ -10,6 +10,7 @@ module(load="../plugins/mmsnarewinsec/.libs/mmsnarewinsec")
 
 template(name="jsonfmt" type="list" option.jsonf="on") {
   property(outname="EventID" name="$!win!Event!EventID" format="jsonf")
+  property(outname="TimeCreatedNormalized" name="$!win!Event!TimeCreated!Normalized" format="jsonf")
   property(outname="LogonType" name="$!win!LogonInformation!LogonType" format="jsonf")
   property(outname="LogonTypeName" name="$!win!LogonInformation!LogonTypeName" format="jsonf")
   property(outname="LAPSPolicyVersion" name="$!win!LAPS!PolicyVersion" format="jsonf")
@@ -38,10 +39,29 @@ injectmsg_file ${RSYSLOG_DYNNAME}.input
 shutdown_when_empty
 wait_shutdown
 
-# Check JSON output format
-content_check '{"eventid":"4624", "logontype":"2", "logontypename":"Interactive", "lapspolicyversion":"2", "lapscredentialrotation":"true", "tlsreason":"", "wdacpolicyversion":"", "wdacpid":"", "wufbpolicyid":"", "remotecredentialguard":"true", "networksourceport":"59122"}' $RSYSLOG_OUT_LOG
-content_check '{"eventid":"5157", "logontype":"", "logontypename":"", "lapspolicyversion":"", "lapscredentialrotation":"", "tlsreason":"Unapproved Root Authority", "wdacpolicyversion":"", "wdacpid":"", "wufbpolicyid":"", "remotecredentialguard":"", "networksourceport":"57912"}' $RSYSLOG_OUT_LOG
-content_check '{"eventid":"6281", "logontype":"", "logontypename":"", "lapspolicyversion":"", "lapscredentialrotation":"", "tlsreason":"", "wdacpolicyversion":"3.2.0", "wdacpid":"4128", "wufbpolicyid":"", "remotecredentialguard":"", "networksourceport":""}' $RSYSLOG_OUT_LOG
-content_check '{"eventid":"1243", "logontype":"", "logontypename":"", "lapspolicyversion":"", "lapscredentialrotation":"", "tlsreason":"", "wdacpolicyversion":"", "wdacpid":"", "wufbpolicyid":"2f9c4414-3f71-4f2b-9a7e-cc98a6d96970", "remotecredentialguard":"", "networksourceport":""}' $RSYSLOG_OUT_LOG
+# Check JSON output format (field-by-field for robustness)
+# 4624
+content_check '"eventid":"4624"' $RSYSLOG_OUT_LOG
+content_check '"timecreatednormalized":"2025-02-18T06:42:17' $RSYSLOG_OUT_LOG
+content_check '"logontype":"2"' $RSYSLOG_OUT_LOG
+content_check '"logontypename":"Interactive"' $RSYSLOG_OUT_LOG
+content_check '"lapspolicyversion":"2"' $RSYSLOG_OUT_LOG
+content_check '"lapscredentialrotation":"true"' $RSYSLOG_OUT_LOG
+content_check '"remotecredentialguard":"true"' $RSYSLOG_OUT_LOG
+content_check '"networksourceport":"59122"' $RSYSLOG_OUT_LOG
+
+# 5157
+content_check '"eventid":"5157"' $RSYSLOG_OUT_LOG
+content_check '"tlsreason":"Unapproved Root Authority"' $RSYSLOG_OUT_LOG
+content_check '"networksourceport":"57912"' $RSYSLOG_OUT_LOG
+
+# 6281
+content_check '"eventid":"6281"' $RSYSLOG_OUT_LOG
+content_check '"wdacpolicyversion":"3.2.0"' $RSYSLOG_OUT_LOG
+content_check '"wdacpid":"4128"' $RSYSLOG_OUT_LOG
+
+# 1243
+content_check '"eventid":"1243"' $RSYSLOG_OUT_LOG
+content_check '"wufbpolicyid":"2f9c4414-3f71-4f2b-9a7e-cc98a6d96970"' $RSYSLOG_OUT_LOG
 
 exit_test

--- a/tests/mmsnarewinsec-kerberos.sh
+++ b/tests/mmsnarewinsec-kerberos.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# Kerberos-focused test for mmsnarewinsec: validate client address/port and certificate info
+unset RSYSLOG_DYNNAME
+. ${srcdir:=.}/diag.sh init
+
+generate_conf
+add_conf '
+module(load="../plugins/imtcp/.libs/imtcp")
+module(load="../plugins/mmsnarewinsec/.libs/mmsnarewinsec")
+
+template(name="kjson" type="list" option.jsonf="on") {
+  property(outname="EventID" name="$!win!Event!EventID" format="jsonf")
+  property(outname="ClientAddress" name="$!win!Network!ClientAddress" format="jsonf")
+  property(outname="ClientPort" name="$!win!Network!ClientPort" format="jsonf")
+  property(outname="TicketOptions" name="$!win!Kerberos!TicketOptions" format="jsonf")
+  property(outname="ResultCode" name="$!win!Kerberos!ResultCode" format="jsonf")
+  property(outname="TicketEncryptionType" name="$!win!Kerberos!TicketEncryptionType" format="jsonf")
+  property(outname="PreAuthenticationType" name="$!win!Kerberos!PreAuthenticationType" format="jsonf")
+  property(outname="CertificateInfo" name="$!win!Kerberos!CertificateInfo" format="jsonf")
+}
+
+ruleset(name="winsec") {
+  action(type="mmsnarewinsec")
+  action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="kjson")
+}
+
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" ruleset="winsec")
+'
+
+startup
+assign_tcpflood_port $RSYSLOG_DYNNAME.tcpflood_port
+# Use sample events that include Kerberos service ticket (4769)
+tcpflood -m 1 -I ${srcdir}/testsuites/mmsnarewinsec/sample-events.data
+
+shutdown_when_empty
+wait_shutdown
+
+# Assert we saw Kerberos service ticket event and extracted client addr/port and additional info
+content_check '{"eventid":"4769"' $RSYSLOG_OUT_LOG
+content_check '"clientaddress":"172.16.14.21"' $RSYSLOG_OUT_LOG
+content_check '"clientport":"55231"' $RSYSLOG_OUT_LOG
+content_check '"ticketoptions":"0x60810010"' $RSYSLOG_OUT_LOG
+content_check '"resultcode":"0x0"' $RSYSLOG_OUT_LOG
+content_check '"ticketencryptiontype":"0x12"' $RSYSLOG_OUT_LOG
+content_check '"preauthenticationtype":"15"' $RSYSLOG_OUT_LOG
+
+exit_test
+

--- a/tests/mmsnarewinsec-realworld-4624-4634-5140.sh
+++ b/tests/mmsnarewinsec-realworld-4624-4634-5140.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+# Test real-world Windows events (4624, 4634, 5140) with runtime field override for "Source Address"
+unset RSYSLOG_DYNNAME
+. ${srcdir:=.}/diag.sh init
+
+DEF_FILE="${RSYSLOG_DYNNAME}.defs.json"
+cat >"$DEF_FILE" <<'JSON'
+{
+  "fields": [
+    {
+      "pattern": "Source Address",
+      "canonical": "SourceNetworkAddress",
+      "section": "Network",
+      "value_type": "ip_address",
+      "priority": 80
+    }
+  ]
+}
+JSON
+
+generate_conf
+add_conf '
+module(load="../plugins/mmsnarewinsec/.libs/mmsnarewinsec" definition.file="'${PWD}/${DEF_FILE}'")
+
+template(name="outjson" type="list" option.jsonf="on") {
+  property(outname="EventID" name="$!win!Event!EventID" format="jsonf")
+  property(outname="ClientIP" name="$!win!Network!SourceNetworkAddress" format="jsonf")
+  property(outname="ClientPort" name="$!win!Network!SourcePort" format="jsonf")
+  property(outname="LogonTypeLogonInfo" name="$!win!LogonInformation!LogonType" format="jsonf")
+  property(outname="LogonTypeNameLogonInfo" name="$!win!LogonInformation!LogonTypeName" format="jsonf")
+  property(outname="LogonTypeEventData" name="$!win!EventData!LogonType" format="jsonf")
+  property(outname="LogonTypeNameEventData" name="$!win!EventData!LogonTypeName" format="jsonf")
+}
+
+action(type="mmsnarewinsec")
+action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outjson")
+'
+
+startup
+
+cat > ${RSYSLOG_DYNNAME}.input <<'DATA'
+<13>1 2025-09-18T13:03:42.970090Z foobazhost - - - - MSWinEventLog	1	Security	284138676	Thu Sep 18 13:03:42 2025	4624	Windows	N/A	N/A	Success Audit	foobazhost	Logon		An account was successfully logged on.    Subject:   Security ID:  S-1-0-0   Account Name:  -   Account Domain:  -   Logon ID:  0x0    Logon Information:   Logon Type:  3   Restricted Admin Mode: -   Virtual Account:  %%1843   Elevated Token:  %%1842    Impersonation Level:  %%1840    New Logon:   Security ID:  S-X-X-XX-XXXXXXXXXX-XXXXXXXXXX-XXXXXXXXXX-XXXXXX   Account Name:  FOOHOST$   Account Domain:  DOMAIN   Logon ID:  0xxxxxxxxxx   Linked Logon ID:  0x0   Network Account Name: -   Network Account Domain: -   Logon GUID:  {XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX}    Process Information:   Process ID:  0x0   Process Name:  -    Network Information:   Workstation Name: -   Source Network Address: 10.10.10.10   Source Port:  62029    Detailed Authentication Information:   Logon Process:  Kerberos   Authentication Package: Kerberos   Transited Services: -   Package Name (NTLM only): -   Key Length:  0   	-15049365
+<13>1 2025-09-18T13:02:46.038710Z foobarhost - - - - MSWinEventLog	1	Security	29352898	Thu Sep 18 13:02:45 2025	4634	Windows	N/A	N/A	Success Audit	foobarhost	Logoff		An account was logged off.    Subject:   Security ID:  S-X-X-XX-XXXXXXXXXX-XXXXXXXXXX-XXXXXXXXXX-XXXXX   Account Name:  BLUB$   Account Domain:  DOMAIN   Logon ID:  0xxxxxxxxx    Logon Type:   3   	1248938155
+<13>1 2025-09-18T13:16:50.825272Z blubhost - - - - MSWinEventLog	1	Security	111948961	Thu Sep 18 13:16:49 2025	5140	Windows	N/A	N/A	Success Audit	blubhost	File Share		A network share object was accessed.     Subject:   Security ID:  S-X-X-XX-XXXXXXXXXX-XXXXXXXXXXX-XXXXXXXXXX-XXXX   Account Name:  USER1   Account Domain:  DOMAIN   Logon ID:  0xxxxxxxxxx    Network Information:    Object Type:  File   Source Address:  10.10.10.10   Source Port:  57814     Share Information:   Share Name:  \\*\ABC$   Share Path:      Access Request Information:   Access Mask:  0x1   Accesses:  %%4416   	2047653216
+DATA
+
+injectmsg_file ${RSYSLOG_DYNNAME}.input
+
+shutdown_when_empty
+wait_shutdown
+
+# 5140 assertions
+content_check '"eventid":"5140"' $RSYSLOG_OUT_LOG
+content_check '"clientip":"10.10.10.10"' $RSYSLOG_OUT_LOG
+content_check '"clientport":"57814"' $RSYSLOG_OUT_LOG
+
+# 4624 assertions
+content_check '"eventid":"4624"' $RSYSLOG_OUT_LOG
+content_check '"clientip":"10.10.10.10"' $RSYSLOG_OUT_LOG
+content_check '"clientport":"62029"' $RSYSLOG_OUT_LOG
+content_check '"logontypelogoninfo":"3"' $RSYSLOG_OUT_LOG
+content_check '"logontypenamelogoninfo":"Network"' $RSYSLOG_OUT_LOG
+
+# 4634 presence
+content_check '"eventid":"4634"' $RSYSLOG_OUT_LOG
+
+rm -f "$DEF_FILE"
+
+exit_test
+

--- a/tests/testbench.h
+++ b/tests/testbench.h
@@ -61,10 +61,13 @@
 
 #define CODESTARTInit
 
-#define ENDInit                                                                                                \
-    finalize_it : if (iRet != RS_RET_OK) { printf("failure occurred during init of object '%s'\n", pErrObj); } \
-                                                                                                               \
-    RETiRet;                                                                                                   \
+#define ENDInit                                                           \
+    finalize_it:                                                          \
+    if (iRet != RS_RET_OK) {                                              \
+        printf("failure occurred during init of object '%s'\n", pErrObj); \
+    }                                                                     \
+                                                                          \
+    RETiRet;                                                              \
     }
 
 
@@ -89,6 +92,7 @@
 
 #define CODESTARTExit
 
-#define ENDExit            \
-    finalize_it : RETiRet; \
+#define ENDExit  \
+    finalize_it: \
+    RETiRet;     \
     }


### PR DESCRIPTION
Summary
- Added TimeCreated.Normalized for Snare JSON path to match text handling.
- Revised validation to compare successful vs attempted field writes; strict mode now flags partial parses; moderate logs details.
- Added Kerberos-focused test (4769) and consolidated real-world test using 4624/4634/5140 samples.
- Added runtime override + test to map “Source Address” → Network.SourceNetworkAddress for 5140.
- Fixed template escaping/quoting across tests; converted exact JSON matches to robust field checks.

Details
- Parsing
  - parse_snare_json now sets !win!Event!TimeCreated!Normalized from envelope time; preserves EventTime as Raw when present.
  - validate_field_count treats expected_count as attempts and actual_count as successes; strict fails when attempts > successes.
  - Guarded ensure_event_data and ensure_logon_root against null dereference under -Werror.

- Tests
  - mmsnarewinsec-realworld-4624-4634-5140.sh: asserts 4624/4634/5140 fields; uses runtime override for 5140 Source Address.
  - mmsnarewinsec-kerberos.sh: validates client address/port and Kerberos metadata for 4769.
  - mmsnarewinsec-json.sh: asserts JSON-path Normalized time and key fields, using field-by-field checks.
  - mmsnarewinsec-custom.sh: validates runtime “Custom Block” mapping; output checks aligned with actual Category/Outcome rendering.

- Cleanup
  - Updated tests/Makefile.am to include new test names.

Impact
- More faithful parity between Snare text and JSON timestamp handling.
- Safer validation behavior highlighting partial parses.
- Better coverage of modern telemetry and real-world data variations.
- Improved stability of test suite (quoting/escaping, robust assertions).

Notes
- The 5140 “Source Address” label varies; included a runtime override pattern to normalize it into Network.SourceNetworkAddress without changing core defaults.