### PR TITLE
ommysql: initialize per-worker MySQL client threads

### DIFF
--- a/plugins/ommysql/ommysql.c
+++ b/plugins/ommysql/ommysql.c
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "rsyslog.h"
 #include <stdio.h>
+#include <stdbool.h>
 #include <stdarg.h>
 #include <stdlib.h>
 #include <string.h>
@@ -71,6 +72,7 @@ typedef struct wrkrInstanceData {
     instanceData *pData;
     MYSQL *hmysql; /* handle to MySQL */
     unsigned uLastMySQLErrno; /* last errno returned by MySQL or 0 if all is well */
+    bool threadInitialized; /* whether mysql_thread_init() succeeded */
 } wrkrInstanceData_t;
 
 typedef struct configSettings_s {
@@ -110,6 +112,7 @@ ENDcreateInstance
 BEGINcreateWrkrInstance
     CODESTARTcreateWrkrInstance;
     pWrkrData->hmysql = NULL;
+    pWrkrData->threadInitialized = false;
 ENDcreateWrkrInstance
 
 
@@ -138,7 +141,10 @@ ENDfreeInstance
 BEGINfreeWrkrInstance
     CODESTARTfreeWrkrInstance;
     closeMySQL(pWrkrData);
-    mysql_thread_end();
+    if (pWrkrData->threadInitialized) {
+        mysql_thread_end();
+        pWrkrData->threadInitialized = false;
+    }
 ENDfreeWrkrInstance
 
 
@@ -185,6 +191,14 @@ static rsRetVal initMySQL(wrkrInstanceData_t *pWrkrData, int bSilent) {
 
     assert(pWrkrData->hmysql == NULL);
     pData = pWrkrData->pData;
+
+    if (!pWrkrData->threadInitialized) {
+        if (mysql_thread_init()) {
+            LogError(0, RS_RET_SUSPENDED, "ommysql: failed to initialize thread for MySQL client library");
+            ABORT_FINALIZE(RS_RET_SUSPENDED);
+        }
+        pWrkrData->threadInitialized = true;
+    }
 
     pWrkrData->hmysql = mysql_init(NULL);
     if (pWrkrData->hmysql == NULL) {

--- a/tests/mysql-asyn.sh
+++ b/tests/mysql-asyn.sh
@@ -2,13 +2,25 @@
 # This file is part of the rsyslog project, released under ASL 2.0
 # asyn test for mysql functionality (running on async action queue)
 . ${srcdir:=.}/diag.sh init
-export NUMMESSAGES=50000
+export NUMMESSAGES=25000
 generate_conf
 add_conf '
 $ModLoad ../plugins/ommysql/.libs/ommysql
 $ActionQueueType LinkedList
-$ActionQueueTimeoutEnqueue 20000
-:msg, contains, "msgnum:" :ommysql:127.0.0.1,'$RSYSLOG_DYNNAME',rsyslog,testbench;
+$ActionQueueTimeoutEnqueue 1000
+if $msg contains "msgnum:" then {
+  action(
+    type="ommysql"
+    server="127.0.0.1"
+    db="'$RSYSLOG_DYNNAME'"
+    uid="rsyslog"
+    pwd="testbench"
+    queue.type="LinkedList"
+    queue.timeoutEnqueue="10000"
+    queue.workerThreads="2"
+    queue.workerThreadMinimumMessages="64"
+  )
+}
 '
 mysql_prep_for_test
 startup


### PR DESCRIPTION
## Summary
- call `mysql_thread_init()` the first time each worker thread opens a MySQL connection
- release the MySQL client thread state when a worker shuts down or connection setup fails so retries can reattach cleanly

