### PR TITLE
Fix imptcp null pointer dereference error

### DIFF
--- a/plugins/imptcp/imptcp.c
+++ b/plugins/imptcp/imptcp.c
@@ -1499,7 +1499,8 @@ finalize_it:
                  "imptcp: failed to fully accept session from remote peer %s[%s]. "
                  "This can be caused by a peer that closed the session immediately after "
                  "connect, like during a security or health check port probe.",
-                 propGetSzStr(peerName), propGetSzStr(peerIP));
+                 propGetSzStrOrDefault(peerName, "(unknown)"),
+                 propGetSzStrOrDefault(peerIP, "(unknown)"));
         if (pSess != NULL) {
             if (pSess->next != NULL) {
                 unlinkSess(pSess);


### PR DESCRIPTION
Replace `propGetSzStr` with `propGetSzStrOrDefault` in `imptcp.c` to fix a build failure with GCC 14.2.

Newer GCC versions (e.g., 14.2) treat potential null pointer dereferences as errors (`-Werror=null-dereference`). This change addresses a warning in an error logging path where `peerName` or `peerIP` could theoretically be null, causing the build to fail.

---
<a href="https://cursor.com/background-agent?bcId=bc-717072c0-896d-4e75-aad2-d4f30e33e079"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-717072c0-896d-4e75-aad2-d4f30e33e079"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

