### PR TITLE
Investigate intermittent manytcp-too-few-tls-vg test failures

### DIFF
--- a/tests/manytcp-too-few-tls-vg.sh
+++ b/tests/manytcp-too-few-tls-vg.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # test many concurrent tcp connections
 # released under ASL 2.0
+export USE_VALGRIND="YES"
 . ${srcdir:=.}/diag.sh init
 skip_platform "FreeBSD"  "This test does not work on FreeBSD"
 export NUMMESSAGES=40000 # we unfortunately need many messages as we have many connections


### PR DESCRIPTION
Set `USE_VALGRIND` in `manytcp-too-few-tls-vg.sh` to fix intermittent startup timeouts when running under Valgrind.

The test was failing intermittently due to a startup timeout. Although the test runs under Valgrind, `USE_VALGRIND` was not exported before `diag.sh` was sourced. This prevented the test harness from extending the startup timeout from 60s to 240s for Valgrind runs, leading to premature test abortion.

---
<a href="https://cursor.com/background-agent?bcId=bc-761e0a1a-1e1b-415d-b449-7428c9313dcd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-761e0a1a-1e1b-415d-b449-7428c9313dcd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

