### PR TITLE
Fix imtcp connection test on macos

### DIFF
--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -3515,7 +3515,11 @@ case $1 in
 			echo "hint: was init accidentally called twice?"
 			exit 2
 		fi
-		export RSYSLOG_DYNNAME="rstb_$(./test_id $(basename $0))$(tr -dc 'a-zA-Z0-9' < /dev/urandom | head --bytes 4)"
+		# Generate a short ASCII-only random suffix in a POSIX/portable way.
+		# On macOS, BSD tr with UTF-8 locales can error with "Illegal byte sequence"
+		# when fed /dev/urandom. Force C locale and use head -c (portable) instead of
+		# GNU head --bytes to avoid flaky failures in GitHub Actions runners.
+		export RSYSLOG_DYNNAME="rstb_$(./test_id $(basename $0))$(LC_ALL=C tr -dc 'a-zA-Z0-9' < /dev/urandom | head -c 4)"
 		export RSYSLOG_OUT_LOG="${RSYSLOG_DYNNAME}.out.log"
 		export RSYSLOG2_OUT_LOG="${RSYSLOG_DYNNAME}_2.out.log"
 		export RSYSLOG_PIDBASE="${RSYSLOG_DYNNAME}:" # also used by instance 2!


### PR DESCRIPTION
Make RSYSLOG_DYNNAME generation portable in `tests/diag.sh` to fix flaky macOS failures.

The previous method for generating `RSYSLOG_DYNNAME` used locale-sensitive `tr` and GNU-specific `head --bytes`. On macOS, this led to "Illegal byte sequence" errors from `tr` and non-portable command usage. This change forces a C locale for `tr` and uses the POSIX-compliant `head -c` to ensure robust and consistent behavior across all test environments.

---
<a href="https://cursor.com/background-agent?bcId=bc-aefff553-ae0f-434f-8ad5-61f6bf831d98"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-aefff553-ae0f-434f-8ad5-61f6bf831d98"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

