### PR TITLE
Sync pull request filters in run_macos.yml

### DIFF
--- a/.github/workflows/run_macos.yml
+++ b/.github/workflows/run_macos.yml
@@ -25,6 +25,16 @@ name: check_run_macos
 
 'on':
   pull_request:
+    paths:
+      - '**/*.c'
+      - '**/*.h'
+      - 'grammar/lexer.l'
+      - 'grammar/grammar.y'
+      - 'tests/*.sh'
+      - 'diag.sh'
+      - '**/Makefile.am'
+      - 'configure.ac'
+      - '.github/workflows/*.yml'
 
 jobs:
   check_run:


### PR DESCRIPTION
Add `pull_request` path filters to `run_macos.yml` to match `run_checks.yml`.

---
<a href="https://cursor.com/background-agent?bcId=bc-efded89e-0057-46b6-b630-65f1baa77a33"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-efded89e-0057-46b6-b630-65f1baa77a33"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

