### PR TITLE
Investigate rare bug occurrence

### DIFF
--- a/.artifacts/job-logs.txt
+++ b/.artifacts/job-logs.txt
@@ -1,0 +1,2782 @@
+﻿2025-10-09T20:05:12.6102590Z Current runner version: '2.328.0'
+2025-10-09T20:05:12.6117890Z ##[group]Runner Image Provisioner
+2025-10-09T20:05:12.6118390Z Hosted Compute Agent
+2025-10-09T20:05:12.6118730Z Version: 20251003.420
+2025-10-09T20:05:12.6119120Z Commit: 2377dc5bf0f6cca5c863dfc4fa0dabc70e08de87
+2025-10-09T20:05:12.6119630Z Build Date: 2025-10-03T16:01:39Z
+2025-10-09T20:05:12.6120000Z ##[endgroup]
+2025-10-09T20:05:12.6120400Z ##[group]Operating System
+2025-10-09T20:05:12.6120770Z macOS
+2025-10-09T20:05:12.6121080Z 15.6.1
+2025-10-09T20:05:12.6121380Z 24G90
+2025-10-09T20:05:12.6121660Z ##[endgroup]
+2025-10-09T20:05:12.6121970Z ##[group]Runner Image
+2025-10-09T20:05:12.6122300Z Image: macos-15-arm64
+2025-10-09T20:05:12.6122680Z Version: 20250928.2397
+2025-10-09T20:05:12.6123420Z Included Software: https://github.com/actions/runner-images/blob/macos-15-arm64/20250928.2397/images/macos/macos-15-arm64-Readme.md
+2025-10-09T20:05:12.6124450Z Image Release: https://github.com/actions/runner-images/releases/tag/macos-15-arm64%2F20250928.2397
+2025-10-09T20:05:12.6125070Z ##[endgroup]
+2025-10-09T20:05:12.6126830Z ##[group]GITHUB_TOKEN Permissions
+2025-10-09T20:05:12.6127960Z Actions: write
+2025-10-09T20:05:12.6128280Z Attestations: write
+2025-10-09T20:05:12.6128590Z Checks: write
+2025-10-09T20:05:12.6128960Z Contents: write
+2025-10-09T20:05:12.6129270Z Deployments: write
+2025-10-09T20:05:12.6129590Z Discussions: write
+2025-10-09T20:05:12.6129900Z Issues: write
+2025-10-09T20:05:12.6130210Z Metadata: read
+2025-10-09T20:05:12.6130630Z Models: read
+2025-10-09T20:05:12.6130940Z Packages: write
+2025-10-09T20:05:12.6131280Z Pages: write
+2025-10-09T20:05:12.6131650Z PullRequests: write
+2025-10-09T20:05:12.6132020Z RepositoryProjects: write
+2025-10-09T20:05:12.6132380Z SecurityEvents: write
+2025-10-09T20:05:12.6132840Z Statuses: write
+2025-10-09T20:05:12.6133200Z ##[endgroup]
+2025-10-09T20:05:12.6134640Z Secret source: Actions
+2025-10-09T20:05:12.6135050Z Prepare workflow directory
+2025-10-09T20:05:12.6541470Z Prepare all required actions
+2025-10-09T20:05:12.6572900Z Getting action download info
+2025-10-09T20:05:12.8675860Z Download action repository 'actions/checkout@v4' (SHA:08eba0b27e820071cde6df949e0beb9ba4906955)
+2025-10-09T20:05:13.2876840Z Complete job name: CI (macos-15, arm64, tsan)
+2025-10-09T20:05:13.3536730Z ##[group]Run brew install pkgconf \
+2025-10-09T20:05:13.3537210Z [36;1mbrew install pkgconf \[0m
+2025-10-09T20:05:13.3537550Z [36;1m  gnutls \[0m
+2025-10-09T20:05:13.3537840Z [36;1m  libestr \[0m
+2025-10-09T20:05:13.3538150Z [36;1m  libfastjson \[0m
+2025-10-09T20:05:13.3538460Z [36;1m  docutils \[0m
+2025-10-09T20:05:13.3538760Z [36;1m  autoconf \[0m
+2025-10-09T20:05:13.3539060Z [36;1m  automake \[0m
+2025-10-09T20:05:13.3539370Z [36;1m  libtool[0m
+2025-10-09T20:05:13.3598050Z shell: /bin/bash -e {0}
+2025-10-09T20:05:13.3599100Z env:
+2025-10-09T20:05:13.3599410Z   USE_AUTO_DEBUG: true
+2025-10-09T20:05:13.3599740Z   ABORT_ALL_ON_TEST_FAIL: true
+2025-10-09T20:05:13.3600070Z ##[endgroup]
+2025-10-09T20:05:16.7611080Z ##[warning]pkgconf 2.5.1 is already installed and up-to-date.
+To reinstall 2.5.1, run:
+  brew reinstall pkgconf
+
+2025-10-09T20:05:16.7617290Z ##[warning]gnutls 3.8.10 is already installed and up-to-date.
+To reinstall 3.8.10, run:
+  brew reinstall gnutls
+
+2025-10-09T20:05:17.2997140Z [32m==>[0m [1mFetching downloads for: [32mlibestr[39m, [32mlibfastjson[39m, [32mdocutils[39m, [32mautoconf[39m, [32mautomake[39m and [32mlibtool[39m[0m
+2025-10-09T20:05:17.3064590Z [34m==>[0m [1mDownloading https://ghcr.io/v2/homebrew/core/libestr/manifests/0.1.11[0m
+2025-10-09T20:05:18.2906960Z [34m==>[0m [1mDownloading https://ghcr.io/v2/homebrew/core/libfastjson/manifests/1.2304.0[0m
+2025-10-09T20:05:18.7072850Z [34m==>[0m [1mDownloading https://ghcr.io/v2/homebrew/core/docutils/manifests/0.22.2[0m
+2025-10-09T20:05:19.1020000Z [34m==>[0m [1mDownloading https://ghcr.io/v2/homebrew/core/autoconf/manifests/2.72-1[0m
+2025-10-09T20:05:19.6203290Z [34m==>[0m [1mDownloading https://ghcr.io/v2/homebrew/core/automake/manifests/1.18.1[0m
+2025-10-09T20:05:20.1323020Z [34m==>[0m [1mDownloading https://ghcr.io/v2/homebrew/core/libtool/manifests/2.5.4[0m
+2025-10-09T20:05:20.7356160Z [32m==>[0m [1mFetching [32mlibestr[39m[0m
+2025-10-09T20:05:20.7387280Z [34m==>[0m [1mDownloading https://ghcr.io/v2/homebrew/core/libestr/blobs/sha256:c4ee35e1e3e47e5009e3fdb7be52737edebddcdd812e8c1811fcf73648a656cb[0m
+2025-10-09T20:05:21.1640880Z [32m==>[0m [1mFetching [32mlibfastjson[39m[0m
+2025-10-09T20:05:21.1743130Z [34m==>[0m [1mDownloading https://ghcr.io/v2/homebrew/core/libfastjson/blobs/sha256:e9a8424dc257099992210434ed1b30517d31ea60793715f5b2878421144ffa9e[0m
+2025-10-09T20:05:21.6935130Z [32m==>[0m [1mFetching [32mdocutils[39m[0m
+2025-10-09T20:05:21.7044430Z [34m==>[0m [1mDownloading https://ghcr.io/v2/homebrew/core/docutils/blobs/sha256:25feb788160d84ea9bc516b9f561d114027d9a8f1be5541886376043a83176d5[0m
+2025-10-09T20:05:22.7520020Z [32m==>[0m [1mFetching dependencies for autoconf: [32mm4[39m[0m
+2025-10-09T20:05:22.7562960Z [34m==>[0m [1mDownloading https://ghcr.io/v2/homebrew/core/m4/manifests/1.4.20[0m
+2025-10-09T20:05:24.2023840Z [32m==>[0m [1mFetching [32mm4[39m[0m
+2025-10-09T20:05:24.2028130Z [34m==>[0m [1mDownloading https://ghcr.io/v2/homebrew/core/m4/blobs/sha256:80bd9ecaa8798a7db6a2e86acc61089dc31d83e6e9e01495a6a57c3703155f47[0m
+2025-10-09T20:05:24.6324640Z [32m==>[0m [1mFetching [32mautoconf[39m[0m
+2025-10-09T20:05:24.6331040Z [34m==>[0m [1mDownloading https://ghcr.io/v2/homebrew/core/autoconf/blobs/sha256:b1d110e2efd457a5e56c4469f2d6741109d542801a401fe08b750d0614581a9a[0m
+2025-10-09T20:05:25.1010490Z [32m==>[0m [1mFetching [32mautomake[39m[0m
+2025-10-09T20:05:25.1025140Z [34m==>[0m [1mDownloading https://ghcr.io/v2/homebrew/core/automake/blobs/sha256:3c00a332610983c37659eee42e4a93341a3051892481362d223a40f5435b7555[0m
+2025-10-09T20:05:25.5660620Z [32m==>[0m [1mFetching [32mlibtool[39m[0m
+2025-10-09T20:05:25.5749020Z [34m==>[0m [1mDownloading https://ghcr.io/v2/homebrew/core/libtool/blobs/sha256:f21ea809c3bdc0aa1b25dce05dc05bebd228adb213957df244bf00af760392ef[0m
+2025-10-09T20:05:26.0626800Z [34m==>[0m [1mPouring libestr--0.1.11.arm64_sequoia.bottle.tar.gz[0m
+2025-10-09T20:05:26.3154620Z 🍺  /opt/homebrew/Cellar/libestr/0.1.11: 13 files, 124.1KB
+2025-10-09T20:05:26.3171980Z [34m==>[0m [1mPouring libfastjson--1.2304.0.arm64_sequoia.bottle.tar.gz[0m
+2025-10-09T20:05:26.4493050Z 🍺  /opt/homebrew/Cellar/libfastjson/1.2304.0: 18 files, 231.2KB
+2025-10-09T20:05:26.4902480Z [34m==>[0m [1mPouring docutils--0.22.2.all.bottle.tar.gz[0m
+2025-10-09T20:05:26.6799430Z 🍺  /opt/homebrew/Cellar/docutils/0.22.2: 246 files, 2.3MB
+2025-10-09T20:05:26.6841870Z [32m==>[0m [1mInstalling autoconf dependency: [32mm4[39m[0m
+2025-10-09T20:05:26.6844570Z [34m==>[0m [1mDownloading https://ghcr.io/v2/homebrew/core/m4/manifests/1.4.20[0m
+2025-10-09T20:05:26.6847070Z Already downloaded: /Users/runner/Library/Caches/Homebrew/downloads/6daeb2039950dd6932facf910fa817e9572e091a75508870ed06c1711c450a43--m4-1.4.20.bottle_manifest.json
+2025-10-09T20:05:26.6855870Z [34m==>[0m [1mPouring m4--1.4.20.arm64_sequoia.bottle.tar.gz[0m
+2025-10-09T20:05:26.7501800Z 🍺  /opt/homebrew/Cellar/m4/1.4.20: 14 files, 783.8KB
+2025-10-09T20:05:26.7507730Z [34m==>[0m [1mPouring autoconf--2.72.arm64_sequoia.bottle.1.tar.gz[0m
+2025-10-09T20:05:26.9398710Z 🍺  /opt/homebrew/Cellar/autoconf/2.72: 72 files, 3.6MB
+2025-10-09T20:05:26.9512070Z [34m==>[0m [1mPouring automake--1.18.1.arm64_sequoia.bottle.tar.gz[0m
+2025-10-09T20:05:27.1927610Z 🍺  /opt/homebrew/Cellar/automake/1.18.1: 134 files, 3.4MB
+2025-10-09T20:05:27.1970450Z [34m==>[0m [1mPouring libtool--2.5.4.arm64_sequoia.bottle.tar.gz[0m
+2025-10-09T20:05:27.4088720Z [34m==>[0m [1mCaveats[0m
+2025-10-09T20:05:27.4090430Z All commands have been installed with the prefix "g".
+2025-10-09T20:05:27.4091050Z If you need to use these commands with their normal names, you
+2025-10-09T20:05:27.4091670Z can add a "gnubin" directory to your PATH from your bashrc like:
+2025-10-09T20:05:27.4097160Z   PATH="/opt/homebrew/opt/libtool/libexec/gnubin:$PATH"
+2025-10-09T20:05:27.4097660Z [34m==>[0m [1mSummary[0m
+2025-10-09T20:05:27.4099730Z 🍺  /opt/homebrew/Cellar/libtool/2.5.4: 76 files, 4.0MB
+2025-10-09T20:05:27.4103930Z [34m==>[0m [1mNo outdated dependents to upgrade![0m
+2025-10-09T20:05:27.4104350Z [32m==>[0m [1mCaveats[0m
+2025-10-09T20:05:27.4104810Z [34m==>[0m [1mlibtool[0m
+2025-10-09T20:05:27.4108670Z All commands have been installed with the prefix "g".
+2025-10-09T20:05:27.4109140Z If you need to use these commands with their normal names, you
+2025-10-09T20:05:27.4111800Z can add a "gnubin" directory to your PATH from your bashrc like:
+2025-10-09T20:05:27.4112290Z   PATH="/opt/homebrew/opt/libtool/libexec/gnubin:$PATH"
+2025-10-09T20:05:27.5181320Z ##[group]Run df -h
+2025-10-09T20:05:27.5183850Z [36;1mdf -h[0m
+2025-10-09T20:05:27.5184250Z [36;1mecho "Available disk space before build:"[0m
+2025-10-09T20:05:27.5185160Z [36;1mdf -h . | tail -1 | awk '{print "Free space: " $4 " (" $5 " used)"}'[0m
+2025-10-09T20:05:27.5571460Z shell: /bin/bash -e {0}
+2025-10-09T20:05:27.5572140Z env:
+2025-10-09T20:05:27.5572420Z   USE_AUTO_DEBUG: true
+2025-10-09T20:05:27.5572640Z   ABORT_ALL_ON_TEST_FAIL: true
+2025-10-09T20:05:27.5572880Z ##[endgroup]
+2025-10-09T20:05:27.6163170Z Filesystem        Size    Used   Avail Capacity iused ifree %iused  Mounted on
+2025-10-09T20:05:27.6164400Z /dev/disk3s1s1   325Gi    10Gi    87Gi    11%    426k  910M    0%   /
+2025-10-09T20:05:27.6165480Z devfs            198Ki   198Ki     0Bi   100%     684     0  100%   /dev
+2025-10-09T20:05:27.6166670Z /dev/disk3s6     325Gi    20Ki    87Gi     1%       0  910M    0%   /System/Volumes/VM
+2025-10-09T20:05:27.6168090Z /dev/disk3s2     325Gi   5.6Gi    87Gi     7%     136  910M    0%   /System/Volumes/Preboot
+2025-10-09T20:05:27.6175080Z /dev/disk3s4     325Gi   260Ki    87Gi     1%      20  910M    0%   /System/Volumes/Update
+2025-10-09T20:05:27.6176240Z /dev/disk1s2     500Mi    20Ki   495Mi     1%       0  5.1M    0%   /System/Volumes/xarts
+2025-10-09T20:05:27.6211640Z /dev/disk1s1     500Mi    96Ki   495Mi     1%      20  5.1M    0%   /System/Volumes/iSCPreboot
+2025-10-09T20:05:27.6213610Z /dev/disk1s3     500Mi   216Ki   495Mi     1%      17  5.1M    0%   /System/Volumes/Hardware
+2025-10-09T20:05:27.6242930Z /dev/disk3s5     325Gi   220Gi    87Gi    72%    1.9M  910M    0%   /System/Volumes/Data
+2025-10-09T20:05:27.6243800Z /dev/disk5s1     4.0Mi   676Ki   3.0Mi    19%      18   31k    0%   /System/Library/AssetsV2/com_apple_MobileAsset_PKITrustStore/purpose_auto/6dd55b0d06633a00de6f57ccb910a66a5ba2409a.asset/.AssetData
+2025-10-09T20:05:27.6279870Z map auto_home      0Bi     0Bi     0Bi   100%       0     0     -   /System/Volumes/Data/home
+2025-10-09T20:05:27.6280640Z Available disk space before build:
+2025-10-09T20:05:27.6285940Z Free space: 87Gi (72% used)
+2025-10-09T20:05:27.6525280Z ##[group]Run actions/checkout@v4
+2025-10-09T20:05:27.6525710Z with:
+2025-10-09T20:05:27.6525930Z   repository: alorbach/rsyslog
+2025-10-09T20:05:27.6526420Z   token: ***
+2025-10-09T20:05:27.6526640Z   ssh-strict: true
+2025-10-09T20:05:27.6526920Z   ssh-user: git
+2025-10-09T20:05:27.6527130Z   persist-credentials: true
+2025-10-09T20:05:27.6527390Z   clean: true
+2025-10-09T20:05:27.6527550Z   sparse-checkout-cone-mode: true
+2025-10-09T20:05:27.6527720Z   fetch-depth: 1
+2025-10-09T20:05:27.6527860Z   fetch-tags: false
+2025-10-09T20:05:27.6528040Z   show-progress: true
+2025-10-09T20:05:27.6528170Z   lfs: false
+2025-10-09T20:05:27.6528300Z   submodules: false
+2025-10-09T20:05:27.6528450Z   set-safe-directory: true
+2025-10-09T20:05:27.6528610Z env:
+2025-10-09T20:05:27.6528970Z   USE_AUTO_DEBUG: true
+2025-10-09T20:05:27.6529130Z   ABORT_ALL_ON_TEST_FAIL: true
+2025-10-09T20:05:27.6529310Z ##[endgroup]
+2025-10-09T20:05:28.0827410Z Syncing repository: alorbach/rsyslog
+2025-10-09T20:05:28.0828810Z ##[group]Getting Git version info
+2025-10-09T20:05:28.0829080Z Working directory is '/Users/runner/work/rsyslog/rsyslog'
+2025-10-09T20:05:28.0830020Z [command]/opt/homebrew/bin/git version
+2025-10-09T20:05:28.0912770Z git version 2.50.1
+2025-10-09T20:05:28.0948610Z ##[endgroup]
+2025-10-09T20:05:28.0962790Z Copying '/Users/runner/.gitconfig' to '/Users/runner/work/_temp/f296b5ad-cef0-4ceb-9ee1-7eec70481f05/.gitconfig'
+2025-10-09T20:05:28.0970470Z Temporarily overriding HOME='/Users/runner/work/_temp/f296b5ad-cef0-4ceb-9ee1-7eec70481f05' before making global git config changes
+2025-10-09T20:05:28.0972540Z Adding repository directory to the temporary git global config as a safe directory
+2025-10-09T20:05:28.0974260Z [command]/opt/homebrew/bin/git config --global --add safe.directory /Users/runner/work/rsyslog/rsyslog
+2025-10-09T20:05:28.1107830Z Deleting the contents of '/Users/runner/work/rsyslog/rsyslog'
+2025-10-09T20:05:28.1114550Z ##[group]Initializing the repository
+2025-10-09T20:05:28.1123980Z [command]/opt/homebrew/bin/git init /Users/runner/work/rsyslog/rsyslog
+2025-10-09T20:05:28.1344400Z hint: Using 'master' as the name for the initial branch. This default branch name
+2025-10-09T20:05:28.1346620Z hint: is subject to change. To configure the initial branch name to use in all
+2025-10-09T20:05:28.1347120Z hint: of your new repositories, which will suppress this warning, call:
+2025-10-09T20:05:28.1347420Z hint:
+2025-10-09T20:05:28.1347670Z hint: 	git config --global init.defaultBranch <name>
+2025-10-09T20:05:28.1347950Z hint:
+2025-10-09T20:05:28.1348210Z hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
+2025-10-09T20:05:28.1348710Z hint: 'development'. The just-created branch can be renamed via this command:
+2025-10-09T20:05:28.1349000Z hint:
+2025-10-09T20:05:28.1349160Z hint: 	git branch -m <name>
+2025-10-09T20:05:28.1349370Z hint:
+2025-10-09T20:05:28.1351490Z hint: Disable this message with "git config set advice.defaultBranchName false"
+2025-10-09T20:05:28.1352190Z Initialized empty Git repository in /Users/runner/work/rsyslog/rsyslog/.git/
+2025-10-09T20:05:28.1370100Z [command]/opt/homebrew/bin/git remote add origin https://github.com/alorbach/rsyslog
+2025-10-09T20:05:28.1475500Z ##[endgroup]
+2025-10-09T20:05:28.1573580Z ##[group]Disabling automatic garbage collection
+2025-10-09T20:05:28.1574500Z [command]/opt/homebrew/bin/git config --local gc.auto 0
+2025-10-09T20:05:28.1631850Z ##[endgroup]
+2025-10-09T20:05:28.1632200Z ##[group]Setting up auth
+2025-10-09T20:05:28.1633370Z [command]/opt/homebrew/bin/git config --local --name-only --get-regexp core\.sshCommand
+2025-10-09T20:05:28.1713440Z [command]/opt/homebrew/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+2025-10-09T20:05:28.3057230Z [command]/opt/homebrew/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+2025-10-09T20:05:28.3132050Z [command]/opt/homebrew/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+2025-10-09T20:05:28.4381900Z [command]/opt/homebrew/bin/git config --local http.https://github.com/.extraheader AUTHORIZATION: basic ***
+2025-10-09T20:05:28.4392900Z ##[endgroup]
+2025-10-09T20:05:28.4393250Z ##[group]Fetching the repository
+2025-10-09T20:05:28.4394230Z [command]/opt/homebrew/bin/git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +eb72b35a82e428df7b83cbfcaf3c7d1b7130ca4f:refs/remotes/pull/55/merge
+2025-10-09T20:05:30.5929540Z From https://github.com/alorbach/rsyslog
+2025-10-09T20:05:30.5931700Z  * [new ref]         eb72b35a82e428df7b83cbfcaf3c7d1b7130ca4f -> pull/55/merge
+2025-10-09T20:05:30.6021640Z ##[endgroup]
+2025-10-09T20:05:30.6022210Z ##[group]Determining the checkout info
+2025-10-09T20:05:30.6025730Z ##[endgroup]
+2025-10-09T20:05:30.6025980Z [command]/opt/homebrew/bin/git sparse-checkout disable
+2025-10-09T20:05:30.6109340Z [command]/opt/homebrew/bin/git config --local --unset-all extensions.worktreeConfig
+2025-10-09T20:05:30.6178570Z ##[group]Checking out the ref
+2025-10-09T20:05:30.6180020Z [command]/opt/homebrew/bin/git checkout --progress --force refs/remotes/pull/55/merge
+2025-10-09T20:05:31.0567980Z HEAD is now at eb72b35 Merge 81530b7487c3051063b76afad2b447f54b0dcc31 into 2d19b082f28b991192428615cab73a10220c3cb3
+2025-10-09T20:05:31.0594130Z ##[endgroup]
+2025-10-09T20:05:31.0677590Z [command]/opt/homebrew/bin/git log -1 --format=%H
+2025-10-09T20:05:31.0763180Z eb72b35a82e428df7b83cbfcaf3c7d1b7130ca4f
+2025-10-09T20:05:31.0901930Z ##[group]Run # Set debugging flags for better stack traces on segfaults
+2025-10-09T20:05:31.0902320Z [36;1m# Set debugging flags for better stack traces on segfaults[0m
+2025-10-09T20:05:31.0902610Z [36;1mBASE_CFLAGS="-g -O1 -fno-omit-frame-pointer"[0m
+2025-10-09T20:05:31.0902820Z [36;1mBASE_LDFLAGS="-g"[0m
+2025-10-09T20:05:31.0902950Z [36;1m[0m
+2025-10-09T20:05:31.0903070Z [36;1mif [ "tsan" = "asan" ]; then[0m
+2025-10-09T20:05:31.0903290Z [36;1m  # AddressSanitizer for memory error detection[0m
+2025-10-09T20:05:31.0903560Z [36;1m  export CFLAGS="$BASE_CFLAGS -fsanitize=address \[0m
+2025-10-09T20:05:31.0903820Z [36;1m    -fsanitize-address-use-after-scope"[0m
+2025-10-09T20:05:31.0904080Z [36;1m  export LDFLAGS="$BASE_LDFLAGS -fsanitize=address"[0m
+2025-10-09T20:05:31.0904360Z [36;1m  echo "Building with AddressSanitizer"[0m
+2025-10-09T20:05:31.0904580Z [36;1melif [ "tsan" = "tsan" ]; then[0m
+2025-10-09T20:05:31.0904870Z [36;1m  # ThreadSanitizer for threading error detection[0m
+2025-10-09T20:05:31.0905140Z [36;1m  export CFLAGS="$BASE_CFLAGS -fsanitize=thread"[0m
+2025-10-09T20:05:31.0905420Z [36;1m  export LDFLAGS="$BASE_LDFLAGS -fsanitize=thread"[0m
+2025-10-09T20:05:31.0905660Z [36;1m  echo "Building with ThreadSanitizer"[0m
+2025-10-09T20:05:31.0905860Z [36;1melse[0m
+2025-10-09T20:05:31.0906020Z [36;1m  # No sanitizer (normal build)[0m
+2025-10-09T20:05:31.0906220Z [36;1m  export CFLAGS="$BASE_CFLAGS"[0m
+2025-10-09T20:05:31.0906430Z [36;1m  export LDFLAGS="$BASE_LDFLAGS"[0m
+2025-10-09T20:05:31.0906640Z [36;1m  echo "Building without sanitizers"[0m
+2025-10-09T20:05:31.0906850Z [36;1mfi[0m
+2025-10-09T20:05:31.0906970Z [36;1mautoreconf -fvi[0m
+2025-10-09T20:05:31.0907190Z [36;1m./configure --enable-silent-rules --enable-testbench \[0m
+2025-10-09T20:05:31.0907510Z [36;1m   --enable-imdiag --disable-imdocker --disable-imfile \[0m
+2025-10-09T20:05:31.0907830Z [36;1m   --disable-default-tests --disable-impstats --disable-imptcp \[0m
+2025-10-09T20:05:31.0908190Z [36;1m   --disable-mmanon --disable-mmaudit --disable-mmfields \[0m
+2025-10-09T20:05:31.0908490Z [36;1m   --disable-mmjsonparse --disable-mmpstrucdata \[0m
+2025-10-09T20:05:31.0908800Z [36;1m   --disable-mmsequence --disable-mmutf8fix --disable-mail \[0m
+2025-10-09T20:05:31.0909110Z [36;1m   --disable-omprog --disable-improg --disable-omruleset \[0m
+2025-10-09T20:05:31.0909400Z [36;1m   --enable-omstdout --disable-omuxsock \[0m
+2025-10-09T20:05:31.0909690Z [36;1m   --disable-pmaixforwardedfrom --disable-pmciscoios \[0m
+2025-10-09T20:05:31.0910020Z [36;1m   --disable-pmcisconames --disable-pmlastmsg --disable-pmsnare \[0m
+2025-10-09T20:05:31.0910330Z [36;1m   --disable-libgcrypt --disable-mmnormalize \[0m
+2025-10-09T20:05:31.0910620Z [36;1m   --disable-omudpspoof --disable-relp --disable-mmsnmptrapd \[0m
+2025-10-09T20:05:31.0910950Z [36;1m   --enable-gnutls --enable-usertools --disable-mysql \[0m
+2025-10-09T20:05:31.0911270Z [36;1m   --disable-valgrind --disable-mmkubernetes --disable-omkafka \[0m
+2025-10-09T20:05:31.0911610Z [36;1m   --disable-imkafka --disable-ommongodb --disable-omrabbitmq \[0m
+2025-10-09T20:05:31.0911940Z [36;1m   --disable-mmdarwin --enable-compile-warnings=error \[0m
+2025-10-09T20:05:31.0912230Z [36;1m   --disable-helgrind --disable-uuid --disable-fmhttp[0m
+2025-10-09T20:05:31.0953450Z shell: /bin/bash -e {0}
+2025-10-09T20:05:31.0953610Z env:
+2025-10-09T20:05:31.0953760Z   USE_AUTO_DEBUG: true
+2025-10-09T20:05:31.0954210Z   ABORT_ALL_ON_TEST_FAIL: true
+2025-10-09T20:05:31.0954380Z ##[endgroup]
+2025-10-09T20:05:31.1325670Z Building with ThreadSanitizer
+2025-10-09T20:05:31.2374270Z autoreconf: export WARNINGS=
+2025-10-09T20:05:31.2410500Z autoreconf: Entering directory '.'
+2025-10-09T20:05:31.2435360Z autoreconf: configure.ac: not using Gettext
+2025-10-09T20:05:32.3192390Z autoreconf: running: aclocal --force -I m4
+2025-10-09T20:05:33.5543550Z autoreconf: configure.ac: tracing
+2025-10-09T20:05:34.1851510Z autoreconf: running: glibtoolize --copy --force
+2025-10-09T20:05:36.2425990Z glibtoolize: putting auxiliary files in '.'.
+2025-10-09T20:05:36.2428900Z glibtoolize: copying file './ltmain.sh'
+2025-10-09T20:05:36.3397740Z glibtoolize: putting macros in AC_CONFIG_MACRO_DIRS, 'm4'.
+2025-10-09T20:05:36.3398220Z glibtoolize: copying file 'm4/libtool.m4'
+2025-10-09T20:05:36.3640570Z glibtoolize: copying file 'm4/ltoptions.m4'
+2025-10-09T20:05:36.3929710Z glibtoolize: copying file 'm4/ltsugar.m4'
+2025-10-09T20:05:36.4211490Z glibtoolize: copying file 'm4/ltversion.m4'
+2025-10-09T20:05:36.4415620Z glibtoolize: copying file 'm4/lt~obsolete.m4'
+2025-10-09T20:05:36.4891620Z autoreconf: configure.ac: not using Intltool
+2025-10-09T20:05:36.4891940Z autoreconf: configure.ac: not using Gtkdoc
+2025-10-09T20:05:36.4892190Z autoreconf: running: aclocal --force -I m4
+2025-10-09T20:05:37.6055620Z autoreconf: running: /opt/homebrew/Cellar/autoconf/2.72/bin/autoconf --force
+2025-10-09T20:05:38.0857880Z configure.ac:42: warning: AC_PROG_LEX without either yywrap or noyywrap is obsolete
+2025-10-09T20:05:38.0858370Z ./lib/autoconf/programs.m4:743: _AC_PROG_LEX is expanded from...
+2025-10-09T20:05:38.0858700Z ./lib/autoconf/programs.m4:736: AC_PROG_LEX is expanded from...
+2025-10-09T20:05:38.0858970Z configure.ac:42: the top level
+2025-10-09T20:05:38.0859210Z configure.ac:45: warning: The macro 'AC_PROG_CC_C99' is obsolete.
+2025-10-09T20:05:38.0859560Z configure.ac:45: You should run autoupdate.
+2025-10-09T20:05:38.0859950Z ./lib/autoconf/c.m4:1662: AC_PROG_CC_C99 is expanded from...
+2025-10-09T20:05:38.0860380Z configure.ac:45: the top level
+2025-10-09T20:05:38.0860690Z configure.ac:49: warning: The macro 'AC_LIBTOOL_DLOPEN' is obsolete.
+2025-10-09T20:05:38.0861030Z configure.ac:49: You should run autoupdate.
+2025-10-09T20:05:38.0861350Z m4/ltoptions.m4:113: AC_LIBTOOL_DLOPEN is expanded from...
+2025-10-09T20:05:38.0861740Z configure.ac:49: the top level
+2025-10-09T20:05:38.0862130Z configure.ac:49: warning: AC_LIBTOOL_DLOPEN: Remove this warning and the call to _LT_SET_OPTION when you
+2025-10-09T20:05:38.0862620Z configure.ac:49: put the 'dlopen' option into LT_INIT's first parameter.
+2025-10-09T20:05:38.0862970Z ./lib/autoconf/general.m4:2434: AC_DIAGNOSE is expanded from...
+2025-10-09T20:05:38.0863350Z m4/ltoptions.m4:113: AC_LIBTOOL_DLOPEN is expanded from...
+2025-10-09T20:05:38.0863630Z configure.ac:49: the top level
+2025-10-09T20:05:38.0863860Z configure.ac:52: warning: The macro 'AC_PROG_LIBTOOL' is obsolete.
+2025-10-09T20:05:38.0864170Z configure.ac:52: You should run autoupdate.
+2025-10-09T20:05:38.0864480Z m4/libtool.m4:100: AC_PROG_LIBTOOL is expanded from...
+2025-10-09T20:05:38.0864720Z configure.ac:52: the top level
+2025-10-09T20:05:38.0864940Z configure.ac:183: warning: The macro 'AC_HEADER_STDC' is obsolete.
+2025-10-09T20:05:38.0865220Z configure.ac:183: You should run autoupdate.
+2025-10-09T20:05:38.0865480Z ./lib/autoconf/headers.m4:663: AC_HEADER_STDC is expanded from...
+2025-10-09T20:05:38.0865720Z configure.ac:183: the top level
+2025-10-09T20:05:38.0866030Z configure.ac:215: warning: The macro 'AC_HEADER_TIME' is obsolete.
+2025-10-09T20:05:38.0866290Z configure.ac:215: You should run autoupdate.
+2025-10-09T20:05:38.0866540Z ./lib/autoconf/headers.m4:702: AC_HEADER_TIME is expanded from...
+2025-10-09T20:05:38.0866790Z configure.ac:215: the top level
+2025-10-09T20:05:38.0867050Z configure.ac:230: warning: The macro 'AC_PROG_GCC_TRADITIONAL' is obsolete.
+2025-10-09T20:05:38.0867330Z configure.ac:230: You should run autoupdate.
+2025-10-09T20:05:38.0868370Z ./lib/autoconf/c.m4:1676: AC_PROG_GCC_TRADITIONAL is expanded from...
+2025-10-09T20:05:38.0868810Z configure.ac:230: the top level
+2025-10-09T20:05:38.0869110Z configure.ac:232: warning: The macro 'AC_TYPE_SIGNAL' is obsolete.
+2025-10-09T20:05:38.0869480Z configure.ac:232: You should run autoupdate.
+2025-10-09T20:05:38.0869740Z ./lib/autoconf/types.m4:805: AC_TYPE_SIGNAL is expanded from...
+2025-10-09T20:05:38.0870020Z configure.ac:232: the top level
+2025-10-09T20:05:38.0870530Z configure.ac:259: warning: The macro 'AC_TRY_COMPILE' is obsolete.
+2025-10-09T20:05:38.0870820Z configure.ac:259: You should run autoupdate.
+2025-10-09T20:05:38.0871080Z ./lib/autoconf/general.m4:2845: AC_TRY_COMPILE is expanded from...
+2025-10-09T20:05:38.0871340Z configure.ac:259: the top level
+2025-10-09T20:05:38.0871570Z configure.ac:302: warning: The macro 'AC_TRY_RUN' is obsolete.
+2025-10-09T20:05:38.0871830Z configure.ac:302: You should run autoupdate.
+2025-10-09T20:05:38.0872090Z ./lib/autoconf/general.m4:2995: AC_TRY_RUN is expanded from...
+2025-10-09T20:05:38.0872370Z lib/m4sugar/m4sh.m4:690: _AS_IF_ELSE is expanded from...
+2025-10-09T20:05:38.0872620Z lib/m4sugar/m4sh.m4:697: AS_IF is expanded from...
+2025-10-09T20:05:38.0872900Z ./lib/autoconf/general.m4:2249: AC_CACHE_VAL is expanded from...
+2025-10-09T20:05:38.0873210Z ./lib/autoconf/general.m4:2270: AC_CACHE_CHECK is expanded from...
+2025-10-09T20:05:38.0873520Z m4/atomic_operations.m4:10: RS_ATOMIC_OPERATIONS is expanded from...
+2025-10-09T20:05:38.0873780Z configure.ac:302: the top level
+2025-10-09T20:05:38.0874010Z configure.ac:303: warning: The macro 'AC_TRY_RUN' is obsolete.
+2025-10-09T20:05:38.0874260Z configure.ac:303: You should run autoupdate.
+2025-10-09T20:05:38.0874510Z ./lib/autoconf/general.m4:2995: AC_TRY_RUN is expanded from...
+2025-10-09T20:05:38.0874790Z lib/m4sugar/m4sh.m4:690: _AS_IF_ELSE is expanded from...
+2025-10-09T20:05:38.0875050Z lib/m4sugar/m4sh.m4:697: AS_IF is expanded from...
+2025-10-09T20:05:38.0875310Z ./lib/autoconf/general.m4:2249: AC_CACHE_VAL is expanded from...
+2025-10-09T20:05:38.0875620Z ./lib/autoconf/general.m4:2270: AC_CACHE_CHECK is expanded from...
+2025-10-09T20:05:38.0875970Z m4/atomic_operations_64bit.m4:10: RS_ATOMIC_OPERATIONS_64BIT is expanded from...
+2025-10-09T20:05:38.0876240Z configure.ac:303: the top level
+2025-10-09T20:05:38.0876480Z configure.ac:877: warning: The macro 'AC_TRY_LINK' is obsolete.
+2025-10-09T20:05:38.0876740Z configure.ac:877: You should run autoupdate.
+2025-10-09T20:05:38.0877020Z ./lib/autoconf/general.m4:2918: AC_TRY_LINK is expanded from...
+2025-10-09T20:05:38.0877280Z lib/m4sugar/m4sh.m4:697: AS_IF is expanded from...
+2025-10-09T20:05:38.0877490Z configure.ac:877: the top level
+2025-10-09T20:05:38.0877750Z configure.ac:1497: warning: The macro 'AC_TRY_COMPILE' is obsolete.
+2025-10-09T20:05:38.0878030Z configure.ac:1497: You should run autoupdate.
+2025-10-09T20:05:38.0878550Z ./lib/autoconf/general.m4:2845: AC_TRY_COMPILE is expanded from...
+2025-10-09T20:05:38.0878890Z m4/ac_check_define.m4:15: AX_CHECK_DEFINED is expanded from...
+2025-10-09T20:05:38.0879130Z configure.ac:1497: the top level
+2025-10-09T20:05:38.0879370Z configure.ac:2002: warning: The macro 'AC_TRY_COMPILE' is obsolete.
+2025-10-09T20:05:38.0879640Z configure.ac:2002: You should run autoupdate.
+2025-10-09T20:05:38.0879910Z ./lib/autoconf/general.m4:2845: AC_TRY_COMPILE is expanded from...
+2025-10-09T20:05:38.0880160Z configure.ac:2002: the top level
+2025-10-09T20:05:38.3100280Z autoreconf: running: /opt/homebrew/Cellar/autoconf/2.72/bin/autoheader --force
+2025-10-09T20:05:38.8736770Z autoreconf: running: automake --add-missing --copy --force-missing
+2025-10-09T20:05:39.1820060Z configure.ac:39: installing './compile'
+2025-10-09T20:05:39.1873410Z configure.ac:52: installing './config.guess'
+2025-10-09T20:05:39.1925060Z configure.ac:52: installing './config.sub'
+2025-10-09T20:05:39.1975610Z configure.ac:9: installing './install-sh'
+2025-10-09T20:05:39.2025690Z configure.ac:9: installing './missing'
+2025-10-09T20:05:39.2354090Z Makefile.am: installing './INSTALL'
+2025-10-09T20:05:39.2837170Z compat/Makefile.am: installing './depcomp'
+2025-10-09T20:05:40.3015610Z configure.ac: installing './ylwrap'
+2025-10-09T20:05:42.2037270Z tests/Makefile.am:83: warning: es-basic-server.log was already defined in condition ENABLE_ELASTICSEARCH_TESTS_MINIMAL and ENABLE_TESTBENCH, which includes condition ENABLE_ELASTICSEARCH_TESTS_MINIMAL and ENABLE_TESTBENCH and HAVE_VALGRIND ...
+2025-10-09T20:05:42.2041100Z tests/Makefile.am:70: ... 'es-basic-server.log' previously defined here
+2025-10-09T20:05:42.2043330Z tests/Makefile.am:84: warning: elasticsearch-stop.log was already defined in condition ENABLE_ELASTICSEARCH_TESTS_MINIMAL and ENABLE_TESTBENCH, which includes condition ENABLE_ELASTICSEARCH_TESTS_MINIMAL and ENABLE_TESTBENCH and HAVE_VALGRIND ...
+2025-10-09T20:05:42.2045420Z tests/Makefile.am:74: ... 'elasticsearch-stop.log' previously defined here
+2025-10-09T20:05:42.2058670Z tests/Makefile.am:90: warning: es-basic-server.log was already defined in condition ENABLE_ELASTICSEARCH_TESTS_MINIMAL and ENABLE_TESTBENCH, which includes condition ENABLE_ELASTICSEARCH_TESTS_MINIMAL and ENABLE_HELGRIND and ENABLE_TESTBENCH and HAVE_VALGRIND ...
+2025-10-09T20:05:42.2060930Z tests/Makefile.am:70: ... 'es-basic-server.log' previously defined here
+2025-10-09T20:05:42.2063220Z tests/Makefile.am:91: warning: elasticsearch-stop.log was already defined in condition ENABLE_ELASTICSEARCH_TESTS_MINIMAL and ENABLE_TESTBENCH, which includes condition ENABLE_ELASTICSEARCH_TESTS_MINIMAL and ENABLE_HELGRIND and ENABLE_TESTBENCH and HAVE_VALGRIND ...
+2025-10-09T20:05:42.2065440Z tests/Makefile.am:74: ... 'elasticsearch-stop.log' previously defined here
+2025-10-09T20:05:42.2067610Z tests/Makefile.am:126: warning: elasticsearch-stop.log was already defined in condition ENABLE_ELASTICSEARCH_TESTS and ENABLE_TESTBENCH, which includes condition ENABLE_ELASTICSEARCH_TESTS and ENABLE_IMPSTATS and ENABLE_TESTBENCH ...
+2025-10-09T20:05:42.2069950Z tests/Makefile.am:117: ... 'elasticsearch-stop.log' previously defined here
+2025-10-09T20:05:42.2071980Z tests/Makefile.am:139: warning: elasticsearch-stop.log was already defined in condition ENABLE_ELASTICSEARCH_TESTS and ENABLE_TESTBENCH, which includes condition ENABLE_ELASTICSEARCH_TESTS and ENABLE_IMFILE and ENABLE_TESTBENCH ...
+2025-10-09T20:05:42.2074050Z tests/Makefile.am:117: ... 'elasticsearch-stop.log' previously defined here
+2025-10-09T20:05:42.2076180Z tests/Makefile.am:150: warning: elasticsearch-stop.log was already defined in condition ENABLE_ELASTICSEARCH_TESTS and ENABLE_TESTBENCH, which includes condition ENABLE_ELASTICSEARCH_TESTS and ENABLE_TESTBENCH and HAVE_VALGRIND ...
+2025-10-09T20:05:42.2078190Z tests/Makefile.am:117: ... 'elasticsearch-stop.log' previously defined here
+2025-10-09T20:05:42.2080200Z tests/Makefile.am:776: warning: clickhouse-stop.log was already defined in condition ENABLE_CLICKHOUSE_TESTS and ENABLE_TESTBENCH, which includes condition ENABLE_CLICKHOUSE_TESTS and ENABLE_TESTBENCH and HAVE_VALGRIND ...
+2025-10-09T20:05:42.2082110Z tests/Makefile.am:763: ... 'clickhouse-stop.log' previously defined here
+2025-10-09T20:05:42.2083900Z tests/Makefile.am:880: warning: mysqld-stop.log was already defined in condition ENABLE_MYSQL_TESTS and ENABLE_TESTBENCH, which includes condition ENABLE_MYSQL_TESTS and ENABLE_TESTBENCH and HAVE_VALGRIND ...
+2025-10-09T20:05:42.2085650Z tests/Makefile.am:863: ... 'mysqld-stop.log' previously defined here
+2025-10-09T20:05:42.2087490Z tests/Makefile.am:891: warning: mysqld-stop.log was already defined in condition ENABLE_MYSQL_TESTS and ENABLE_TESTBENCH, which includes condition ENABLE_MYSQL_TESTS and ENABLE_OMLIBDBI and ENABLE_TESTBENCH ...
+2025-10-09T20:05:42.2089420Z tests/Makefile.am:863: ... 'mysqld-stop.log' previously defined here
+2025-10-09T20:05:42.2091330Z tests/Makefile.am:897: warning: mysqld-stop.log was already defined in condition ENABLE_MYSQL_TESTS and ENABLE_TESTBENCH, which includes condition ENABLE_MYSQL_TESTS and ENABLE_OMLIBDBI and ENABLE_TESTBENCH and HAVE_VALGRIND ...
+2025-10-09T20:05:42.2094450Z tests/Makefile.am:863: ... 'mysqld-stop.log' previously defined here
+2025-10-09T20:05:42.2501190Z parallel-tests: installing './test-driver'
+2025-10-09T20:05:42.3441920Z autoreconf: Leaving directory '.'
+2025-10-09T20:05:42.7896030Z configure: WARNING: unrecognized options: --enable-compile-warnings
+2025-10-09T20:05:42.8705920Z checking for a BSD-compatible install... /usr/bin/install -c
+2025-10-09T20:05:42.8810480Z checking whether sleep supports fractional seconds... yes
+2025-10-09T20:05:44.2853710Z checking filesystem timestamp resolution... 2
+2025-10-09T20:05:44.2929160Z checking whether build environment is sane... yes
+2025-10-09T20:05:44.3101210Z checking for a race-free mkdir -p... mkdir -p
+2025-10-09T20:05:44.3106980Z checking for gawk... no
+2025-10-09T20:05:44.3109620Z checking for mawk... no
+2025-10-09T20:05:44.3117170Z checking for nawk... no
+2025-10-09T20:05:44.3125050Z checking for awk... awk
+2025-10-09T20:05:44.3348340Z checking whether make sets $(MAKE)... yes
+2025-10-09T20:05:44.3563430Z checking whether make supports nested variables... yes
+2025-10-09T20:05:44.3762890Z checking xargs -n works... yes
+2025-10-09T20:05:44.4161060Z checking how to create a pax tar archive... gnutar
+2025-10-09T20:05:44.4510840Z checking whether make supports the include directive... yes (GNU style)
+2025-10-09T20:05:44.4515830Z checking for gcc... gcc
+2025-10-09T20:05:45.7591590Z checking whether the C compiler works... yes
+2025-10-09T20:05:45.7592740Z checking for C compiler default output file name... a.out
+2025-10-09T20:05:45.8579730Z checking for suffix of executables... 
+2025-10-09T20:05:48.1681400Z checking whether we are cross compiling... no
+2025-10-09T20:05:48.2639930Z checking for suffix of object files... o
+2025-10-09T20:05:48.3055410Z checking whether the compiler supports GNU C... yes
+2025-10-09T20:05:48.3518710Z checking whether gcc accepts -g... yes
+2025-10-09T20:05:48.4908820Z checking for gcc option to enable C11 features... none needed
+2025-10-09T20:05:48.5850390Z checking whether gcc understands -c and -o together... yes
+2025-10-09T20:05:48.7446380Z checking dependency style of gcc... gcc3
+2025-10-09T20:05:48.8072270Z checking for stdio.h... yes
+2025-10-09T20:05:48.8796500Z checking for stdlib.h... yes
+2025-10-09T20:05:48.9298760Z checking for string.h... yes
+2025-10-09T20:05:49.0077020Z checking for inttypes.h... yes
+2025-10-09T20:05:49.0604080Z checking for stdint.h... yes
+2025-10-09T20:05:49.1084930Z checking for strings.h... yes
+2025-10-09T20:05:49.1618880Z checking for sys/stat.h... yes
+2025-10-09T20:05:49.2260730Z checking for sys/types.h... yes
+2025-10-09T20:05:49.2852470Z checking for unistd.h... yes
+2025-10-09T20:05:49.3456410Z checking for wchar.h... yes
+2025-10-09T20:05:49.3934920Z checking for minix/config.h... no
+2025-10-09T20:05:49.4568120Z checking for sys/time.h... yes
+2025-10-09T20:05:49.5250590Z checking for vfork.h... no
+2025-10-09T20:05:49.5891070Z checking for sys/select.h... yes
+2025-10-09T20:05:49.6486530Z checking for sys/socket.h... yes
+2025-10-09T20:05:49.7068270Z checking whether it is safe to define __EXTENSIONS__... yes
+2025-10-09T20:05:49.7560990Z checking whether _XOPEN_SOURCE should be defined... no
+2025-10-09T20:05:49.7589550Z checking for flex... flex
+2025-10-09T20:05:50.2345750Z checking for lex output file root... lex.yy
+2025-10-09T20:05:50.4078800Z checking for lex library... none needed
+2025-10-09T20:05:50.6109010Z checking for library containing yywrap... -ll
+2025-10-09T20:05:50.7275740Z checking whether yytext is a pointer... yes
+2025-10-09T20:05:50.7306100Z checking for bison... bison -y
+2025-10-09T20:05:50.7308100Z checking for gcc... (cached) gcc
+2025-10-09T20:05:50.8795680Z checking whether the compiler supports GNU C... (cached) yes
+2025-10-09T20:05:50.8796860Z checking whether gcc accepts -g... (cached) yes
+2025-10-09T20:05:50.8797970Z checking for gcc option to enable C11 features... (cached) none needed
+2025-10-09T20:05:50.8799780Z checking whether gcc understands -c and -o together... (cached) yes
+2025-10-09T20:05:50.8801860Z checking dependency style of gcc... (cached) gcc3
+2025-10-09T20:05:50.9247510Z checking build system type... aarch64-apple-darwin24.6.0
+2025-10-09T20:05:50.9248070Z checking host system type... aarch64-apple-darwin24.6.0
+2025-10-09T20:05:50.9265130Z checking how to print strings... printf
+2025-10-09T20:05:51.0975710Z checking for a sed that does not truncate output... /usr/bin/sed
+2025-10-09T20:05:51.1042530Z checking for grep that handles long lines and -e... /usr/bin/grep
+2025-10-09T20:05:51.1072060Z checking for egrep... /usr/bin/grep -E
+2025-10-09T20:05:51.1106890Z checking for fgrep... /usr/bin/grep -F
+2025-10-09T20:05:51.1394410Z checking for ld used by gcc... /Applications/Xcode_16.4.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ld
+2025-10-09T20:05:51.1493720Z checking if the linker (/Applications/Xcode_16.4.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ld) is GNU ld... no
+2025-10-09T20:05:51.6923090Z checking for BSD- or MS-compatible name lister (nm)... /usr/bin/nm -B
+2025-10-09T20:05:51.7512840Z checking the name lister (/usr/bin/nm -B) interface... BSD nm
+2025-10-09T20:05:51.7513250Z checking whether ln -s works... yes
+2025-10-09T20:05:51.7576790Z checking the maximum length of command line arguments... 786432
+2025-10-09T20:05:51.7627170Z checking how to convert aarch64-apple-darwin24.6.0 file names to aarch64-apple-darwin24.6.0 format... func_convert_file_noop
+2025-10-09T20:05:51.7628040Z checking how to convert aarch64-apple-darwin24.6.0 file names to toolchain format... func_convert_file_noop
+2025-10-09T20:05:51.7628780Z checking for /Applications/Xcode_16.4.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ld option to reload object files... -r
+2025-10-09T20:05:51.7637940Z checking for file... file
+2025-10-09T20:05:51.7642140Z checking for objdump... objdump
+2025-10-09T20:05:51.7644970Z checking how to recognize dependent libraries... pass_all
+2025-10-09T20:05:51.7649840Z checking for dlltool... no
+2025-10-09T20:05:51.7650730Z checking how to associate runtime and link libraries... printf %s\n
+2025-10-09T20:05:51.7654760Z checking for ranlib... ranlib
+2025-10-09T20:05:51.7658820Z checking for ar... ar
+2025-10-09T20:05:52.2206850Z checking for archiver @FILE support... no
+2025-10-09T20:05:52.2213660Z checking for strip... strip
+2025-10-09T20:05:52.5175800Z checking command to parse /usr/bin/nm -B output from gcc object... ok
+2025-10-09T20:05:52.5270370Z checking for sysroot... no
+2025-10-09T20:05:52.5370770Z checking for a working dd... /bin/dd
+2025-10-09T20:05:52.5441790Z checking how to truncate binary pipes... /bin/dd bs=4096 count=1
+2025-10-09T20:05:52.5449530Z checking for mt... no
+2025-10-09T20:05:52.5505400Z checking if : is a manifest tool... no
+2025-10-09T20:05:52.5519170Z checking for dsymutil... dsymutil
+2025-10-09T20:05:52.5522580Z checking for nmedit... nmedit
+2025-10-09T20:05:52.5526070Z checking for lipo... lipo
+2025-10-09T20:05:52.5529450Z checking for otool... otool
+2025-10-09T20:05:52.5534220Z checking for otool64... no
+2025-10-09T20:05:52.6282780Z checking for -single_module linker flag... ld: warning: -single_module is obsolete
+2025-10-09T20:05:52.6366160Z no
+2025-10-09T20:05:52.7279580Z checking for -no_fixup_chains linker flag... yes
+2025-10-09T20:05:52.8021350Z checking for -exported_symbols_list linker flag... yes
+2025-10-09T20:05:53.3257200Z checking for -force_load linker flag... yes
+2025-10-09T20:05:53.3803660Z checking for dlfcn.h... yes
+2025-10-09T20:05:53.3861840Z checking for objdir... .libs
+2025-10-09T20:05:53.5263530Z checking if gcc supports -fno-rtti -fno-exceptions... yes
+2025-10-09T20:05:53.5264550Z checking for gcc option to produce PIC... -fno-common -DPIC
+2025-10-09T20:05:53.5730970Z checking if gcc PIC flag -fno-common -DPIC works... yes
+2025-10-09T20:05:53.6198270Z checking if gcc static flag -static works... no
+2025-10-09T20:05:53.6903470Z checking if gcc supports -c -o file.o... yes
+2025-10-09T20:05:53.6904360Z checking if gcc supports -c -o file.o... (cached) yes
+2025-10-09T20:05:53.6906900Z checking whether the gcc linker (/Applications/Xcode_16.4.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ld) supports shared libraries... yes
+2025-10-09T20:05:53.7492500Z checking dynamic linker characteristics... darwin24.6.0 dyld
+2025-10-09T20:05:53.7493360Z checking how to hardcode library paths into programs... immediate
+2025-10-09T20:05:54.1878540Z configure: WARNING: missing AX_IS_RELEASE macro, not using AX_COMPILER_FLAGS macro because of this
+2025-10-09T20:05:54.1880290Z checking whether stripping libraries is possible... yes
+2025-10-09T20:05:54.1881090Z checking if libtool supports shared libraries... yes
+2025-10-09T20:05:54.1881750Z checking whether to build shared libraries... yes
+2025-10-09T20:05:54.1882420Z checking whether to build static libraries... no
+2025-10-09T20:05:54.1883210Z checking for pkg-config... /opt/homebrew/bin/pkg-config
+2025-10-09T20:05:54.2091750Z checking pkg-config is at least version 0.9.0... yes
+2025-10-09T20:05:54.2325910Z checking for libestr >= 0.1.9... yes
+2025-10-09T20:05:54.2468290Z checking for libfastjson >= 0.99.8... yes
+2025-10-09T20:05:54.2486090Z ./configure: line 16656: lsb_release: command not found
+2025-10-09T20:05:54.2513870Z HOST: aarch64-apple-darwin24.6.0
+2025-10-09T20:05:54.2520680Z checking for python... /Library/Frameworks/Python.framework/Versions/Current/bin/python
+2025-10-09T20:05:54.3963220Z checking for python version... 3.13
+2025-10-09T20:05:54.4157570Z checking for python platform... darwin
+2025-10-09T20:05:54.4158490Z checking for GNU default python prefix... ${prefix}
+2025-10-09T20:05:54.4159280Z checking for GNU default python exec_prefix... ${exec_prefix}
+2025-10-09T20:05:54.4608300Z checking for python script directory (pythondir)... ${PYTHON_PREFIX}/lib/python3.13/site-packages
+2025-10-09T20:05:54.4949060Z checking for python extension module directory (pyexecdir)... ${PYTHON_EXEC_PREFIX}/lib/python3.13/site-packages
+2025-10-09T20:05:54.5512560Z checking for PATH_MAX... yes
+2025-10-09T20:05:54.6437450Z checking for library containing clock_gettime... none required
+2025-10-09T20:05:54.7870450Z checking for library containing mq_getattr... no
+2025-10-09T20:05:54.8838590Z checking for library containing dlopen... none required
+2025-10-09T20:05:54.8839770Z checking for sys/types.h... (cached) yes
+2025-10-09T20:05:54.9760240Z checking for netinet/in.h... yes
+2025-10-09T20:05:55.0773970Z checking for arpa/nameser.h... yes
+2025-10-09T20:05:55.1827870Z checking for netdb.h... yes
+2025-10-09T20:05:55.2630240Z checking for resolv.h... yes
+2025-10-09T20:05:55.2631760Z checking for egrep... (cached) /usr/bin/grep -E
+2025-10-09T20:05:55.3350410Z checking for sys/wait.h that is POSIX.1 compatible... yes
+2025-10-09T20:05:55.4245410Z checking for arpa/inet.h... yes
+2025-10-09T20:05:55.4621720Z checking for libgen.h... yes
+2025-10-09T20:05:55.5115800Z checking for malloc.h... no
+2025-10-09T20:05:55.6365700Z checking for fcntl.h... yes
+2025-10-09T20:05:55.6992360Z checking for locale.h... yes
+2025-10-09T20:05:55.6994090Z checking for netdb.h... (cached) yes
+2025-10-09T20:05:55.6995510Z checking for netinet/in.h... (cached) yes
+2025-10-09T20:05:55.7650010Z checking for paths.h... yes
+2025-10-09T20:05:55.8536240Z checking for stddef.h... yes
+2025-10-09T20:05:55.8537130Z checking for stdlib.h... (cached) yes
+2025-10-09T20:05:55.8538080Z checking for string.h... (cached) yes
+2025-10-09T20:05:55.9167580Z checking for sys/file.h... yes
+2025-10-09T20:05:56.0125680Z checking for sys/ioctl.h... yes
+2025-10-09T20:05:56.0886110Z checking for sys/param.h... yes
+2025-10-09T20:05:56.1003070Z checking for sys/socket.h... (cached) yes
+2025-10-09T20:05:56.1116820Z checking for sys/time.h... (cached) yes
+2025-10-09T20:05:56.1240900Z checking for sys/stat.h... (cached) yes
+2025-10-09T20:05:56.1349970Z checking for unistd.h... (cached) yes
+2025-10-09T20:05:56.2206720Z checking for utmp.h... yes
+2025-10-09T20:05:56.2728510Z checking for utmpx.h... yes
+2025-10-09T20:05:56.3628210Z checking for sys/epoll.h... no
+2025-10-09T20:05:56.4545530Z checking for sys/prctl.h... no
+2025-10-09T20:05:56.4547070Z checking for sys/select.h... (cached) yes
+2025-10-09T20:05:56.5574730Z checking for getopt.h... yes
+2025-10-09T20:05:56.6262740Z checking for linux/close_range.h... no
+2025-10-09T20:05:56.7091010Z checking for an ANSI C-conforming const... yes
+2025-10-09T20:05:56.7826660Z checking for inline... inline
+2025-10-09T20:05:56.8970590Z checking for off_t... yes
+2025-10-09T20:05:57.0134400Z checking for pid_t... yes
+2025-10-09T20:05:57.1235830Z checking for size_t... yes
+2025-10-09T20:05:57.2612260Z checking for ssize_t... yes
+2025-10-09T20:05:57.3858000Z checking for mode_t... yes
+2025-10-09T20:05:57.4892310Z checking for uid_t... yes
+2025-10-09T20:05:57.6084420Z checking for gid_t... yes
+2025-10-09T20:05:57.6690130Z checking for uint8_t... yes
+2025-10-09T20:05:57.7186120Z checking whether struct tm is in sys/time.h or time.h... time.h
+2025-10-09T20:05:57.7668150Z checking for working volatile... yes
+2025-10-09T20:05:57.8330800Z checking for struct sockaddr.sa_len... yes
+2025-10-09T20:05:58.1012900Z checking for working chown... yes
+2025-10-09T20:05:58.2026040Z checking for fork... yes
+2025-10-09T20:05:58.3016310Z checking for vfork... yes
+2025-10-09T20:05:58.4001960Z checking for vprintf... yes
+2025-10-09T20:05:58.8110560Z checking for working fork... yes
+2025-10-09T20:05:58.8112730Z checking for working vfork... (cached) yes
+2025-10-09T20:05:58.8653520Z checking types of arguments for select... int,fd_set *,struct timeval *
+2025-10-09T20:05:58.9282820Z checking return type of signal handlers... void
+2025-10-09T20:05:59.2163890Z checking whether lstat correctly handles trailing slash... no
+2025-10-09T20:05:59.4862740Z checking whether stat accepts an empty string... no
+2025-10-09T20:05:59.6014380Z checking for gcc options needed to detect all undeclared functions... none needed
+2025-10-09T20:05:59.6873010Z checking whether strerror_r is declared... yes
+2025-10-09T20:05:59.7665230Z checking whether strerror_r returns char *... no
+2025-10-09T20:05:59.8645790Z checking for flock... yes
+2025-10-09T20:05:59.9579640Z checking for recvmmsg... no
+2025-10-09T20:06:00.0864370Z checking for basename... yes
+2025-10-09T20:06:00.2283340Z checking for alarm... yes
+2025-10-09T20:06:00.3318870Z checking for clock_gettime... yes
+2025-10-09T20:06:00.4358690Z checking for gethostbyname... yes
+2025-10-09T20:06:00.5308120Z checking for gethostname... yes
+2025-10-09T20:06:00.6307380Z checking for gettimeofday... yes
+2025-10-09T20:06:00.7211260Z checking for localtime_r... yes
+2025-10-09T20:06:00.8115700Z checking for memset... yes
+2025-10-09T20:06:00.9197880Z checking for mkdir... yes
+2025-10-09T20:06:01.0063760Z checking for regcomp... yes
+2025-10-09T20:06:01.1066700Z checking for select... yes
+2025-10-09T20:06:01.1922730Z checking for setsid... yes
+2025-10-09T20:06:01.2801350Z checking for socket... yes
+2025-10-09T20:06:01.3782920Z checking for strcasecmp... yes
+2025-10-09T20:06:01.4973510Z checking for strchr... yes
+2025-10-09T20:06:01.5998960Z checking for strdup... yes
+2025-10-09T20:06:01.6944660Z checking for strerror... yes
+2025-10-09T20:06:01.7977970Z checking for strndup... yes
+2025-10-09T20:06:01.8890430Z checking for strnlen... yes
+2025-10-09T20:06:01.9634920Z checking for strrchr... yes
+2025-10-09T20:06:02.0660000Z checking for strstr... yes
+2025-10-09T20:06:02.1668410Z checking for strtol... yes
+2025-10-09T20:06:02.2885090Z checking for strtoul... yes
+2025-10-09T20:06:02.3902220Z checking for uname... yes
+2025-10-09T20:06:02.4802300Z checking for ttyname_r... yes
+2025-10-09T20:06:02.5506810Z checking for getline... yes
+2025-10-09T20:06:02.6350860Z checking for malloc_trim... no
+2025-10-09T20:06:02.7330240Z checking for prctl... no
+2025-10-09T20:06:02.8315090Z checking for epoll_create... no
+2025-10-09T20:06:02.9277260Z checking for epoll_create1... no
+2025-10-09T20:06:03.0199160Z checking for fdatasync... yes
+2025-10-09T20:06:03.1024950Z checking for syscall... yes
+2025-10-09T20:06:03.1724000Z checking for lseek64... no
+2025-10-09T20:06:03.3145940Z checking for asprintf... yes
+2025-10-09T20:06:03.4207520Z checking for close_range... no
+2025-10-09T20:06:03.5162590Z checking for pthread_setname_np... yes
+2025-10-09T20:06:03.6089540Z checking for setns... no
+2025-10-09T20:06:03.6971770Z checking for off64_t... no
+2025-10-09T20:06:03.7641850Z checking for sys/inotify.h... no
+2025-10-09T20:06:03.8571310Z checking for inotify_init... no
+2025-10-09T20:06:03.9518720Z checking for library containing getifaddrs... none required
+2025-10-09T20:06:04.0179300Z checking whether SCM_CREDENTIALS is declared... no
+2025-10-09T20:06:04.0794210Z checking whether SO_TIMESTAMP is declared... yes
+2025-10-09T20:06:04.1284030Z checking whether SYS_gettid is declared... yes
+2025-10-09T20:06:04.2533990Z checking for struct sysinfo.uptime... no
+2025-10-09T20:06:04.3102360Z checking whether GLOB_NOMAGIC is declared... yes
+2025-10-09T20:06:04.3502700Z checking for MAXHOSTNAMELEN... yes
+2025-10-09T20:06:04.4319140Z checking for __builtin_expect()... yes
+2025-10-09T20:06:04.6949900Z checking whether the compiler provides atomic builtins... yes
+2025-10-09T20:06:04.9461330Z checking whether the compiler provides atomic builtins for 64 bit data types... yes
+2025-10-09T20:06:05.0185430Z checking for semaphore.h... yes
+2025-10-09T20:06:05.0685660Z checking for sys/syscall.h... yes
+2025-10-09T20:06:05.1409120Z checking for gcc option to enable large file support... none needed
+2025-10-09T20:06:05.1599420Z checking for zlib... yes
+2025-10-09T20:06:05.2224050Z checking for pthread.h... yes
+2025-10-09T20:06:05.3238680Z checking for pthread_create in -lpthread... yes
+2025-10-09T20:06:05.4292660Z checking for pthread_rwlockattr_setkind_np in -lpthread... no
+2025-10-09T20:06:05.5103700Z checking for pthread_setname_np in -lpthread... yes
+2025-10-09T20:06:05.5809580Z checking for library containing pthread_setschedparam... none required
+2025-10-09T20:06:05.6345600Z checking for sched.h... yes
+2025-10-09T20:06:05.7134690Z checking for library containing sched_get_priority_max... none required
+2025-10-09T20:06:05.7926030Z checking for sched_get_priority_max... yes
+2025-10-09T20:06:05.8804760Z checking for libsystemd... no
+2025-10-09T20:06:05.8967730Z configure: WARNING: libsystemd not present - disabling systemd support
+2025-10-09T20:06:05.8968780Z configure: --enable-libsystemd in auto mode, enable-libsystemd is set to no
+2025-10-09T20:06:05.8970800Z configure: enable-debug in auto mode, enable-debug is set to yes
+2025-10-09T20:06:05.9167260Z checking for gnutls >= 1.4.0... yes
+2025-10-09T20:06:06.0101540Z checking for gnutls_certificate_set_retrieve_function... yes
+2025-10-09T20:06:06.0963100Z checking for gnutls_certificate_type_set_priority... no
+2025-10-09T20:06:06.1803310Z checking for protocol.h... no
+2025-10-09T20:06:06.2121410Z checking for liblogging-stdlog >= 1.0.3... no
+2025-10-09T20:06:06.2275480Z configure: liblogging-stdlog not found, parts of the testbench will not run
+2025-10-09T20:06:06.2284340Z checking for ip... no
+2025-10-09T20:06:06.2284670Z configure: Will not check network namespace functionality as 'ip' (part of iproute2) is not available.
+2025-10-09T20:06:06.2288790Z checking for valgrind... no
+2025-10-09T20:06:06.2289140Z configure: WARNING: valgrind is missing -- testbench won't use valgrind!
+2025-10-09T20:06:06.2292390Z configure: WARNING: imfile-tests can not be enabled without imfile support. Disabling imfile tests...
+2025-10-09T20:06:06.2299480Z     TCP input module epoll mode: no
+2025-10-09T20:06:06.2779570Z checking for hdfs.h... no
+2025-10-09T20:06:06.3404620Z checking for hadoop/hdfs.h... no
+2025-10-09T20:06:06.3634130Z configure: Running from git source
+2025-10-09T20:06:06.3635800Z checking for rst2man... rst2man
+2025-10-09T20:06:06.4500740Z checking that generated files are newer than configure... done
+2025-10-09T20:06:06.4527250Z configure: creating ./config.status
+2025-10-09T20:06:07.5107530Z config.status: creating Makefile
+2025-10-09T20:06:07.5571730Z config.status: creating runtime/Makefile
+2025-10-09T20:06:07.6260910Z config.status: creating compat/Makefile
+2025-10-09T20:06:07.6901800Z config.status: creating grammar/Makefile
+2025-10-09T20:06:07.7645330Z config.status: creating tools/Makefile
+2025-10-09T20:06:07.8315830Z config.status: creating plugins/imudp/Makefile
+2025-10-09T20:06:07.8918720Z config.status: creating plugins/imtcp/Makefile
+2025-10-09T20:06:07.9429120Z config.status: creating plugins/im3195/Makefile
+2025-10-09T20:06:07.9985880Z config.status: creating plugins/imgssapi/Makefile
+2025-10-09T20:06:08.0632030Z config.status: creating plugins/imuxsock/Makefile
+2025-10-09T20:06:08.1231360Z config.status: creating plugins/imjournal/Makefile
+2025-10-09T20:06:08.1801520Z config.status: creating plugins/immark/Makefile
+2025-10-09T20:06:08.2373440Z config.status: creating plugins/imklog/Makefile
+2025-10-09T20:06:08.2875640Z config.status: creating plugins/omhdfs/Makefile
+2025-10-09T20:06:08.3461210Z config.status: creating plugins/omotlp/Makefile
+2025-10-09T20:06:08.4106040Z config.status: creating plugins/omkafka/Makefile
+2025-10-09T20:06:08.4783990Z config.status: creating plugins/omprog/Makefile
+2025-10-09T20:06:08.5418940Z config.status: creating plugins/mmexternal/Makefile
+2025-10-09T20:06:08.5951750Z config.status: creating plugins/omstdout/Makefile
+2025-10-09T20:06:08.6455710Z config.status: creating plugins/omsendertrack/Makefile
+2025-10-09T20:06:08.7044210Z config.status: creating plugins/omjournal/Makefile
+2025-10-09T20:06:08.7821970Z config.status: creating plugins/pmciscoios/Makefile
+2025-10-09T20:06:08.8456770Z config.status: creating plugins/pmnull/Makefile
+2025-10-09T20:06:08.9165090Z config.status: creating plugins/pmnormalize/Makefile
+2025-10-09T20:06:08.9733540Z config.status: creating plugins/omruleset/Makefile
+2025-10-09T20:06:09.0242770Z config.status: creating plugins/omuxsock/Makefile
+2025-10-09T20:06:09.0796850Z config.status: creating plugins/imfile/Makefile
+2025-10-09T20:06:09.1352720Z config.status: creating plugins/imsolaris/Makefile
+2025-10-09T20:06:09.1947860Z config.status: creating plugins/imptcp/Makefile
+2025-10-09T20:06:09.2560880Z config.status: creating plugins/impstats/Makefile
+2025-10-09T20:06:09.3149640Z config.status: creating plugins/imrelp/Makefile
+2025-10-09T20:06:09.3706680Z config.status: creating plugins/imdiag/Makefile
+2025-10-09T20:06:09.4215580Z config.status: creating plugins/imkafka/Makefile
+2025-10-09T20:06:09.4765510Z config.status: creating plugins/omtesting/Makefile
+2025-10-09T20:06:09.5418870Z config.status: creating plugins/omgssapi/Makefile
+2025-10-09T20:06:09.6131850Z config.status: creating plugins/ommysql/Makefile
+2025-10-09T20:06:09.6697100Z config.status: creating plugins/ompgsql/Makefile
+2025-10-09T20:06:09.7207830Z config.status: creating plugins/omrelp/Makefile
+2025-10-09T20:06:09.7781050Z config.status: creating plugins/omlibdbi/Makefile
+2025-10-09T20:06:09.8396770Z config.status: creating plugins/ommail/Makefile
+2025-10-09T20:06:09.8900560Z config.status: creating plugins/fmhttp/Makefile
+2025-10-09T20:06:09.9458270Z config.status: creating plugins/omsnmp/Makefile
+2025-10-09T20:06:10.0068570Z config.status: creating plugins/omudpspoof/Makefile
+2025-10-09T20:06:10.0654990Z config.status: creating plugins/ommongodb/Makefile
+2025-10-09T20:06:10.1214130Z config.status: creating plugins/mmnormalize/Makefile
+2025-10-09T20:06:10.1826200Z config.status: creating plugins/mmjsonparse/Makefile
+2025-10-09T20:06:10.2612700Z config.status: creating plugins/mmjsontransform/Makefile
+2025-10-09T20:06:10.3272420Z config.status: creating plugins/mmleefparse/Makefile
+2025-10-09T20:06:10.3942360Z config.status: creating plugins/mmaudit/Makefile
+2025-10-09T20:06:10.4670560Z config.status: creating plugins/mmanon/Makefile
+2025-10-09T20:06:10.5332460Z config.status: creating plugins/mmrm1stspace/Makefile
+2025-10-09T20:06:10.5952700Z config.status: creating plugins/mmutf8fix/Makefile
+2025-10-09T20:06:10.6525890Z config.status: creating plugins/mmfields/Makefile
+2025-10-09T20:06:10.7132040Z config.status: creating plugins/mmpstrucdata/Makefile
+2025-10-09T20:06:10.7811080Z config.status: creating plugins/mmaitag/Makefile
+2025-10-09T20:06:10.8421070Z config.status: creating plugins/omelasticsearch/Makefile
+2025-10-09T20:06:10.9061160Z config.status: creating plugins/omclickhouse/Makefile
+2025-10-09T20:06:10.9582850Z config.status: creating plugins/mmsnmptrapd/Makefile
+2025-10-09T20:06:11.0135680Z config.status: creating plugins/pmlastmsg/Makefile
+2025-10-09T20:06:11.0775180Z config.status: creating plugins/mmdblookup/Makefile
+2025-10-09T20:06:11.1403490Z config.status: creating plugins/omazureeventhubs/Makefile
+2025-10-09T20:06:11.2019820Z config.status: creating plugins/imdtls/Makefile
+2025-10-09T20:06:11.2684050Z config.status: creating plugins/omdtls/Makefile
+2025-10-09T20:06:11.3396490Z config.status: creating contrib/mmdarwin/Makefile
+2025-10-09T20:06:11.3982180Z config.status: creating contrib/omhttp/Makefile
+2025-10-09T20:06:11.4533350Z config.status: creating contrib/fmhash/Makefile
+2025-10-09T20:06:11.5053440Z config.status: creating contrib/fmunflatten/Makefile
+2025-10-09T20:06:11.5550050Z config.status: creating plugins/fmpcre/Makefile
+2025-10-09T20:06:11.6108200Z config.status: creating contrib/ffaup/Makefile
+2025-10-09T20:06:11.6778720Z config.status: creating contrib/pmsnare/Makefile
+2025-10-09T20:06:11.7408290Z config.status: creating contrib/pmpanngfw/Makefile
+2025-10-09T20:06:11.8088260Z config.status: creating contrib/pmaixforwardedfrom/Makefile
+2025-10-09T20:06:11.8869260Z config.status: creating contrib/omhiredis/Makefile
+2025-10-09T20:06:11.9804750Z config.status: creating contrib/omrabbitmq/Makefile
+2025-10-09T20:06:12.0619960Z config.status: creating contrib/imkmsg/Makefile
+2025-10-09T20:06:12.1311310Z config.status: creating contrib/mmgrok/Makefile
+2025-10-09T20:06:12.1853820Z config.status: creating contrib/mmcount/Makefile
+2025-10-09T20:06:12.2498530Z config.status: creating contrib/omczmq/Makefile
+2025-10-09T20:06:12.3421180Z config.status: creating contrib/imczmq/Makefile
+2025-10-09T20:06:12.4259660Z config.status: creating contrib/mmsequence/Makefile
+2025-10-09T20:06:12.4998770Z config.status: creating contrib/mmrfc5424addhmac/Makefile
+2025-10-09T20:06:12.5875080Z config.status: creating plugins/mmsnareparse/Makefile
+2025-10-09T20:06:12.6670080Z config.status: creating contrib/pmcisconames/Makefile
+2025-10-09T20:06:12.7423070Z config.status: creating contrib/omhttpfs/Makefile
+2025-10-09T20:06:12.8269510Z config.status: creating contrib/omamqp1/Makefile
+2025-10-09T20:06:12.9026780Z config.status: creating contrib/omtcl/Makefile
+2025-10-09T20:06:12.9769980Z config.status: creating contrib/imbatchreport/Makefile
+2025-10-09T20:06:13.0297390Z config.status: creating contrib/omfile-hardened/Makefile
+2025-10-09T20:06:13.1076660Z config.status: creating contrib/mmkubernetes/Makefile
+2025-10-09T20:06:13.1774470Z config.status: creating contrib/impcap/Makefile
+2025-10-09T20:06:13.2483150Z config.status: creating contrib/imtuxedoulog/Makefile
+2025-10-09T20:06:13.3269090Z config.status: creating contrib/improg/Makefile
+2025-10-09T20:06:13.4021260Z config.status: creating contrib/imhttp/Makefile
+2025-10-09T20:06:13.4760880Z config.status: creating contrib/mmtaghostname/Makefile
+2025-10-09T20:06:13.5557880Z config.status: creating contrib/imdocker/Makefile
+2025-10-09T20:06:13.6408470Z config.status: creating contrib/pmdb2diag/Makefile
+2025-10-09T20:06:13.7274420Z config.status: creating contrib/imhiredis/Makefile
+2025-10-09T20:06:13.8074530Z config.status: creating tests/set-envvars
+2025-10-09T20:06:13.8814100Z config.status: creating tests/Makefile
+2025-10-09T20:06:13.9752770Z config.status: creating config.h
+2025-10-09T20:06:14.0050770Z config.status: executing depfiles commands
+2025-10-09T20:06:18.0954030Z config.status: executing libtool commands
+2025-10-09T20:06:18.1266650Z ****************************************************
+2025-10-09T20:06:18.1267740Z rsyslog will be compiled with the following settings:
+2025-10-09T20:06:18.1268380Z 
+2025-10-09T20:06:18.1268750Z     Large file support enabled:               yes
+2025-10-09T20:06:18.1269810Z configure: WARNING: unrecognized options: --enable-compile-warnings
+2025-10-09T20:06:18.1270530Z     Networking support enabled:               yes
+2025-10-09T20:06:18.1284950Z     Regular expressions support enabled:      yes
+2025-10-09T20:06:18.1285620Z     rsyslog runtime will be built:            yes
+2025-10-09T20:06:18.1286200Z     rsyslogd will be built:                   yes
+2025-10-09T20:06:18.1286750Z     have to generate man pages:               yes
+2025-10-09T20:06:18.1287500Z     Unlimited select() support enabled:       no
+2025-10-09T20:06:18.1288060Z     uuid support enabled:                     no
+2025-10-09T20:06:18.1289380Z     Log file signing support via KSI LS12:    no
+2025-10-09T20:06:18.1307320Z     Log file gcry encryption support:         no
+2025-10-09T20:06:18.1324080Z     Log file ossl encryption support:         no
+2025-10-09T20:06:18.1325100Z     Log file compression via zstd support:    no
+2025-10-09T20:06:18.1325340Z     anonymization support enabled:            no
+2025-10-09T20:06:18.1325610Z     message counting support enabled:         no
+2025-10-09T20:06:18.1325890Z     liblogging-stdlog support enabled:        no
+2025-10-09T20:06:18.1326130Z     libsystemd enabled:                       no
+2025-10-09T20:06:18.1326330Z     kafka static linking enabled:             no
+2025-10-09T20:06:18.1326550Z     qpid proton static linking enabled:       no
+2025-10-09T20:06:18.1326760Z     atomic operations enabled:                yes
+2025-10-09T20:06:18.1326970Z     libcap-ng support enabled:                no
+2025-10-09T20:06:18.1327100Z 
+2025-10-09T20:06:18.1327280Z ---{ input plugins }---
+2025-10-09T20:06:18.1327480Z     Klog functionality enabled:               yes (bsd)
+2025-10-09T20:06:18.1327710Z     /dev/kmsg functionality enabled:          no
+2025-10-09T20:06:18.1327920Z     tcp input module epoll permitted:         no
+2025-10-09T20:06:18.1328130Z     plain tcp input module enabled:           no
+2025-10-09T20:06:18.1328330Z     DTLS udp input module enabled:            no
+2025-10-09T20:06:18.1328530Z     imdiag enabled:                           yes
+2025-10-09T20:06:18.1328730Z     file input module enabled:                no
+2025-10-09T20:06:18.1328940Z     docker log input module enabled:          no
+2025-10-09T20:06:18.1329140Z     Solaris input module enabled:             no
+2025-10-09T20:06:18.1329340Z     periodic statistics module enabled:       no
+2025-10-09T20:06:18.1329550Z     imczmq input module enabled:              no
+2025-10-09T20:06:18.1329750Z     imjournal input module enabled:           no
+2025-10-09T20:06:18.1329960Z     imbatchreport input module enabled:       no
+2025-10-09T20:06:18.1330180Z     imkafka module will be compiled:          no
+2025-10-09T20:06:18.1330380Z     impcap input module enabled:              no
+2025-10-09T20:06:18.1330590Z     imtuxedoulog module will be compiled:     no
+2025-10-09T20:06:18.1330790Z     improg input module enabled:              no
+2025-10-09T20:06:18.1330990Z     imhttp input module enabled:              no
+2025-10-09T20:06:18.1331190Z     imhiredis input module enabled:           no
+2025-10-09T20:06:18.1331330Z 
+2025-10-09T20:06:18.1331380Z ---{ output plugins }---
+2025-10-09T20:06:18.1331550Z     Mail support enabled:                     no
+2025-10-09T20:06:18.1331760Z     omfile-hardened module will be compiled:  no
+2025-10-09T20:06:18.1331960Z     omprog module will be compiled:           no
+2025-10-09T20:06:18.1332170Z     omstdout module will be compiled:         yes
+2025-10-09T20:06:18.1332380Z     omsendertrack module will be compiled:    no
+2025-10-09T20:06:18.1332580Z     omjournal module will be compiled:        no
+2025-10-09T20:06:18.1332790Z     omhdfs module will be compiled:           no
+2025-10-09T20:06:18.1332990Z     omotlp module will be compiled:           no
+2025-10-09T20:06:18.1333200Z     omelasticsearch module will be compiled:  no
+2025-10-09T20:06:18.1333400Z     omclickhouse module will be compiled:     no
+2025-10-09T20:06:18.1333600Z     omhttp module will be compiled:           no
+2025-10-09T20:06:18.1333800Z     omruleset module will be compiled:        no
+2025-10-09T20:06:18.1334010Z     omudpspoof module will be compiled:       no
+2025-10-09T20:06:18.1334550Z     omuxsock module will be compiled:         no
+2025-10-09T20:06:18.1334760Z     omczmq module will be compiled:           no
+2025-10-09T20:06:18.1334960Z     omrabbitmq module will be compiled:       no
+2025-10-09T20:06:18.1335160Z     omhttpfs module will be compiled:         no
+2025-10-09T20:06:18.1335360Z     omamqp1 module will be compiled:          no
+2025-10-09T20:06:18.1335560Z     omtcl module will be compiled:            no
+2025-10-09T20:06:18.1335760Z     omkafka module will be compiled:          no
+2025-10-09T20:06:18.1336130Z     omhiredis module will be compiled:        no
+2025-10-09T20:06:18.1336340Z     omazureeventhubs module will be compiled: no
+2025-10-09T20:06:18.1336540Z     omdtls module will be compiled:           no
+2025-10-09T20:06:18.1336680Z 
+2025-10-09T20:06:18.1336730Z ---{ parser modules }---
+2025-10-09T20:06:18.1336890Z     pmlastmsg module will be compiled:        no
+2025-10-09T20:06:18.1337100Z     pmcisconames module will be compiled:     no
+2025-10-09T20:06:18.1337310Z     pmciscoios module will be compiled:       no
+2025-10-09T20:06:18.1337520Z     pmnull module will be compiled:           no
+2025-10-09T20:06:18.1337720Z     pmnormalize module will be compiled:      no
+2025-10-09T20:06:18.1338000Z     pmaixforwardedfrom module w.be compiled:  no
+2025-10-09T20:06:18.1338210Z     pmsnare module will be compiled:          no
+2025-10-09T20:06:18.1338430Z     pmdb2diag module will be compiled:        no
+2025-10-09T20:06:18.1338630Z     pmpanngfw module will be compiled:        no
+2025-10-09T20:06:18.1338770Z 
+2025-10-09T20:06:18.1338840Z ---{ message modification modules }---
+2025-10-09T20:06:18.1339040Z     mmnormalize module will be compiled:      no
+2025-10-09T20:06:18.1339250Z     mmjsonparse module will be compiled:      no
+2025-10-09T20:06:18.1339460Z     mmjsontransform module will be compiled:  no
+2025-10-09T20:06:18.1339670Z     mmleefparse module will be compiled:      yes
+2025-10-09T20:06:18.1339880Z     mmgrok module will be compiled:           no
+2025-10-09T20:06:18.1340090Z     mmjaduit module will be compiled:         no
+2025-10-09T20:06:18.1340300Z     mmsnmptrapd module will be compiled:      no
+2025-10-09T20:06:18.1340500Z     mmutf8fix enabled:                        no
+2025-10-09T20:06:18.1343860Z     mmrfc5424addhmac enabled:                 no
+2025-10-09T20:06:18.1344440Z     mmsnareparse enabled:                    no
+2025-10-09T20:06:18.1345080Z     mmpstrucdata enabled:                     no
+2025-10-09T20:06:18.1345620Z     mmsequence enabled:                       no
+2025-10-09T20:06:18.1346190Z     mmdblookup enabled:                       no
+2025-10-09T20:06:18.1346740Z     mmdarwin enabled:                         no
+2025-10-09T20:06:18.1347300Z     mmfields enabled:                         no
+2025-10-09T20:06:18.1347880Z     mmrm1stspace module enabled:              no
+2025-10-09T20:06:18.1348450Z     mmkubernetes enabled:                     no
+2025-10-09T20:06:18.1349000Z     mmaitag enabled:                          no
+2025-10-09T20:06:18.1349590Z     mmtaghostname enabled:                    no
+2025-10-09T20:06:18.1350000Z 
+2025-10-09T20:06:18.1351080Z ---{ database support }---
+2025-10-09T20:06:18.1354700Z     MySql support enabled:                    no
+2025-10-09T20:06:18.1354980Z     libdbi support enabled:                   no
+2025-10-09T20:06:18.1355200Z     PostgreSQL support enabled:               no
+2025-10-09T20:06:18.1355420Z     mongodb support enabled:                  no
+2025-10-09T20:06:18.1355620Z     hiredis support enabled:                  no
+2025-10-09T20:06:18.1355780Z 
+2025-10-09T20:06:18.1355840Z ---{ protocol support }---
+2025-10-09T20:06:18.1356020Z     openssl network stream driver enabled:    no
+2025-10-09T20:06:18.1356240Z     GnuTLS network stream driver enabled:     yes
+2025-10-09T20:06:18.1356470Z     GSSAPI Kerberos 5 support enabled:        no
+2025-10-09T20:06:18.1356670Z     RELP support enabled:                     no
+2025-10-09T20:06:18.1356870Z     SNMP support enabled:                     no
+2025-10-09T20:06:18.1357500Z 
+2025-10-09T20:06:18.1357560Z ---{ function modules }---
+2025-10-09T20:06:18.1357720Z     fmhttp enabled:                           no
+2025-10-09T20:06:18.1357910Z     fmhash enabled:                           yes
+2025-10-09T20:06:18.1358110Z     fmhash with xxhash enabled:               no
+2025-10-09T20:06:18.1358310Z     fmunflatten enabled:                      no
+2025-10-09T20:06:18.1358500Z     fmpcre enabled:                          no
+2025-10-09T20:06:18.1358690Z     ffaup enabled:                            no
+2025-10-09T20:06:18.1359020Z 
+2025-10-09T20:06:18.1359090Z ---{ debugging support }---
+2025-10-09T20:06:18.1359260Z     distcheck workaround enabled:             no
+2025-10-09T20:06:18.1359470Z     Testbench enabled:                        yes
+2025-10-09T20:06:18.1359670Z     valgrind tests enabled:                   
+2025-10-09T20:06:18.1359860Z     valgrind helgrind tests enabled:          no
+2025-10-09T20:06:18.1360060Z     Default tests enabled:                    no
+2025-10-09T20:06:18.1360270Z     Testbench libfaketime tests enabled:      no
+2025-10-09T20:06:18.1360480Z     Extended Testbench enabled:               no
+2025-10-09T20:06:18.1360670Z     MySQL Tests enabled:                      no
+2025-10-09T20:06:18.1360870Z     Elasticsearch Tests:                      no
+2025-10-09T20:06:18.1361070Z     ClickHouse Tests:                         no
+2025-10-09T20:06:18.1361270Z     PostgreSQL Tests enabled:                 no
+2025-10-09T20:06:18.1361510Z     Kafka Tests enabled:                      no
+2025-10-09T20:06:18.1361710Z     Redis Tests enabled:                      no
+2025-10-09T20:06:18.1361920Z     Omazureeventhubs Tests enabled:           no
+2025-10-09T20:06:18.1362180Z     Imdocker Tests enabled:                   no
+2025-10-09T20:06:18.1369920Z     imtcp tests enabled:                      yes
+2025-10-09T20:06:18.1370160Z     gnutls tests enabled:                     yes
+2025-10-09T20:06:18.1370360Z     imfile tests enabled:                     no
+2025-10-09T20:06:18.1370870Z     systemd journal tests enabled:            no
+2025-10-09T20:06:18.1371070Z     SNMP Tests enabled:                       no
+2025-10-09T20:06:18.1371260Z     Flaky Tests enabled:                      no
+2025-10-09T20:06:18.1371450Z     Debug mode enabled:                       yes
+2025-10-09T20:06:18.1371650Z     (total) debugless mode enabled:           no
+2025-10-09T20:06:18.1371850Z     Diagnostic tools enabled:                 no
+2025-10-09T20:06:18.1372040Z     End-User tools enabled:                   yes
+2025-10-09T20:06:18.1372260Z     Valgrind support settings enabled:        no
+2025-10-09T20:06:18.1372390Z 
+2025-10-09T20:06:18.2548310Z ##[group]Run make -j
+2025-10-09T20:06:18.2548540Z [36;1mmake -j[0m
+2025-10-09T20:06:18.2681170Z shell: /bin/bash -e {0}
+2025-10-09T20:06:18.2681420Z env:
+2025-10-09T20:06:18.2681600Z   USE_AUTO_DEBUG: true
+2025-10-09T20:06:18.2681790Z   ABORT_ALL_ON_TEST_FAIL: true
+2025-10-09T20:06:18.2681990Z ##[endgroup]
+2025-10-09T20:06:18.3543590Z /Applications/Xcode_16.4.app/Contents/Developer/usr/bin/make  all-recursive
+2025-10-09T20:06:18.3676270Z Making all in compat
+2025-10-09T20:06:18.3874830Z   CC       compat_la-asprintf.lo
+2025-10-09T20:06:18.3897030Z   CC       compat_la-getifaddrs.lo
+2025-10-09T20:06:18.3910140Z   CC       compat_la-strndup.lo
+2025-10-09T20:06:18.3936330Z   CC       compat_la-solaris_elf_fix.lo
+2025-10-09T20:06:18.5832210Z   CCLD     compat.la
+2025-10-09T20:06:18.7031930Z warning: /Applications/Xcode_16.4.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ranlib: archive library: .libs/compat.a the table of contents is empty (no object file members in the library define global symbols)
+2025-10-09T20:06:18.7232460Z Making all in runtime
+2025-10-09T20:06:18.7337890Z   CC       librsyslog_la-rsyslog.lo
+2025-10-09T20:06:18.7520660Z   CC       librsyslog_la-glbl.lo
+2025-10-09T20:06:18.7532710Z   CC       librsyslog_la-conf.lo
+2025-10-09T20:06:18.7836840Z   CC       librsyslog_la-dnscache.lo
+2025-10-09T20:06:18.7936020Z   CC       librsyslog_la-janitor.lo
+2025-10-09T20:06:18.8101290Z   CC       librsyslog_la-rsconf.lo
+2025-10-09T20:06:18.8242730Z   CC       librsyslog_la-parser.lo
+2025-10-09T20:06:18.8407900Z   CC       librsyslog_la-strgen.lo
+2025-10-09T20:06:18.8570730Z   CC       librsyslog_la-linkedlist.lo
+2025-10-09T20:06:18.8755250Z   CC       librsyslog_la-msg.lo
+2025-10-09T20:06:18.8886270Z   CC       librsyslog_la-objomsr.lo
+2025-10-09T20:06:18.8983400Z   CC       librsyslog_la-stringbuf.lo
+2025-10-09T20:06:18.9087700Z   CC       librsyslog_la-datetime.lo
+2025-10-09T20:06:18.9194360Z   CC       librsyslog_la-srutils.lo
+2025-10-09T20:06:18.9316720Z   CC       librsyslog_la-errmsg.lo
+2025-10-09T20:06:18.9464940Z   CC       librsyslog_la-operatingstate.lo
+2025-10-09T20:06:18.9604510Z   CC       librsyslog_la-debug.lo
+2025-10-09T20:06:18.9744590Z   CC       librsyslog_la-obj.lo
+2025-10-09T20:06:18.9876920Z   CC       librsyslog_la-modules.lo
+2025-10-09T20:06:18.9993530Z   CC       librsyslog_la-statsobj.lo
+2025-10-09T20:06:19.0102210Z   CC       librsyslog_la-dynstats.lo
+2025-10-09T20:06:19.0217480Z   CC       librsyslog_la-perctile_ringbuf.lo
+2025-10-09T20:06:19.0347290Z   CC       librsyslog_la-perctile_stats.lo
+2025-10-09T20:06:19.0348190Z   CC       librsyslog_la-stream.lo
+2025-10-09T20:06:19.0462930Z   CC       librsyslog_la-var.lo
+2025-10-09T20:06:19.0565940Z   CC       librsyslog_la-wtp.lo
+2025-10-09T20:06:19.0602080Z   CC       librsyslog_la-wti.lo
+2025-10-09T20:06:19.0604430Z   CC       librsyslog_la-queue.lo
+2025-10-09T20:06:19.0604770Z   CC       librsyslog_la-ruleset.lo
+2025-10-09T20:06:19.0605100Z   CC       librsyslog_la-prop.lo
+2025-10-09T20:06:19.0605320Z   CC       librsyslog_la-lookup.lo
+2025-10-09T20:06:19.0605650Z   CC       librsyslog_la-cfsysline.lo
+2025-10-09T20:06:19.0617570Z   CC       librsyslog_la-ratelimit.lo
+2025-10-09T20:06:19.1477800Z   CC       librsyslog_la-hashtable.lo
+2025-10-09T20:06:19.1630070Z   CC       librsyslog_la-hashtable_itr.lo
+2025-10-09T20:06:19.1857750Z   CC       librsyslog_la-timezones.lo
+2025-10-09T20:06:19.2020700Z   CC       lmregexp_la-regexp.lo
+2025-10-09T20:06:19.2220480Z   CC       lmzlibw_la-zlibw.lo
+2025-10-09T20:06:19.2399570Z   CC       lmnet_la-net.lo
+2025-10-09T20:06:19.2700320Z   CC       lmnetstrms_la-netstrms.lo
+2025-10-09T20:06:19.2814750Z   CC       lmnet_la-netns_socket.lo
+2025-10-09T20:06:19.2935440Z   CC       lmnsd_ptcp_la-nsd_ptcp.lo
+2025-10-09T20:06:19.3054690Z   CC       lmnetstrms_la-netstrm.lo
+2025-10-09T20:06:19.3177850Z   CC       lmnsd_gtls_la-nsd_gtls.lo
+2025-10-09T20:06:19.3305230Z   CC       lmtcpsrv_la-tcpsrv.lo
+2025-10-09T20:06:19.3437610Z   CC       lmtcpsrv_la-tcps_sess.lo
+2025-10-09T20:06:19.3560330Z   CC       lmtcpclt_la-tcpclt.lo
+2025-10-09T20:06:20.2313620Z tcpsrv.c:1102:9: warning: variable 'nAccept' set but not used [-Wunused-but-set-variable]
+2025-10-09T20:06:20.2431110Z  1102 |     int nAccept = 0;
+2025-10-09T20:06:20.2569500Z       |         ^
+2025-10-09T20:06:21.0524090Z   CC       ../librsyslog_la-action.lo
+2025-10-09T20:06:21.0643610Z   CC       ../librsyslog_la-threads.lo
+2025-10-09T20:06:21.0784220Z   CC       ../librsyslog_la-parse.lo
+2025-10-09T20:06:21.0914690Z   CC       ../librsyslog_la-outchannel.lo
+2025-10-09T20:06:21.1017590Z   CCLD     lmregexp.la
+2025-10-09T20:06:21.1119030Z   CC       ../librsyslog_la-template.lo
+2025-10-09T20:06:21.5065950Z debug.c:76:85: warning: 'syscall' is deprecated: first deprecated in macOS 10.12 - syscall(2) is unsupported; please switch to a supported interface. For SYS_kdebug_trace use kdebug_signpost(). [-Wdeprecated-declarations]
+2025-10-09T20:06:21.5071150Z    76 |     if (bOutputTidToStderr) fprintf(stderr, "thread tid %u, name '%s'\n", (unsigned)syscall(SYS_gettid), name);
+2025-10-09T20:06:21.5170920Z       |                                                                                     ^
+2025-10-09T20:06:21.5272840Z /Applications/Xcode_16.4.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/unistd.h:744:6: note: 'syscall' has been explicitly marked deprecated here
+2025-10-09T20:06:21.5419480Z   744 | int      syscall(int, ...);
+2025-10-09T20:06:21.5520540Z       |          ^
+2025-10-09T20:06:21.5623350Z debug.c:77:64: warning: 'syscall' is deprecated: first deprecated in macOS 10.12 - syscall(2) is unsupported; please switch to a supported interface. For SYS_kdebug_trace use kdebug_signpost(). [-Wdeprecated-declarations]
+2025-10-09T20:06:21.5726210Z    77 |     DBGPRINTF("thread created, tid %u, name '%s'\n", (unsigned)syscall(SYS_gettid), name);
+2025-10-09T20:06:21.5828340Z       |                                                                ^
+2025-10-09T20:06:21.5931030Z /Applications/Xcode_16.4.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/unistd.h:744:6: note: 'syscall' has been explicitly marked deprecated here
+2025-10-09T20:06:21.6031810Z   744 | int      syscall(int, ...);
+2025-10-09T20:06:21.6135200Z       |          ^
+2025-10-09T20:06:22.0231950Z   CCLD     lmzlibw.la
+2025-10-09T20:06:22.2360220Z netns_socket.c:108:41: warning: unused parameter 'fd' [-Wunused-parameter]
+2025-10-09T20:06:22.2371870Z   108 | rsRetVal ATTR_NONNULL() netns_save(int *fd) {
+2025-10-09T20:06:22.2372480Z       |                                         ^
+2025-10-09T20:06:22.2474940Z 1 warning generated.
+2025-10-09T20:06:22.5380280Z queue.c:663:48: warning: cast from 'rsRetVal (*)(qqueue_t *)' (aka 'enum rsRetVal_ (*)(struct queue_s *)') to 'rsRetVal (*)(void *, int)' (aka 'enum rsRetVal_ (*)(void *, int)') converts to incompatible function type [-Wcast-function-type-mismatch]
+2025-10-09T20:06:22.5481250Z   663 |     CHKiRet(wtpSetpfChkStopWrkr(pThis->pWtpDA, (rsRetVal(*)(void *pUsr, int))qqueueChkStopWrkrDA));
+2025-10-09T20:06:22.5498160Z       |                                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+2025-10-09T20:06:22.5498810Z ./rsyslog.h:764:21: note: expanded from macro 'CHKiRet'
+2025-10-09T20:06:22.5499650Z   764 |         if ((iRet = code) != RS_RET_OK) goto finalize_it
+2025-10-09T20:06:22.5500260Z       |                     ^~~~
+2025-10-09T20:06:22.7567390Z queue.c:2549:49: warning: cast from 'rsRetVal (*)(qqueue_t *)' (aka 'enum rsRetVal_ (*)(struct queue_s *)') to 'rsRetVal (*)(void *, int)' (aka 'enum rsRetVal_ (*)(void *, int)') converts to incompatible function type [-Wcast-function-type-mismatch]
+2025-10-09T20:06:22.7670670Z  2549 |     CHKiRet(wtpSetpfChkStopWrkr(pThis->pWtpReg, (rsRetVal(*)(void *pUsr, int))ChkStopWrkrReg));
+2025-10-09T20:06:22.7772170Z       |                                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+2025-10-09T20:06:22.7874250Z ./rsyslog.h:764:21: note: expanded from macro 'CHKiRet'
+2025-10-09T20:06:22.7974080Z   764 |         if ((iRet = code) != RS_RET_OK) goto finalize_it
+2025-10-09T20:06:22.8075300Z       |                     ^~~~
+2025-10-09T20:06:22.8282410Z 2 warnings generated.
+2025-10-09T20:06:22.9916190Z queue.c:3648:1: warning: cast from 'rsRetVal (*)(qqueue_t **, queueType_t, int, int, rsRetVal (*)(void *, batch_t *, wti_t *))' (aka 'enum rsRetVal_ (*)(struct queue_s **, queueType_t, int, int, enum rsRetVal_ (*)(void *, struct batch_s *, struct wti_s *))') to 'rsRetVal (*)(void *)' (aka 'enum rsRetVal_ (*)(void *)') converts to incompatible function type [-Wcast-function-type-mismatch]
+2025-10-09T20:06:23.0015860Z  3648 | BEGINObjClassInit(qqueue, 1, OBJ_IS_CORE_MODULE)
+2025-10-09T20:06:23.0016340Z   CCLD     lmtcpclt.la
+2025-10-09T20:06:23.0117670Z       | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+2025-10-09T20:06:23.0220490Z ./obj-types.h:192:77: note: expanded from macro 'BEGINObjClassInit'
+2025-10-09T20:06:23.0322500Z   192 |         CHKiRet(obj.InfoConstruct(&pObjInfoOBJ, (uchar *)#objName, objVers, (rsRetVal(*)(void *))objName##Construct, \
+2025-10-09T20:06:23.0422640Z       |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+2025-10-09T20:06:23.0524760Z   193 |                                   (rsRetVal(*)(void *))objName##Destruct,                                            \
+2025-10-09T20:06:23.0624730Z       |                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+2025-10-09T20:06:23.0725250Z   194 |                                   (rsRetVal(*)(interface_t *))objName##QueryInterface, pModInfo));
+2025-10-09T20:06:23.0804610Z       |                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+2025-10-09T20:06:23.0805360Z ./rsyslog.h:764:21: note: expanded from macro 'CHKiRet'
+2025-10-09T20:06:23.0806470Z   764 |         if ((iRet = code) != RS_RET_OK) goto finalize_it
+2025-10-09T20:06:23.0807230Z       |                     ^~~~
+2025-10-09T20:06:23.5969900Z   CCLD     lmnetstrms.la
+2025-10-09T20:06:23.8289680Z   CCLD     lmnet.la
+2025-10-09T20:06:23.9338960Z   CCLD     lmnsd_ptcp.la
+2025-10-09T20:06:24.0947670Z 1 warning generated.
+2025-10-09T20:06:24.1394150Z   CCLD     lmtcpsrv.la
+2025-10-09T20:06:24.3140020Z   CCLD     lmnsd_gtls.la
+2025-10-09T20:06:24.4610730Z 3 warnings generated.
+2025-10-09T20:06:24.7719510Z   CCLD     librsyslog.la
+2025-10-09T20:06:25.0177290Z Making all in grammar
+2025-10-09T20:06:25.0322890Z   YACC     grammar.c
+2025-10-09T20:06:25.9993930Z updating grammar.h
+2025-10-09T20:06:26.0306960Z /Applications/Xcode_16.4.app/Contents/Developer/usr/bin/make  all-am
+2025-10-09T20:06:26.0451230Z   CC       libgrammar_la-grammar.lo
+2025-10-09T20:06:26.0482360Z   CC       libgrammar_la-rainerscript.lo
+2025-10-09T20:06:26.0526730Z   LEX      lexer.c
+2025-10-09T20:06:26.3091510Z   CC       libgrammar_la-lexer.lo
+2025-10-09T20:06:27.1017270Z   CCLD     libgrammar.la
+2025-10-09T20:06:27.2785730Z Making all in .
+2025-10-09T20:06:27.2906420Z Making all in plugins/immark
+2025-10-09T20:06:27.3040520Z   CC       immark_la-immark.lo
+2025-10-09T20:06:27.4702380Z   CCLD     immark.la
+2025-10-09T20:06:27.6299070Z Making all in plugins/imuxsock
+2025-10-09T20:06:27.6382160Z   CC       imuxsock_la-imuxsock.lo
+2025-10-09T20:06:27.8758500Z   CCLD     imuxsock.la
+2025-10-09T20:06:28.0962340Z Making all in plugins/imtcp
+2025-10-09T20:06:28.1048430Z   CC       imtcp_la-imtcp.lo
+2025-10-09T20:06:28.4546550Z   CCLD     imtcp.la
+2025-10-09T20:06:28.6771280Z Making all in plugins/imudp
+2025-10-09T20:06:28.6887000Z   CC       imudp_la-imudp.lo
+2025-10-09T20:06:29.0048120Z   CCLD     imudp.la
+2025-10-09T20:06:29.3070570Z Making all in plugins/omtesting
+2025-10-09T20:06:29.3153070Z   CC       omtesting_la-omtesting.lo
+2025-10-09T20:06:29.5168120Z   CCLD     omtesting.la
+2025-10-09T20:06:29.8537390Z Making all in plugins/mmexternal
+2025-10-09T20:06:29.8670490Z   CC       mmexternal_la-mmexternal.lo
+2025-10-09T20:06:30.1617950Z   CCLD     mmexternal.la
+2025-10-09T20:06:30.4791740Z Making all in tools
+2025-10-09T20:06:30.4922510Z   CC       rsyslogd-rsyslogd.o
+2025-10-09T20:06:30.5143550Z   CC       rsyslogd-syslogd.o
+2025-10-09T20:06:30.5401170Z   CC       rsyslogd-omshell.o
+2025-10-09T20:06:30.5580960Z   CC       rsyslogd-omusrmsg.o
+2025-10-09T20:06:30.5761240Z   CC       rsyslogd-omfwd.o
+2025-10-09T20:06:30.5942050Z   CC       rsyslogd-omfile.o
+2025-10-09T20:06:30.6078930Z   CC       rsyslogd-ompipe.o
+2025-10-09T20:06:30.6196710Z   CC       rsyslogd-omdiscard.o
+2025-10-09T20:06:30.6325100Z   CC       rsyslogd-pmrfc3164.o
+2025-10-09T20:06:30.6463610Z   CC       rsyslogd-smtradfile.o
+2025-10-09T20:06:30.6565140Z   CC       rsyslogd-smfile.o
+2025-10-09T20:06:30.6670850Z   CC       rsyslogd-smfwd.o
+2025-10-09T20:06:30.6803420Z   CC       rsyslogd-smtradfwd.o
+2025-10-09T20:06:30.6949110Z   CC       rsyslogd-iminternal.o
+2025-10-09T20:06:30.6986370Z   CC       rsyslogd-pmrfc5424.o
+2025-10-09T20:06:31.7202420Z   CCLD     rsyslogd
+2025-10-09T20:06:32.7612270Z Making all in plugins/imklog
+2025-10-09T20:06:32.7730410Z   CC       imklog_la-bsd.lo
+2025-10-09T20:06:32.7739910Z   CC       imklog_la-imklog.lo
+2025-10-09T20:06:33.0609630Z   CCLD     imklog.la
+2025-10-09T20:06:33.2664850Z Making all in plugins/omstdout
+2025-10-09T20:06:33.2850410Z   CC       omstdout_la-omstdout.lo
+2025-10-09T20:06:33.5278960Z   CCLD     omstdout.la
+2025-10-09T20:06:33.7475140Z Making all in plugins/imdiag
+2025-10-09T20:06:33.7600090Z   CC       imdiag_la-imdiag.lo
+2025-10-09T20:06:33.9542510Z imdiag.c:772:5: warning: 'sem_destroy' is deprecated [-Wdeprecated-declarations]
+2025-10-09T20:06:33.9544290Z   772 |     sem_destroy(&statsReportingBlocker);
+2025-10-09T20:06:33.9545320Z       |     ^
+2025-10-09T20:06:33.9547200Z /Applications/Xcode_16.4.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/sys/semaphore.h:53:26: note: 'sem_destroy' has been explicitly marked deprecated here
+2025-10-09T20:06:33.9548700Z    53 | int sem_destroy(sem_t *) __deprecated;
+2025-10-09T20:06:33.9549100Z       |                          ^
+2025-10-09T20:06:33.9549740Z /Applications/Xcode_16.4.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/sys/cdefs.h:214:40: note: expanded from macro '__deprecated'
+2025-10-09T20:06:33.9550440Z   214 | #define __deprecated    __attribute__((__deprecated__))
+2025-10-09T20:06:33.9550810Z       |                                        ^
+2025-10-09T20:06:33.9559180Z imdiag.c:881:5: warning: 'sem_init' is deprecated [-Wdeprecated-declarations]
+2025-10-09T20:06:33.9560520Z   881 |     sem_init(&statsReportingBlocker, 0, 1);
+2025-10-09T20:06:33.9561530Z       |     ^
+2025-10-09T20:06:33.9563290Z /Applications/Xcode_16.4.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/sys/semaphore.h:55:42: note: 'sem_init' has been explicitly marked deprecated here
+2025-10-09T20:06:33.9565630Z    55 | int sem_init(sem_t *, int, unsigned int) __deprecated;
+2025-10-09T20:06:33.9566250Z       |                                          ^
+2025-10-09T20:06:33.9567740Z /Applications/Xcode_16.4.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/sys/cdefs.h:214:40: note: expanded from macro '__deprecated'
+2025-10-09T20:06:33.9570440Z   214 | #define __deprecated    __attribute__((__deprecated__))
+2025-10-09T20:06:33.9573730Z       |                                        ^
+2025-10-09T20:06:34.0526690Z 2 warnings generated.
+2025-10-09T20:06:34.1069390Z   CCLD     imdiag.la
+2025-10-09T20:06:34.3575420Z Making all in contrib/fmhash
+2025-10-09T20:06:34.3690350Z   CC       fmhash_la-fmhash.lo
+2025-10-09T20:06:34.6163610Z   CCLD     fmhash.la
+2025-10-09T20:06:34.8444920Z Making all in plugins/mmleefparse
+2025-10-09T20:06:34.8529590Z   CC       mmleefparse_la-mmleefparse.lo
+2025-10-09T20:06:35.1777090Z   CCLD     mmleefparse.la
+2025-10-09T20:06:35.3929470Z Making all in tests
+2025-10-09T20:06:35.4313310Z   CC       liboverride_gethostname_nonfqdn_la-override_gethostname_nonfqdn.lo
+2025-10-09T20:06:35.4336790Z   CC       liboverride_getaddrinfo_la-override_getaddrinfo.lo
+2025-10-09T20:06:35.4419690Z   CC       liboverride_gethostname_la-override_gethostname.lo
+2025-10-09T20:06:35.6906530Z   CCLD     liboverride_gethostname_nonfqdn.la
+2025-10-09T20:06:35.7658410Z   CCLD     liboverride_getaddrinfo.la
+2025-10-09T20:06:35.7706510Z   CCLD     liboverride_gethostname.la
+2025-10-09T20:06:36.1401850Z ##[group]Run df -h . | tail -1 | \
+2025-10-09T20:06:36.1402130Z [36;1mdf -h . | tail -1 | \[0m
+2025-10-09T20:06:36.1402440Z [36;1m  awk '{print "Free space before tests: " $4 " (" $5 " used)"}'[0m
+2025-10-09T20:06:36.1402780Z [36;1m# Clean up to free some space[0m
+2025-10-09T20:06:36.1402980Z [36;1mrm -rf /tmp/rsyslog-test-*[0m
+2025-10-09T20:06:36.1443900Z shell: /bin/bash -e {0}
+2025-10-09T20:06:36.1444110Z env:
+2025-10-09T20:06:36.1444240Z   USE_AUTO_DEBUG: true
+2025-10-09T20:06:36.1444390Z   ABORT_ALL_ON_TEST_FAIL: true
+2025-10-09T20:06:36.1444610Z ##[endgroup]
+2025-10-09T20:06:36.2408180Z Free space before tests: 87Gi (72% used)
+2025-10-09T20:06:36.2555450Z ##[group]Run sudo mkdir -p /cores
+2025-10-09T20:06:36.2556250Z [36;1msudo mkdir -p /cores[0m
+2025-10-09T20:06:36.2556880Z [36;1msudo sysctl -w kern.corefile=/cores/core-%P[0m
+2025-10-09T20:06:36.2642640Z shell: /bin/bash -e {0}
+2025-10-09T20:06:36.2643030Z env:
+2025-10-09T20:06:36.2643310Z   USE_AUTO_DEBUG: true
+2025-10-09T20:06:36.2643510Z   ABORT_ALL_ON_TEST_FAIL: true
+2025-10-09T20:06:36.2643730Z ##[endgroup]
+2025-10-09T20:06:36.3450700Z kern.corefile: /cores/core.%P -> /cores/core-%P
+2025-10-09T20:06:36.3488720Z ##[group]Run # Enable core dumps for debugging segfaults
+2025-10-09T20:06:36.3489160Z [36;1m# Enable core dumps for debugging segfaults[0m
+2025-10-09T20:06:36.3489430Z [36;1mulimit -c unlimited[0m
+2025-10-09T20:06:36.3489630Z [36;1m[0m
+2025-10-09T20:06:36.3489940Z [36;1m# Configure sanitizer options based on which one we're using[0m
+2025-10-09T20:06:36.3490250Z [36;1mif [ "tsan" = "asan" ]; then[0m
+2025-10-09T20:06:36.3490520Z [36;1m  echo "Configuring AddressSanitizer options"[0m
+2025-10-09T20:06:36.3491060Z [36;1m  export ASAN_OPTIONS="verbosity=1:halt_on_error=1:\[0m
+2025-10-09T20:06:36.3491400Z [36;1m    check_initialization_order=1:strict_init_order=1:\[0m
+2025-10-09T20:06:36.3491900Z [36;1m    detect_stack_use_after_return=1:print_stacktrace=1"[0m
+2025-10-09T20:06:36.3493140Z [36;1melif [ "tsan" = "tsan" ]; then[0m
+2025-10-09T20:06:36.3493500Z [36;1m  echo "Configuring ThreadSanitizer options"[0m
+2025-10-09T20:06:36.3493960Z [36;1m  export TSAN_OPTIONS="verbosity=1:halt_on_error=1:\[0m
+2025-10-09T20:06:36.3494320Z [36;1m    history_size=7:suppressions=$PWD/tests/tsan-rt.supp"[0m
+2025-10-09T20:06:36.3494630Z [36;1melse[0m
+2025-10-09T20:06:36.3494800Z [36;1m  echo "Running without sanitizers"[0m
+2025-10-09T20:06:36.3495000Z [36;1mfi[0m
+2025-10-09T20:06:36.3495120Z [36;1m[0m
+2025-10-09T20:06:36.3495250Z [36;1mmake -j8 check[0m
+2025-10-09T20:06:36.3530440Z shell: /bin/bash -e {0}
+2025-10-09T20:06:36.3530620Z env:
+2025-10-09T20:06:36.3530760Z   USE_AUTO_DEBUG: true
+2025-10-09T20:06:36.3530920Z   ABORT_ALL_ON_TEST_FAIL: true
+2025-10-09T20:06:36.3531090Z ##[endgroup]
+2025-10-09T20:06:36.4006390Z Configuring ThreadSanitizer options
+2025-10-09T20:06:36.4437650Z Making check in compat
+2025-10-09T20:06:36.4499410Z make[1]: Nothing to be done for `check'.
+2025-10-09T20:06:36.4502140Z Making check in runtime
+2025-10-09T20:06:36.5235990Z make[1]: Nothing to be done for `check'.
+2025-10-09T20:06:36.5238770Z Making check in grammar
+2025-10-09T20:06:36.5312340Z /Applications/Xcode_16.4.app/Contents/Developer/usr/bin/make  check-am
+2025-10-09T20:06:36.5414350Z make[2]: Nothing to be done for `check-am'.
+2025-10-09T20:06:36.5419940Z Making check in .
+2025-10-09T20:06:36.5682430Z Making check in plugins/immark
+2025-10-09T20:06:36.5781070Z make[1]: Nothing to be done for `check'.
+2025-10-09T20:06:36.5803850Z Making check in plugins/imuxsock
+2025-10-09T20:06:36.5893870Z make[1]: Nothing to be done for `check'.
+2025-10-09T20:06:36.5901110Z Making check in plugins/imtcp
+2025-10-09T20:06:36.6033890Z make[1]: Nothing to be done for `check'.
+2025-10-09T20:06:36.6037610Z Making check in plugins/imudp
+2025-10-09T20:06:36.6177160Z make[1]: Nothing to be done for `check'.
+2025-10-09T20:06:36.6179920Z Making check in plugins/omtesting
+2025-10-09T20:06:36.6301140Z make[1]: Nothing to be done for `check'.
+2025-10-09T20:06:36.6303810Z Making check in plugins/mmexternal
+2025-10-09T20:06:36.6405480Z make[1]: Nothing to be done for `check'.
+2025-10-09T20:06:36.6412490Z Making check in tools
+2025-10-09T20:06:36.6624830Z make[1]: Nothing to be done for `check'.
+2025-10-09T20:06:36.6632820Z Making check in plugins/imklog
+2025-10-09T20:06:36.6744010Z make[1]: Nothing to be done for `check'.
+2025-10-09T20:06:36.6749230Z Making check in plugins/omstdout
+2025-10-09T20:06:36.6901990Z make[1]: Nothing to be done for `check'.
+2025-10-09T20:06:36.6908980Z Making check in plugins/imdiag
+2025-10-09T20:06:36.7000800Z make[1]: Nothing to be done for `check'.
+2025-10-09T20:06:36.7003260Z Making check in contrib/fmhash
+2025-10-09T20:06:36.7157790Z make[1]: Nothing to be done for `check'.
+2025-10-09T20:06:36.7162690Z Making check in plugins/mmleefparse
+2025-10-09T20:06:36.7264430Z make[1]: Nothing to be done for `check'.
+2025-10-09T20:06:36.7266700Z Making check in tests
+2025-10-09T20:06:36.7519390Z /Applications/Xcode_16.4.app/Contents/Developer/usr/bin/make  ourtail tcpflood chkseq msleep randomgen diagtalker uxsockrcvr syslog_caller inputfilegen minitcpsrv omrelp_dflt_port mangle_qi have_relpSrvSetOversizeMode have_relpEngineSetTLSLibByName have_relpSrvSetTlsConfigCmd check_relpEngineVersion test_id  
+2025-10-09T20:06:36.7740100Z   CC       ourtail.o
+2025-10-09T20:06:36.7893930Z   CC       tcpflood-tcpflood.o
+2025-10-09T20:06:36.8005600Z   CC       chkseq.o
+2025-10-09T20:06:36.8181630Z   CC       msleep.o
+2025-10-09T20:06:36.8671020Z   CC       randomgen.o
+2025-10-09T20:06:36.8675250Z   CC       diagtalker.o
+2025-10-09T20:06:36.8888160Z   CC       uxsockrcvr.o
+2025-10-09T20:06:36.8989560Z   CC       syslog_caller-syslog_caller.o
+2025-10-09T20:06:37.1787390Z   CC       inputfilegen.o
+2025-10-09T20:06:37.2421520Z   CC       minitcpsrvr.o
+2025-10-09T20:06:37.2834270Z syslog_caller.c:46:70: warning: unused variable 'fmt' [-Wunused-variable]
+2025-10-09T20:06:37.2935550Z    46 | static enum { FMT_NATIVE, FMT_SYSLOG_INJECT_L, FMT_SYSLOG_INJECT_C } fmt = FMT_NATIVE;
+2025-10-09T20:06:37.3037130Z       |                                                                      ^~~
+2025-10-09T20:06:37.3139500Z minitcpsrvr.c:88:9: warning: declaration shadows a variable in the global scope [-Wshadow]
+2025-10-09T20:06:37.3241950Z    88 |     int opt = 1;
+2025-10-09T20:06:37.3242190Z   CC       omrelp_dflt_port.o
+2025-10-09T20:06:37.3343280Z       |         ^
+2025-10-09T20:06:37.3343480Z   CC       mangle_qi.o
+2025-10-09T20:06:37.3446260Z minitcpsrvr.c:51:5: note: previous declaration is here
+2025-10-09T20:06:37.3548150Z    51 | int opt;
+2025-10-09T20:06:37.3650130Z       |     ^
+2025-10-09T20:06:37.3650370Z   CC       have_relpSrvSetOversizeMode.o
+2025-10-09T20:06:37.3773570Z minitcpsrvr.c:157:9: warning: unused variable 'fdc' [-Wunused-variable]
+2025-10-09T20:06:37.3855330Z   157 |     int fdc;
+2025-10-09T20:06:37.3858950Z       |         ^~~
+2025-10-09T20:06:37.3859230Z minitcpsrvr.c:159:24: warning: unused variable 'cliAddr' [-Wunused-variable]
+2025-10-09T20:06:37.3859560Z   159 |     struct sockaddr_in cliAddr;
+2025-10-09T20:06:37.3859760Z       |                        ^~~~~~~
+2025-10-09T20:06:37.3860040Z minitcpsrvr.c:160:18: warning: unused variable 'cliAddrLen' [-Wunused-variable]
+2025-10-09T20:06:37.3860320Z   160 |     unsigned int cliAddrLen;
+2025-10-09T20:06:37.3860500Z       |                  ^~~~~~~~~~
+2025-10-09T20:06:37.3860890Z minitcpsrvr.c:301:83: warning: comparison of integers of different signs: 'size_t' (aka 'unsigned long') and 'int' [-Wsign-compare]
+2025-10-09T20:06:37.3861490Z   301 |                 if ((buffer_offs[i] == 0) && (dropConnection_NbrRcv > 0) && (nRcv >= dropConnection_NbrRcv) &&
+2025-10-09T20:06:37.3861810Z       |                                                                              ~~~~ ^  ~~~~~~~~~~~~~~~~~~~~~
+2025-10-09T20:06:37.3862090Z tcpflood.c:550:10: warning: unused variable 'msgBuf' [-Wunused-variable]
+2025-10-09T20:06:37.3862330Z   550 |     char msgBuf[128];
+2025-10-09T20:06:37.3862520Z       |          ^~~~~~
+2025-10-09T20:06:37.3862740Z tcpflood.c:551:12: warning: unused variable 'lenMsg' [-Wunused-variable]
+2025-10-09T20:06:37.3863050Z   551 |     size_t lenMsg;
+2025-10-09T20:06:37.3863230Z       |            ^~~~~~
+2025-10-09T20:06:37.3863540Z tcpflood.c:772:54: warning: comparison of integers of different signs: 'int' and 'unsigned long' [-Wsign-compare]
+2025-10-09T20:06:37.3863990Z   772 |         if (payloadStringLen < 0 || payloadStringLen >= sizeof(payloadLen)) {
+2025-10-09T20:06:37.3864580Z       |                                     ~~~~~~~~~~~~~~~~ ^  ~~~~~~~~~~~~~~~~~~
+2025-10-09T20:06:37.3865100Z tcpflood.c:868:58: warning: incompatible pointer types passing 'struct sockaddr_in *' to parameter of type 'const struct sockaddr *' [-Wincompatible-pointer-types]
+2025-10-09T20:06:37.3865650Z   868 |             lenSend = sendto(udpsockout, buf, lenBuf, 0, &udpRcvr, sizeof(udpRcvr));
+2025-10-09T20:06:37.3865940Z       |                                                          ^~~~~~~~
+2025-10-09T20:06:37.3866960Z /Applications/Xcode_16.4.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/sys/socket.h:725:33: note: passing argument to parameter here
+2025-10-09T20:06:37.3870080Z   725 |     int, const struct sockaddr *, socklen_t) __DARWIN_ALIAS_C(sendto);
+2025-10-09T20:06:37.3870370Z       |                                 ^
+2025-10-09T20:06:37.3870750Z tcpflood.c:884:36: warning: comparison of integers of different signs: 'size_t' (aka 'unsigned long') and 'int' [-Wsign-compare]
+2025-10-09T20:06:37.3871180Z   884 |                 lenSend = (lenSend == offsSendBuf) ? lenBuf : -1;
+2025-10-09T20:06:37.3871420Z       |                            ~~~~~~~ ^  ~~~~~~~~~~~
+2025-10-09T20:06:37.3871810Z tcpflood.c:946:33: warning: comparison of integers of different signs: 'size_t' (aka 'unsigned long') and 'int' [-Wsign-compare]
+2025-10-09T20:06:37.3872230Z   946 |                     if (lenSend != offsSendBuf) {
+2025-10-09T20:06:37.3872450Z       |                         ~~~~~~~ ^  ~~~~~~~~~~~
+2025-10-09T20:06:37.3872860Z tcpflood.c:1910:20: warning: comparison of integers of different signs: 'int' and 'size_t' (aka 'unsigned long') [-Wsign-compare]
+2025-10-09T20:06:37.3873240Z  1910 |     while (lenSent != lenBuf) {
+2025-10-09T20:06:37.3873430Z       |            ~~~~~~~ ^  ~~~~~~
+2025-10-09T20:06:37.3873610Z 1 warning generated.
+2025-10-09T20:06:37.3968160Z   CC       have_relpEngineSetTLSLibByName.o
+2025-10-09T20:06:37.4191640Z   CC       have_relpSrvSetTlsConfigCmd.o
+2025-10-09T20:06:37.4602320Z   CC       check_relpEngineVersion.o
+2025-10-09T20:06:37.4687300Z tcpflood.c:295:13: warning: unused function 'initDTLSSess' [-Wunused-function]
+2025-10-09T20:06:37.4788710Z   295 | static void initDTLSSess(void);
+2025-10-09T20:06:37.4788990Z   CC       test_id.o
+2025-10-09T20:06:37.4893260Z       |             ^~~~~~~~~~~~
+2025-10-09T20:06:37.4893970Z tcpflood.c:296:12: warning: unused function 'sendDTLS' [-Wunused-function]
+2025-10-09T20:06:37.4894360Z   296 | static int sendDTLS(char *buf, size_t lenBuf);
+2025-10-09T20:06:37.4894660Z       |            ^~~~~~~~
+2025-10-09T20:06:37.4894930Z tcpflood.c:297:13: warning: unused function 'closeDTLSSess' [-Wunused-function]
+2025-10-09T20:06:37.4895240Z   297 | static void closeDTLSSess(void);
+2025-10-09T20:06:37.4895430Z       |             ^~~~~~~~~~~~~
+2025-10-09T20:06:37.5099290Z   CCLD     ourtail
+2025-10-09T20:06:37.5432340Z check_relpEngineVersion.c:26:10: warning: unused variable 'iRelpVerMajor' [-Wunused-variable]
+2025-10-09T20:06:37.5533780Z    26 |     long iRelpVerMajor = 0;
+2025-10-09T20:06:37.5635280Z       |          ^~~~~~~~~~~~~
+2025-10-09T20:06:37.5708480Z   CCLD     chkseq
+2025-10-09T20:06:37.5738450Z check_relpEngineVersion.c:27:10: warning: unused variable 'iRelpVerMinor' [-Wunused-variable]
+2025-10-09T20:06:37.5808330Z   CCLD     msleep
+2025-10-09T20:06:37.5840160Z    27 |     long iRelpVerMinor = 0;
+2025-10-09T20:06:37.5922890Z       |          ^~~~~~~~~~~~~
+2025-10-09T20:06:37.5924210Z check_relpEngineVersion.c:28:10: warning: unused variable 'iRelpVerSubMinor' [-Wunused-variable]
+2025-10-09T20:06:37.5924650Z    28 |     long iRelpVerSubMinor = 0;
+2025-10-09T20:06:37.5924950Z       |          ^~~~~~~~~~~~~~~~
+2025-10-09T20:06:37.5925380Z check_relpEngineVersion.c:29:10: warning: unused variable 'iRelpCmpMajor' [-Wunused-variable]
+2025-10-09T20:06:37.5925780Z    29 |     long iRelpCmpMajor = 0;
+2025-10-09T20:06:37.5926070Z       |          ^~~~~~~~~~~~~
+2025-10-09T20:06:37.5926460Z check_relpEngineVersion.c:30:10: warning: unused variable 'iRelpCmpMinor' [-Wunused-variable]
+2025-10-09T20:06:37.5926860Z    30 |     long iRelpCmpMinor = 0;
+2025-10-09T20:06:37.5927120Z       |          ^~~~~~~~~~~~~
+2025-10-09T20:06:37.5927500Z check_relpEngineVersion.c:31:10: warning: unused variable 'iRelpCmpSubMinor' [-Wunused-variable]
+2025-10-09T20:06:37.5927910Z    31 |     long iRelpCmpSubMinor = 0;
+2025-10-09T20:06:37.5931600Z       |          ^~~~~~~~~~~~~~~~
+2025-10-09T20:06:37.5934590Z test_id.c:32:27: warning: format specifies type 'long' but the argument has type '__darwin_suseconds_t' (aka 'int') [-Wformat]
+2025-10-09T20:06:37.5936790Z    32 |     printf("%06ld_%4.4x", tv.tv_usec, hash_from_string(argv[1]));
+2025-10-09T20:06:37.5937970Z       |             ~~~~~         ^~~~~~~~~~
+2025-10-09T20:06:37.5938450Z       |             %06d
+2025-10-09T20:06:37.5938840Z 6 warnings generated.
+2025-10-09T20:06:37.6137230Z   CCLD     randomgen
+2025-10-09T20:06:37.6337940Z 1 warning5 warnings generated.
+2025-10-09T20:06:37.6439130Z  generated.
+2025-10-09T20:06:37.7081270Z   CCLD     uxsockrcvr
+2025-10-09T20:06:37.7182170Z   CCLD     diagtalker
+2025-10-09T20:06:37.7285270Z   CCLD     syslog_caller
+2025-10-09T20:06:37.8830510Z   CCLD     inputfilegen
+2025-10-09T20:06:38.0057360Z   CCLD     minitcpsrv
+2025-10-09T20:06:38.0061870Z   CCLD     omrelp_dflt_port
+2025-10-09T20:06:38.0382520Z   CCLD     mangle_qi
+2025-10-09T20:06:38.1837580Z   CCLD     have_relpSrvSetOversizeMode
+2025-10-09T20:06:38.2984270Z   CCLD     have_relpEngineSetTLSLibByName
+2025-10-09T20:06:38.3086240Z   CCLD     have_relpSrvSetTlsConfigCmd
+2025-10-09T20:06:38.5052330Z   CCLD     test_id
+2025-10-09T20:06:38.5158890Z   CCLD     check_relpEngineVersion
+2025-10-09T20:06:38.7097120Z 10 warnings generated.
+2025-10-09T20:06:38.7601760Z   CCLD     tcpflood
+2025-10-09T20:06:38.9796430Z /Applications/Xcode_16.4.app/Contents/Developer/usr/bin/make  check-TESTS
+2025-10-09T20:06:51.5617450Z PASS: fromhost-port-async-ruleset.sh
+2025-10-09T20:06:52.1722300Z PASS: fromhost-port.sh
+2025-10-09T20:06:52.1929420Z PASS: allowed-sender-tcp-fail.sh
+2025-10-09T20:06:52.2563000Z PASS: imtcp-discard-truncated-msg.sh
+2025-10-09T20:06:52.4370690Z PASS: fromhost-port-tuple.sh
+2025-10-09T20:06:52.8714160Z PASS: allowed-sender-tcp-ok.sh
+2025-10-09T20:06:53.2161220Z PASS: allowed-sender-tcp-hostname-fail.sh
+2025-10-09T20:07:02.6035130Z PASS: allowed-sender-tcp-hostname-ok.sh
+2025-10-09T20:07:04.3808580Z PASS: imtcp-maxFrameSize.sh
+2025-10-09T20:07:05.2015780Z PASS: imtcp-msg-truncation-on-number.sh
+2025-10-09T20:07:05.7511940Z PASS: imtcp-starvation-0.sh
+2025-10-09T20:07:05.9594020Z PASS: imtcp-basic.sh
+2025-10-09T20:07:06.3550810Z PASS: imtcp-basic-hup.sh
+2025-10-09T20:07:07.4721100Z PASS: imtcp-starvation-1.sh
+2025-10-09T20:07:11.9240330Z PASS: imtcp-impstats-single-thread.sh
+2025-10-09T20:07:13.5564540Z SKIP: manytcp.sh
+2025-10-09T20:07:15.3408300Z PASS: imtcp-NUL.sh
+2025-10-09T20:07:16.0765300Z PASS: imtcp-NUL-rawmsg.sh
+2025-10-09T20:07:16.2615900Z PASS: imtcp_incomplete_frame_at_end.sh
+2025-10-09T20:07:18.2422920Z PASS: imtcp-bigmessage-octetcounting.sh
+2025-10-09T20:07:20.1022850Z PASS: imtcp-bigmessage-octetstuffing.sh
+2025-10-09T20:07:21.7878900Z PASS: imtcp-msg-truncation-on-number2.sh
+2025-10-09T20:07:24.2173150Z PASS: imtcp-multiport.sh
+2025-10-09T20:07:27.1765730Z PASS: imtcp_no_octet_counted.sh
+2025-10-09T20:07:29.2026790Z PASS: imtcp_spframingfix.sh
+2025-10-09T20:07:29.2434480Z PASS: imtcp_addtlframedelim.sh
+2025-10-09T20:07:29.7339530Z PASS: imtcp-connection-msg-recieved.sh
+2025-10-09T20:07:30.2821130Z PASS: imtcp_addtlframedelim_on_input.sh
+2025-10-09T20:07:39.1101150Z PASS: omstdout-basic.sh
+2025-10-09T20:07:45.5679510Z PASS: sndrcv_udp_nonstdpt.sh
+2025-10-09T20:07:52.4133670Z PASS: sndrcv.sh
+2025-10-09T20:07:55.6173510Z PASS: imtcp_conndrop.sh
+2025-10-09T20:07:56.7552110Z PASS: sndrcv_udp_nonstdpt_v6.sh
+2025-10-09T20:07:58.4578170Z PASS: sndrcv_failover.sh
+2025-10-09T20:07:59.0427030Z PASS: sndrcv_gzip.sh
+2025-10-09T20:08:08.2370840Z PASS: imtcp-tls-gibberish.sh
+2025-10-09T20:08:08.2473050Z PASS: imtcp-tls-basic-verifydepth.sh
+2025-10-09T20:08:11.2929990Z PASS: imtcp-tls-input-basic.sh
+2025-10-09T20:08:18.4231470Z PASS: imtcp-tls-input-2certs.sh
+2025-10-09T20:08:31.1518760Z PASS: sndrcv_tls_anon_hostname.sh
+2025-10-09T20:08:37.0907250Z PASS: sndrcv_tls_certless_clientonly.sh
+2025-10-09T20:08:39.0388030Z PASS: sndrcv_tls_gtls_servercert_gtls_clientanon.sh
+2025-10-09T20:08:40.0343610Z PASS: sndrcv_tls_anon_ipv4.sh
+2025-10-09T20:08:45.4570120Z PASS: sndrcv_tls_anon_ipv6.sh
+2025-10-09T20:08:45.6914920Z FAIL: imtcp-tls-basic.sh
+2025-10-09T20:09:01.1356950Z PASS: imtcp_conndrop_tls.sh
+2025-10-09T20:09:04.2065750Z PASS: sndrcv_tls_gtls_servercert_gtls_clientanon_legacy.sh
+2025-10-09T20:09:08.0228000Z PASS: sndrcv_tls_gtls_serveranon_gtls_clientanon.sh
+2025-10-09T20:09:09.6182160Z SKIP: sndrcv_tls_client_missing_cert.sh
+2025-10-09T20:09:10.8796470Z PASS: sndrcv_tls_certvalid_expired.sh
+2025-10-09T20:09:18.3519510Z PASS: sndrcv_tls_priorityString.sh
+2025-10-09T20:09:27.4376700Z PASS: imtcp-tls-no-lstn-startup.sh
+2025-10-09T20:09:32.6135540Z PASS: sndrcv_tls_certvalid.sh
+2025-10-09T20:09:32.8544100Z PASS: imtcp-tls-gtls-x509fingerprint-invld.sh
+2025-10-09T20:09:36.2071040Z PASS: sndrcv_tls_certvalid_revoked.sh
+2025-10-09T20:09:53.9607470Z PASS: imtcp-tls-gtls-x509name-invld.sh
+2025-10-09T20:09:54.4488590Z PASS: imtcp-tls-gtls-x509name-legacy.sh
+2025-10-09T20:09:54.8677510Z PASS: imtcp-tls-gtls-x509name.sh
+2025-10-09T20:10:02.8345780Z PASS: imtcp-drvr-in-input-basic.sh
+2025-10-09T20:10:03.2833620Z PASS: sndrcv_tls_certvalid_expired_defaultmode.sh
+2025-10-09T20:10:03.9318800Z PASS: imtcp-tls-gtls-x509fingerprint.sh
+2025-10-09T20:10:04.3341740Z PASS: sndrcv_tls_certvalid_action_level.sh
+2025-10-09T20:10:16.9981690Z PASS: imtcp-multi-drvr-basic.sh
+2025-10-09T20:10:17.0968840Z PASS: imtcp-multi-drvr-basic-parallel.sh
+2025-10-09T20:10:44.5196650Z PASS: sndrcv_tls_anon_rebind.sh
+2025-10-09T20:10:44.6889410Z ============================================================================
+2025-10-09T20:10:44.6902460Z Testsuite summary for rsyslog 8.2510.0.daily
+2025-10-09T20:10:44.6904990Z ============================================================================
+2025-10-09T20:10:44.6905290Z # TOTAL: 66
+2025-10-09T20:10:44.6905490Z # PASS:  63
+2025-10-09T20:10:44.6905750Z # SKIP:  2
+2025-10-09T20:10:44.6905930Z # XFAIL: 0
+2025-10-09T20:10:44.6906150Z # FAIL:  1
+2025-10-09T20:10:44.6906310Z # XPASS: 0
+2025-10-09T20:10:44.6906550Z # ERROR: 0
+2025-10-09T20:10:44.6906970Z ============================================================================
+2025-10-09T20:10:44.6907280Z See tests/test-suite.log for debugging.
+2025-10-09T20:10:44.6931120Z Some test(s) failed.  Please report this to rsyslog@lists.adiscon.com,
+2025-10-09T20:10:44.6931780Z together with the test-suite.log file (gzipped) and your system
+2025-10-09T20:10:44.6933760Z make[3]: *** [test-suite.log] Error 1
+2025-10-09T20:10:44.6934400Z information.  Thanks.
+2025-10-09T20:10:44.6936600Z ============================================================================
+2025-10-09T20:10:44.6966140Z make[2]: *** [check-TESTS] Error 2
+2025-10-09T20:10:44.6979620Z make[1]: *** [check-am] Error 2
+2025-10-09T20:10:44.7006280Z make: *** [check-recursive] Error 1
+2025-10-09T20:10:44.7047930Z ##[error]Process completed with exit code 2.
+2025-10-09T20:10:44.7304910Z ##[group]Run echo "=== Post-failure diagnostics ==="
+2025-10-09T20:10:44.7305800Z [36;1mecho "=== Post-failure diagnostics ==="[0m
+2025-10-09T20:10:44.7306770Z [36;1mecho "Note: Comprehensive error analysis including core dumps,"[0m
+2025-10-09T20:10:44.7308300Z [36;1mecho "system info, and logs is now handled automatically by"[0m
+2025-10-09T20:10:44.7309130Z [36;1mecho "tests/diag.sh during test failures."[0m
+2025-10-09T20:10:44.7312040Z [36;1mecho ""[0m
+2025-10-09T20:10:44.7312260Z [36;1mecho "=== Basic disk space check ==="[0m
+2025-10-09T20:10:44.7312590Z [36;1mdf -h . | tail -1 | awk '{print "Free space: " $4 " (" $5 " used)"}'[0m
+2025-10-09T20:10:44.7312880Z [36;1mecho ""[0m
+2025-10-09T20:10:44.7313140Z [36;1mecho "=== Additional error log collection ==="[0m
+2025-10-09T20:10:44.7313440Z [36;1mif [ -f "devtools/gather-check-logs.sh" ]; then[0m
+2025-10-09T20:10:44.7313720Z [36;1m  devtools/gather-check-logs.sh[0m
+2025-10-09T20:10:44.7313990Z [36;1mfi[0m
+2025-10-09T20:10:44.7314290Z [36;1mif [ -f "failed-tests.log" ]; then[0m
+2025-10-09T20:10:44.7314550Z [36;1m  echo "=== Failed Tests Summary ==="[0m
+2025-10-09T20:10:44.7318280Z [36;1m  cat failed-tests.log[0m
+2025-10-09T20:10:44.7318480Z [36;1mfi[0m
+2025-10-09T20:10:44.7540930Z shell: /bin/bash -e {0}
+2025-10-09T20:10:44.7541170Z env:
+2025-10-09T20:10:44.7541360Z   USE_AUTO_DEBUG: true
+2025-10-09T20:10:44.7541590Z   ABORT_ALL_ON_TEST_FAIL: true
+2025-10-09T20:10:44.7541830Z ##[endgroup]
+2025-10-09T20:10:44.8136810Z === Post-failure diagnostics ===
+2025-10-09T20:10:44.8138110Z Note: Comprehensive error analysis including core dumps,
+2025-10-09T20:10:44.8140480Z system info, and logs is now handled automatically by
+2025-10-09T20:10:44.8142650Z tests/diag.sh during test failures.
+2025-10-09T20:10:44.8145890Z 
+2025-10-09T20:10:44.8155960Z === Basic disk space check ===
+2025-10-09T20:10:44.8198220Z Free space: 87Gi (72% used)
+2025-10-09T20:10:44.8202970Z 
+2025-10-09T20:10:44.8203790Z === Additional error log collection ===
+2025-10-09T20:10:44.8239830Z find failing tests
+2025-10-09T20:10:46.4405030Z === Failed Tests Summary ===
+2025-10-09T20:10:46.4429870Z 
+2025-10-09T20:10:46.4430730Z FAIL: ./tests/imtcp-tls-basic 		########################################################		################################
+2025-10-09T20:10:46.4431230Z 
+2025-10-09T20:10:46.4431410Z ==24821==Installed the sigaction for signal 11
+2025-10-09T20:10:46.4431710Z ==24821==Installed the sigaction for signal 10
+2025-10-09T20:10:46.4432280Z ==24821==Installed the sigaction for signal 8
+2025-10-09T20:10:46.4432780Z ThreadSanitizer: reading suppressions file at /Users/runner/work/rsyslog/rsyslog/tests/tsan-rt.supp
+2025-10-09T20:10:46.4433290Z ThreadSanitizer: parsing '# supressions for LLVM TSAN
+2025-10-09T20:10:46.4433680Z # doc: https://github.com/google/sanitizers/wiki/ThreadSanitizerSuppressions
+2025-10-09T20:10:46.4434690Z race:^close$
+2025-10-09T20:10:46.4435060Z race:^closeSess$
+2025-10-09T20:10:46.4435360Z race:^bs_arrcmp_glblDbgFiles$
+2025-10-09T20:10:46.4435660Z race:^imptcp_destruct_epd$
+2025-10-09T20:10:46.4435890Z race:doLogMsg
+2025-10-09T20:10:46.4436390Z race:setlocale
+2025-10-09T20:10:46.4436760Z race:doSIGTTIN
+2025-10-09T20:10:46.4437050Z '
+2025-10-09T20:10:46.4437320Z ThreadSanitizer: parsed suppression entry '^close$'
+2025-10-09T20:10:46.4437720Z ThreadSanitizer: parsed suppression entry '^closeSess$'
+2025-10-09T20:10:46.4438080Z ThreadSanitizer: parsed suppression entry '^bs_arrcmp_glblDbgFiles$'
+2025-10-09T20:10:46.4438640Z ThreadSanitizer: parsed suppression entry '^imptcp_destruct_epd$'
+2025-10-09T20:10:46.4439320Z ThreadSanitizer: parsed suppression entry 'doLogMsg'
+2025-10-09T20:10:46.4439880Z ThreadSanitizer: parsed suppression entry 'setlocale'
+2025-10-09T20:10:46.4440290Z ThreadSanitizer: parsed suppression entry 'doSIGTTIN'
+2025-10-09T20:10:46.4440590Z ThreadSanitizer: parsing '<null>'
+2025-10-09T20:10:46.4440850Z ThreadSanitizer: parsing 'race:^_M_rep$
+2025-10-09T20:10:46.4441130Z race:^_M_is_leaked$
+2025-10-09T20:10:46.4445430Z race:std::_Sp_counted_ptr_inplace<std::thread::_Impl
+2025-10-09T20:10:46.4445670Z mutex:ConvertMatchingCGEvents
+2025-10-09T20:10:46.4445930Z mutex:AcquireCoalescingStack
+2025-10-09T20:10:46.4466680Z mutex:CFRunLoopRunSpecific
+2025-10-09T20:10:46.4466990Z mutex:QuartzCore::post_notification
+2025-10-09T20:10:46.4469320Z '
+2025-10-09T20:10:46.4469660Z ThreadSanitizer: parsed suppression entry '^_M_rep$'
+2025-10-09T20:10:46.4470180Z ThreadSanitizer: parsed suppression entry '^_M_is_leaked$'
+2025-10-09T20:10:46.4470620Z ThreadSanitizer: parsed suppression entry 'std::_Sp_counted_ptr_inplace<std::thread::_Impl'
+2025-10-09T20:10:46.4471160Z ThreadSanitizer: parsed suppression entry 'ConvertMatchingCGEvents'
+2025-10-09T20:10:46.4471570Z ThreadSanitizer: parsed suppression entry 'AcquireCoalescingStack'
+2025-10-09T20:10:46.4472070Z ThreadSanitizer: parsed suppression entry 'CFRunLoopRunSpecific'
+2025-10-09T20:10:46.4472550Z ThreadSanitizer: parsed suppression entry 'QuartzCore::post_notification'
+2025-10-09T20:10:46.4473160Z ==24821==Adding instrumented range 0x000102aa8000-0x000102aac000 from library '/Users/runner/work/rsyslog/rsyslog/tests/test_id'
+2025-10-09T20:10:46.4474100Z ==24821==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4474460Z ==24821==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4474840Z ==24821==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4475200Z ==24821==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4476160Z ==24821==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4476570Z ==24821==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4476910Z ==24821==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4477340Z ==24821==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4477670Z ==24821==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4478030Z ==24821==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4478380Z ==24821==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4478810Z ==24821==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4479160Z ==24821==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4479500Z ==24821==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4479940Z ==24821==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4480270Z ==24821==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4480610Z ***** Running under ThreadSanitizer v3 (pid 24821) *****
+2025-10-09T20:10:46.4481010Z Stats: LargeMmapAllocator: allocated 0 times, remains 0 (0 K) max 0 M; by size logs: 
+2025-10-09T20:10:46.4481560Z Stats: LargeMmapAllocator: allocated 0 times, remains 0 (0 K) max 0 M; by size logs: 
+2025-10-09T20:10:46.4481950Z testbench: TZ env var not set, setting it to UTC
+2025-10-09T20:10:46.4482250Z ------------------------------------------------------------
+2025-10-09T20:10:46.4482590Z 20:07:31[0]  Test: ./imtcp-tls-basic.sh
+2025-10-09T20:10:46.4482850Z ------------------------------------------------------------
+2025-10-09T20:10:46.4483120Z config rstb_827335_d720e136xlAI_.conf is:
+2025-10-09T20:10:46.4483390Z      1	module(load="../plugins/imdiag/.libs/imdiag")
+2025-10-09T20:10:46.4483750Z      2	global(inputs.timeout.shutdown="60000"
+2025-10-09T20:10:46.4484030Z      3	       default.action.queue.timeoutshutdown="20000"
+2025-10-09T20:10:46.4484340Z      4	       default.action.queue.timeoutEnqueue="20000"
+2025-10-09T20:10:46.4484690Z      5	       debug.abortOnProgramError="on")
+2025-10-09T20:10:46.4485050Z      6	# use legacy-style for the following settings so that we can override if needed
+2025-10-09T20:10:46.4485460Z      7	$MainmsgQueueTimeoutEnqueue 20000
+2025-10-09T20:10:46.4485720Z      8	$MainmsgQueueTimeoutShutdown 10000
+2025-10-09T20:10:46.4486340Z      9	$IMDiagListenPortFileName rstb_827335_d720e136xlAI.imdiag.port
+2025-10-09T20:10:46.4486600Z     10	$IMDiagServerRun 0
+2025-10-09T20:10:46.4486900Z     11	$IMDiagAbortTimeout 1500
+2025-10-09T20:10:46.4487050Z     12	
+2025-10-09T20:10:46.4487300Z     13	:syslogtag, contains, "rsyslogd"  ./rstb_827335_d720e136xlAI.started
+2025-10-09T20:10:46.4487640Z     14	###### end of testbench instrumentation part, test conf follows:
+2025-10-09T20:10:46.4487920Z     15	
+2025-10-09T20:10:46.4488170Z     16	global( defaultNetstreamDriverCAFile="./tls-certs/ca.pem"
+2025-10-09T20:10:46.4488520Z     17		defaultNetstreamDriverCertFile="./tls-certs/cert.pem"
+2025-10-09T20:10:46.4488800Z     18		defaultNetstreamDriverKeyFile="./tls-certs/key.pem")
+2025-10-09T20:10:46.4489050Z     19	
+2025-10-09T20:10:46.4489200Z     20	module(load="../plugins/imtcp/.libs/imtcp"
+2025-10-09T20:10:46.4489400Z     21		StreamDriver.Name="gtls"
+2025-10-09T20:10:46.4489600Z     22		StreamDriver.Mode="1"
+2025-10-09T20:10:46.4489780Z     23		StreamDriver.AuthMode="anon" )
+2025-10-09T20:10:46.4489950Z     24	
+2025-10-09T20:10:46.4490210Z     25	input(type="imtcp" port="0" listenPortFileName="rstb_827335_d720e136xlAI.tcpflood_port")
+2025-10-09T20:10:46.4490490Z     26	
+2025-10-09T20:10:46.4490850Z     27	template(name="outfmt" type="string" string="%msg:F,58:2%\n")
+2025-10-09T20:10:46.4491250Z     28	:msg, contains, "msgnum:" action(type="omfile" file="rstb_827335_d720e136xlAI.out.log" template="outfmt")
+2025-10-09T20:10:46.4491610Z ==24942==Installed the sigaction for signal 11
+2025-10-09T20:10:46.4491830Z ==24942==Installed the sigaction for signal 10
+2025-10-09T20:10:46.4492060Z ==24942==Installed the sigaction for signal 8
+2025-10-09T20:10:46.4492280Z ==24944==Installed the sigaction for signal 11
+2025-10-09T20:10:46.4492500Z ==24944==Installed the sigaction for signal 10
+2025-10-09T20:10:46.4492710Z ==24944==Installed the sigaction for signal 8
+2025-10-09T20:10:46.4493070Z ThreadSanitizer: reading suppressions file at /Users/runner/work/rsyslog/rsyslog/tests/tsan-rt.supp
+2025-10-09T20:10:46.4493670Z ThreadSanitizer: parsing '# supressions for LLVM TSAN
+2025-10-09T20:10:46.4494020Z # doc: https://github.com/google/sanitizers/wiki/ThreadSanitizerSuppressions
+2025-10-09T20:10:46.4494310Z race:^close$
+2025-10-09T20:10:46.4494430Z race:^closeSess$
+2025-10-09T20:10:46.4494570Z race:^bs_arrcmp_glblDbgFiles$
+2025-10-09T20:10:46.4494740Z race:^imptcp_destruct_epd$
+2025-10-09T20:10:46.4494880Z race:doLogMsg
+2025-10-09T20:10:46.4494990Z race:setlocale
+2025-10-09T20:10:46.4495100Z race:doSIGTTIN
+2025-10-09T20:10:46.4495210Z '
+2025-10-09T20:10:46.4495470Z ThreadSanitizer: reading suppressions file at /Users/runner/work/rsyslog/rsyslog/tests/tsan-rt.supp
+2025-10-09T20:10:46.4495860Z ThreadSanitizer: parsing '# supressions for LLVM TSAN
+2025-10-09T20:10:46.4496390Z # doc: https://github.com/google/sanitizers/wiki/ThreadSanitizerSuppressions
+2025-10-09T20:10:46.4496650Z race:^close$
+2025-10-09T20:10:46.4496760Z race:^closeSess$
+2025-10-09T20:10:46.4496910Z race:^bs_arrcmp_glblDbgFiles$
+2025-10-09T20:10:46.4497070Z race:^imptcp_destruct_epd$
+2025-10-09T20:10:46.4497220Z race:doLogMsg
+2025-10-09T20:10:46.4497370Z race:setlocale
+2025-10-09T20:10:46.4497480Z race:doSIGTTIN
+2025-10-09T20:10:46.4497590Z '
+2025-10-09T20:10:46.4497750Z ThreadSanitizer: parsed suppression entry '^close$'
+2025-10-09T20:10:46.4498020Z ThreadSanitizer: parsed suppression entry '^closeSess$'
+2025-10-09T20:10:46.4498330Z ThreadSanitizer: parsed suppression entry '^bs_arrcmp_glblDbgFiles$'
+2025-10-09T20:10:46.4498670Z ThreadSanitizer: parsed suppression entry '^imptcp_destruct_epd$'
+2025-10-09T20:10:46.4498950Z ThreadSanitizer: parsed suppression entry 'doLogMsg'
+2025-10-09T20:10:46.4499210Z ThreadSanitizer: parsed suppression entry 'setlocale'
+2025-10-09T20:10:46.4499480Z ThreadSanitizer: parsed suppression entry 'doSIGTTIN'
+2025-10-09T20:10:46.4499690Z ThreadSanitizer: parsing '<null>'
+2025-10-09T20:10:46.4499890Z ThreadSanitizer: parsing 'race:^_M_rep$
+2025-10-09T20:10:46.4500060Z race:^_M_is_leaked$
+2025-10-09T20:10:46.4500400Z race:std::_Sp_counted_ptr_inplace<std::thread::_Impl
+2025-10-09T20:10:46.4500610Z mutex:ConvertMatchingCGEvents
+2025-10-09T20:10:46.4500800Z mutex:AcquireCoalescingStack
+2025-10-09T20:10:46.4500970Z mutex:CFRunLoopRunSpecific
+2025-10-09T20:10:46.4501150Z mutex:QuartzCore::post_notification
+2025-10-09T20:10:46.4501330Z '
+2025-10-09T20:10:46.4501500Z ThreadSanitizer: parsed suppression entry '^_M_rep$'
+2025-10-09T20:10:46.4501770Z ThreadSanitizer: parsed suppression entry '^_M_is_leaked$'
+2025-10-09T20:10:46.4502130Z ThreadSanitizer: parsed suppression entry 'std::_Sp_counted_ptr_inplace<std::thread::_Impl'
+2025-10-09T20:10:46.4502540Z ThreadSanitizer: parsed suppression entry 'ConvertMatchingCGEvents'
+2025-10-09T20:10:46.4502880Z ThreadSanitizer: parsed suppression entry 'AcquireCoalescingStack'
+2025-10-09T20:10:46.4503220Z ThreadSanitizer: parsed suppression entry 'CFRunLoopRunSpecific'
+2025-10-09T20:10:46.4503590Z ThreadSanitizer: parsed suppression entry 'QuartzCore::post_notification'
+2025-10-09T20:10:46.4503890Z ThreadSanitizer: parsed suppression entry '^close$'
+2025-10-09T20:10:46.4504160Z ThreadSanitizer: parsed suppression entry '^closeSess$'
+2025-10-09T20:10:46.4504460Z ThreadSanitizer: parsed suppression entry '^bs_arrcmp_glblDbgFiles$'
+2025-10-09T20:10:46.4504890Z ThreadSanitizer: parsed suppression entry '^imptcp_destruct_epd$'
+2025-10-09T20:10:46.4505180Z ThreadSanitizer: parsed suppression entry 'doLogMsg'
+2025-10-09T20:10:46.4505440Z ThreadSanitizer: parsed suppression entry 'setlocale'
+2025-10-09T20:10:46.4505710Z ThreadSanitizer: parsed suppression entry 'doSIGTTIN'
+2025-10-09T20:10:46.4505940Z ThreadSanitizer: parsing '<null>'
+2025-10-09T20:10:46.4506130Z ThreadSanitizer: parsing 'race:^_M_rep$
+2025-10-09T20:10:46.4506310Z race:^_M_is_leaked$
+2025-10-09T20:10:46.4506500Z race:std::_Sp_counted_ptr_inplace<std::thread::_Impl
+2025-10-09T20:10:46.4506710Z mutex:ConvertMatchingCGEvents
+2025-10-09T20:10:46.4506930Z mutex:AcquireCoalescingStack
+2025-10-09T20:10:46.4507090Z mutex:CFRunLoopRunSpecific
+2025-10-09T20:10:46.4507280Z mutex:QuartzCore::post_notification
+2025-10-09T20:10:46.4507440Z '
+2025-10-09T20:10:46.4507590Z ThreadSanitizer: parsed suppression entry '^_M_rep$'
+2025-10-09T20:10:46.4507850Z ThreadSanitizer: parsed suppression entry '^_M_is_leaked$'
+2025-10-09T20:10:46.4508250Z ThreadSanitizer: parsed suppression entry 'std::_Sp_counted_ptr_inplace<std::thread::_Impl'
+2025-10-09T20:10:46.4508650Z ThreadSanitizer: parsed suppression entry 'ConvertMatchingCGEvents'
+2025-10-09T20:10:46.4508990Z ThreadSanitizer: parsed suppression entry 'AcquireCoalescingStack'
+2025-10-09T20:10:46.4509350Z ThreadSanitizer: parsed suppression entry 'CFRunLoopRunSpecific'
+2025-10-09T20:10:46.4509700Z ThreadSanitizer: parsed suppression entry 'QuartzCore::post_notification'
+2025-10-09T20:10:46.4510280Z ==24942==Adding instrumented range 0x000100a5c000-0x000100b3c000 from library '/Users/runner/work/rsyslog/rsyslog/tools/rsyslogd'
+2025-10-09T20:10:46.4510750Z ==24942==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4511040Z ==24942==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4511330Z ==24942==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4511600Z ==24942==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4511900Z ==24942==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4512180Z ==24942==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4512470Z ==24942==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4512750Z ==24942==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4513030Z ==24942==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4513320Z ==24942==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4513610Z ==24942==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4513880Z ==24942==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4514280Z ==24942==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4514590Z ==24942==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4514870Z ==24942==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4515140Z ==24942==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4515420Z ***** Running under ThreadSanitizer v3 (pid 24942) *****
+2025-10-09T20:10:46.4515840Z ==24944==Adding instrumented range 0x000100d88000-0x000100d8c000 from library '/Users/runner/work/rsyslog/rsyslog/tests/msleep'
+2025-10-09T20:10:46.4516280Z ==24944==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4516560Z ==24944==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4516850Z ==24944==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4517120Z ==24944==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4517380Z ==24944==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4517700Z ==24944==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4517980Z ==24944==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4518360Z ==24944==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4518650Z ==24944==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4518970Z ==24944==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4519270Z ==24944==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4519560Z ==24944==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4519830Z ==24944==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4520100Z ==24944==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4520380Z ==24944==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4520650Z ==24944==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4520920Z ***** Running under ThreadSanitizer v3 (pid 24944) *****
+2025-10-09T20:10:46.4521190Z rsyslogd: NOTE: RSYSLOG_DEBUG_TIMEOUTS_TO_STDERR activated
+2025-10-09T20:10:46.4521540Z Stats: LargeMmapAllocator: allocated 0 times, remains 0 (0 K) max 0 M; by size logs: 
+2025-10-09T20:10:46.4521990Z Stats: LargeMmapAllocator: allocated 0 times, remains 0 (0 K) max 0 M; by size logs: 
+2025-10-09T20:10:46.4522530Z ==24942==Adding instrumented range 0x0001013a8000-0x0001013b0000 from library '/Users/runner/work/rsyslog/rsyslog/runtime/.libs/lmnet.so'
+2025-10-09T20:10:46.4523190Z ==24942==Adding instrumented range 0x000103188000-0x000103190000 from library '/Users/runner/work/rsyslog/rsyslog/plugins/imdiag/.libs/imdiag.so'
+2025-10-09T20:10:46.4523870Z ==24942==Adding instrumented range 0x0001031b4000-0x0001031c0000 from library '/Users/runner/work/rsyslog/rsyslog/runtime/.libs/lmnetstrms.so'
+2025-10-09T20:10:46.4524530Z ==24942==Adding instrumented range 0x000103660000-0x000103670000 from library '/Users/runner/work/rsyslog/rsyslog/runtime/.libs/lmtcpsrv.so'
+2025-10-09T20:10:46.4525190Z ==24942==Adding instrumented range 0x00010319c000-0x0001031a4000 from library '/Users/runner/work/rsyslog/rsyslog/plugins/imtcp/.libs/imtcp.so'
+2025-10-09T20:10:46.4525860Z ==24942==Adding instrumented range 0x0001056e0000-0x0001056f0000 from library '/Users/runner/work/rsyslog/rsyslog/runtime/.libs/lmnsd_gtls.so'
+2025-10-09T20:10:46.4526300Z ==24974==Installed the sigaction for signal 11
+2025-10-09T20:10:46.4526510Z ==24974==Installed the sigaction for signal 10
+2025-10-09T20:10:46.4526710Z ==24974==Installed the sigaction for signal 8
+2025-10-09T20:10:46.4527050Z ThreadSanitizer: reading suppressions file at /Users/runner/work/rsyslog/rsyslog/tests/tsan-rt.supp
+2025-10-09T20:10:46.4527420Z ThreadSanitizer: parsing '# supressions for LLVM TSAN
+2025-10-09T20:10:46.4528080Z # doc: https://github.com/google/sanitizers/wiki/ThreadSanitizerSuppressions
+2025-10-09T20:10:46.4528350Z race:^close$
+2025-10-09T20:10:46.4528680Z race:^closeSess$
+2025-10-09T20:10:46.4528820Z race:^bs_arrcmp_glblDbgFiles$
+2025-10-09T20:10:46.4528980Z race:^imptcp_destruct_epd$
+2025-10-09T20:10:46.4529120Z race:doLogMsg
+2025-10-09T20:10:46.4529230Z race:setlocale
+2025-10-09T20:10:46.4529340Z race:doSIGTTIN
+2025-10-09T20:10:46.4529450Z '
+2025-10-09T20:10:46.4529590Z ThreadSanitizer: parsed suppression entry '^close$'
+2025-10-09T20:10:46.4529850Z ThreadSanitizer: parsed suppression entry '^closeSess$'
+2025-10-09T20:10:46.4530160Z ThreadSanitizer: parsed suppression entry '^bs_arrcmp_glblDbgFiles$'
+2025-10-09T20:10:46.4530490Z ThreadSanitizer: parsed suppression entry '^imptcp_destruct_epd$'
+2025-10-09T20:10:46.4530770Z ThreadSanitizer: parsed suppression entry 'doLogMsg'
+2025-10-09T20:10:46.4531030Z ThreadSanitizer: parsed suppression entry 'setlocale'
+2025-10-09T20:10:46.4531290Z ThreadSanitizer: parsed suppression entry 'doSIGTTIN'
+2025-10-09T20:10:46.4531510Z ThreadSanitizer: parsing '<null>'
+2025-10-09T20:10:46.4531690Z ThreadSanitizer: parsing 'race:^_M_rep$
+2025-10-09T20:10:46.4531870Z race:^_M_is_leaked$
+2025-10-09T20:10:46.4532040Z race:std::_Sp_counted_ptr_inplace<std::thread::_Impl
+2025-10-09T20:10:46.4532340Z mutex:ConvertMatchingCGEvents
+2025-10-09T20:10:46.4532510Z mutex:AcquireCoalescingStack
+2025-10-09T20:10:46.4532670Z mutex:CFRunLoopRunSpecific
+2025-10-09T20:10:46.4532830Z mutex:QuartzCore::post_notification
+2025-10-09T20:10:46.4532990Z '
+2025-10-09T20:10:46.4533130Z ThreadSanitizer: parsed suppression entry '^_M_rep$'
+2025-10-09T20:10:46.4533390Z ThreadSanitizer: parsed suppression entry '^_M_is_leaked$'
+2025-10-09T20:10:46.4533750Z ThreadSanitizer: parsed suppression entry 'std::_Sp_counted_ptr_inplace<std::thread::_Impl'
+2025-10-09T20:10:46.4534140Z ThreadSanitizer: parsed suppression entry 'ConvertMatchingCGEvents'
+2025-10-09T20:10:46.4534470Z ThreadSanitizer: parsed suppression entry 'AcquireCoalescingStack'
+2025-10-09T20:10:46.4534800Z ThreadSanitizer: parsed suppression entry 'CFRunLoopRunSpecific'
+2025-10-09T20:10:46.4535140Z ThreadSanitizer: parsed suppression entry 'QuartzCore::post_notification'
+2025-10-09T20:10:46.4535620Z ==24974==Adding instrumented range 0x000102b50000-0x000102b54000 from library '/Users/runner/work/rsyslog/rsyslog/tests/msleep'
+2025-10-09T20:10:46.4536050Z ==24974==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4536340Z ==24974==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4536610Z ==24974==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4536880Z ==24974==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4537160Z ==24974==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4537430Z ==24974==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4537690Z ==24974==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4537960Z ==24974==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4538670Z ==24974==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4538940Z ==24974==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4539210Z ==24974==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4539480Z ==24974==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4539740Z ==24974==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4540010Z ==24974==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4540280Z ==24974==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4540540Z ==24974==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4540800Z ***** Running under ThreadSanitizer v3 (pid 24974) *****
+2025-10-09T20:10:46.4541250Z ==24942==Adding instrumented range 0x0001031cc000-0x0001031d4000 from library '/Users/runner/work/rsyslog/rsyslog/runtime/.libs/lmnsd_ptcp.so'
+2025-10-09T20:10:46.4542030Z Stats: LargeMmapAllocator: allocated 0 times, remains 0 (0 K) max 0 M; by size logs: 
+2025-10-09T20:10:46.4542430Z Stats: LargeMmapAllocator: allocated 0 times, remains 0 (0 K) max 0 M; by size logs: 
+2025-10-09T20:10:46.4542740Z ==25001==Installed the sigaction for signal 11
+2025-10-09T20:10:46.4542950Z ==25001==Installed the sigaction for signal 10
+2025-10-09T20:10:46.4543150Z ==25001==Installed the sigaction for signal 8
+2025-10-09T20:10:46.4543490Z ThreadSanitizer: reading suppressions file at /Users/runner/work/rsyslog/rsyslog/tests/tsan-rt.supp
+2025-10-09T20:10:46.4543870Z ThreadSanitizer: parsing '# supressions for LLVM TSAN
+2025-10-09T20:10:46.4544180Z # doc: https://github.com/google/sanitizers/wiki/ThreadSanitizerSuppressions
+2025-10-09T20:10:46.4544440Z race:^close$
+2025-10-09T20:10:46.4544560Z race:^closeSess$
+2025-10-09T20:10:46.4544690Z race:^bs_arrcmp_glblDbgFiles$
+2025-10-09T20:10:46.4544840Z race:^imptcp_destruct_epd$
+2025-10-09T20:10:46.4544980Z race:doLogMsg
+2025-10-09T20:10:46.4545090Z race:setlocale
+2025-10-09T20:10:46.4545200Z race:doSIGTTIN
+2025-10-09T20:10:46.4545310Z '
+2025-10-09T20:10:46.4545460Z ThreadSanitizer: parsed suppression entry '^close$'
+2025-10-09T20:10:46.4545710Z ThreadSanitizer: parsed suppression entry '^closeSess$'
+2025-10-09T20:10:46.4546400Z ThreadSanitizer: parsed suppression entry '^bs_arrcmp_glblDbgFiles$'
+2025-10-09T20:10:46.4546730Z ThreadSanitizer: parsed suppression entry '^imptcp_destruct_epd$'
+2025-10-09T20:10:46.4547010Z ThreadSanitizer: parsed suppression entry 'doLogMsg'
+2025-10-09T20:10:46.4547260Z ThreadSanitizer: parsed suppression entry 'setlocale'
+2025-10-09T20:10:46.4547510Z ThreadSanitizer: parsed suppression entry 'doSIGTTIN'
+2025-10-09T20:10:46.4547720Z ThreadSanitizer: parsing '<null>'
+2025-10-09T20:10:46.4547910Z ThreadSanitizer: parsing 'race:^_M_rep$
+2025-10-09T20:10:46.4548070Z race:^_M_is_leaked$
+2025-10-09T20:10:46.4548250Z race:std::_Sp_counted_ptr_inplace<std::thread::_Impl
+2025-10-09T20:10:46.4548460Z mutex:ConvertMatchingCGEvents
+2025-10-09T20:10:46.4548620Z mutex:AcquireCoalescingStack
+2025-10-09T20:10:46.4548790Z mutex:CFRunLoopRunSpecific
+2025-10-09T20:10:46.4548960Z mutex:QuartzCore::post_notification
+2025-10-09T20:10:46.4549120Z '
+2025-10-09T20:10:46.4549270Z ThreadSanitizer: parsed suppression entry '^_M_rep$'
+2025-10-09T20:10:46.4549530Z ThreadSanitizer: parsed suppression entry '^_M_is_leaked$'
+2025-10-09T20:10:46.4549890Z ThreadSanitizer: parsed suppression entry 'std::_Sp_counted_ptr_inplace<std::thread::_Impl'
+2025-10-09T20:10:46.4550370Z ThreadSanitizer: parsed suppression entry 'ConvertMatchingCGEvents'
+2025-10-09T20:10:46.4550780Z ThreadSanitizer: parsed suppression entry 'AcquireCoalescingStack'
+2025-10-09T20:10:46.4551210Z ThreadSanitizer: parsed suppression entry 'CFRunLoopRunSpecific'
+2025-10-09T20:10:46.4551570Z ThreadSanitizer: parsed suppression entry 'QuartzCore::post_notification'
+2025-10-09T20:10:46.4552070Z ==25001==Adding instrumented range 0x000104f9c000-0x000104fa0000 from library '/Users/runner/work/rsyslog/rsyslog/tests/msleep'
+2025-10-09T20:10:46.4552520Z ==25001==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4552810Z ==25001==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4553090Z ==25001==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4553390Z ==25001==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4553670Z ==25001==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4553940Z ==25001==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4554240Z ==25001==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4554520Z ==25001==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4554810Z ==25001==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4555110Z ==25001==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4555410Z ==25001==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4556460Z ==25001==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4556820Z ==25001==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4557120Z ==25001==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4557400Z ==25001==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4557690Z ==25001==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4557960Z ***** Running under ThreadSanitizer v3 (pid 25001) *****
+2025-10-09T20:10:46.4558310Z Stats: LargeMmapAllocator: allocated 0 times, remains 0 (0 K) max 0 M; by size logs: 
+2025-10-09T20:10:46.4566640Z Stats: LargeMmapAllocator: allocated 0 times, remains 0 (0 K) max 0 M; by size logs: 
+2025-10-09T20:10:46.4566970Z ==25020==Installed the sigaction for signal 11
+2025-10-09T20:10:46.4567550Z ==25020==Installed the sigaction for signal 10
+2025-10-09T20:10:46.4567770Z ==25020==Installed the sigaction for signal 8
+2025-10-09T20:10:46.4568140Z ThreadSanitizer: reading suppressions file at /Users/runner/work/rsyslog/rsyslog/tests/tsan-rt.supp
+2025-10-09T20:10:46.4568520Z ThreadSanitizer: parsing '# supressions for LLVM TSAN
+2025-10-09T20:10:46.4568850Z # doc: https://github.com/google/sanitizers/wiki/ThreadSanitizerSuppressions
+2025-10-09T20:10:46.4569340Z race:^close$
+2025-10-09T20:10:46.4569460Z race:^closeSess$
+2025-10-09T20:10:46.4569600Z race:^bs_arrcmp_glblDbgFiles$
+2025-10-09T20:10:46.4569760Z race:^imptcp_destruct_epd$
+2025-10-09T20:10:46.4569900Z race:doLogMsg
+2025-10-09T20:10:46.4570020Z race:setlocale
+2025-10-09T20:10:46.4570130Z race:doSIGTTIN
+2025-10-09T20:10:46.4570240Z '
+2025-10-09T20:10:46.4570390Z ThreadSanitizer: parsed suppression entry '^close$'
+2025-10-09T20:10:46.4570640Z ThreadSanitizer: parsed suppression entry '^closeSess$'
+2025-10-09T20:10:46.4570940Z ThreadSanitizer: parsed suppression entry '^bs_arrcmp_glblDbgFiles$'
+2025-10-09T20:10:46.4571260Z ThreadSanitizer: parsed suppression entry '^imptcp_destruct_epd$'
+2025-10-09T20:10:46.4571560Z ThreadSanitizer: parsed suppression entry 'doLogMsg'
+2025-10-09T20:10:46.4571810Z ThreadSanitizer: parsed suppression entry 'setlocale'
+2025-10-09T20:10:46.4572060Z ThreadSanitizer: parsed suppression entry 'doSIGTTIN'
+2025-10-09T20:10:46.4572280Z ThreadSanitizer: parsing '<null>'
+2025-10-09T20:10:46.4572460Z ThreadSanitizer: parsing 'race:^_M_rep$
+2025-10-09T20:10:46.4572640Z race:^_M_is_leaked$
+2025-10-09T20:10:46.4572830Z race:std::_Sp_counted_ptr_inplace<std::thread::_Impl
+2025-10-09T20:10:46.4573030Z mutex:ConvertMatchingCGEvents
+2025-10-09T20:10:46.4573210Z mutex:AcquireCoalescingStack
+2025-10-09T20:10:46.4573640Z mutex:CFRunLoopRunSpecific
+2025-10-09T20:10:46.4573830Z mutex:QuartzCore::post_notification
+2025-10-09T20:10:46.4573990Z '
+2025-10-09T20:10:46.4574140Z ThreadSanitizer: parsed suppression entry '^_M_rep$'
+2025-10-09T20:10:46.4574420Z ThreadSanitizer: parsed suppression entry '^_M_is_leaked$'
+2025-10-09T20:10:46.4574780Z ThreadSanitizer: parsed suppression entry 'std::_Sp_counted_ptr_inplace<std::thread::_Impl'
+2025-10-09T20:10:46.4575170Z ThreadSanitizer: parsed suppression entry 'ConvertMatchingCGEvents'
+2025-10-09T20:10:46.4575500Z ThreadSanitizer: parsed suppression entry 'AcquireCoalescingStack'
+2025-10-09T20:10:46.4575820Z ThreadSanitizer: parsed suppression entry 'CFRunLoopRunSpecific'
+2025-10-09T20:10:46.4576160Z ThreadSanitizer: parsed suppression entry 'QuartzCore::post_notification'
+2025-10-09T20:10:46.4576650Z ==25020==Adding instrumented range 0x000104140000-0x000104144000 from library '/Users/runner/work/rsyslog/rsyslog/tests/msleep'
+2025-10-09T20:10:46.4577090Z ==25020==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4577360Z ==25020==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4577630Z ==25020==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4577900Z ==25020==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4578160Z ==25020==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4578770Z ==25020==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4579070Z ==25020==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4579360Z ==25020==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4579630Z ==25020==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4579900Z ==25020==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4580160Z ==25020==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4580430Z ==25020==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4580700Z ==25020==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4580970Z ==25020==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4581230Z ==25020==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4581500Z ==25020==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4581750Z ***** Running under ThreadSanitizer v3 (pid 25020) *****
+2025-10-09T20:10:46.4582070Z Stats: LargeMmapAllocator: allocated 0 times, remains 0 (0 K) max 0 M; by size logs: 
+2025-10-09T20:10:46.4582550Z Stats: LargeMmapAllocator: allocated 0 times, remains 0 (0 K) max 0 M; by size logs: 
+2025-10-09T20:10:46.4582860Z ==25085==Installed the sigaction for signal 11
+2025-10-09T20:10:46.4583060Z ==25085==Installed the sigaction for signal 10
+2025-10-09T20:10:46.4583270Z ==25085==Installed the sigaction for signal 8
+2025-10-09T20:10:46.4583610Z ThreadSanitizer: reading suppressions file at /Users/runner/work/rsyslog/rsyslog/tests/tsan-rt.supp
+2025-10-09T20:10:46.4583980Z ThreadSanitizer: parsing '# supressions for LLVM TSAN
+2025-10-09T20:10:46.4584300Z # doc: https://github.com/google/sanitizers/wiki/ThreadSanitizerSuppressions
+2025-10-09T20:10:46.4584560Z race:^close$
+2025-10-09T20:10:46.4584670Z race:^closeSess$
+2025-10-09T20:10:46.4584800Z race:^bs_arrcmp_glblDbgFiles$
+2025-10-09T20:10:46.4584960Z race:^imptcp_destruct_epd$
+2025-10-09T20:10:46.4585100Z race:doLogMsg
+2025-10-09T20:10:46.4585220Z race:setlocale
+2025-10-09T20:10:46.4585320Z race:doSIGTTIN
+2025-10-09T20:10:46.4585430Z '
+2025-10-09T20:10:46.4585580Z ThreadSanitizer: parsed suppression entry '^close$'
+2025-10-09T20:10:46.4585830Z ThreadSanitizer: parsed suppression entry '^closeSess$'
+2025-10-09T20:10:46.4586130Z ThreadSanitizer: parsed suppression entry '^bs_arrcmp_glblDbgFiles$'
+2025-10-09T20:10:46.4586460Z ThreadSanitizer: parsed suppression entry '^imptcp_destruct_epd$'
+2025-10-09T20:10:46.4586760Z ThreadSanitizer: parsed suppression entry 'doLogMsg'
+2025-10-09T20:10:46.4587020Z ThreadSanitizer: parsed suppression entry 'setlocale'
+2025-10-09T20:10:46.4587280Z ThreadSanitizer: parsed suppression entry 'doSIGTTIN'
+2025-10-09T20:10:46.4587490Z ThreadSanitizer: parsing '<null>'
+2025-10-09T20:10:46.4587670Z ThreadSanitizer: parsing 'race:^_M_rep$
+2025-10-09T20:10:46.4587840Z race:^_M_is_leaked$
+2025-10-09T20:10:46.4588020Z race:std::_Sp_counted_ptr_inplace<std::thread::_Impl
+2025-10-09T20:10:46.4588230Z mutex:ConvertMatchingCGEvents
+2025-10-09T20:10:46.4588400Z mutex:AcquireCoalescingStack
+2025-10-09T20:10:46.4588560Z mutex:CFRunLoopRunSpecific
+2025-10-09T20:10:46.4588730Z mutex:QuartzCore::post_notification
+2025-10-09T20:10:46.4588890Z '
+2025-10-09T20:10:46.4589040Z ThreadSanitizer: parsed suppression entry '^_M_rep$'
+2025-10-09T20:10:46.4589300Z ThreadSanitizer: parsed suppression entry '^_M_is_leaked$'
+2025-10-09T20:10:46.4589650Z ThreadSanitizer: parsed suppression entry 'std::_Sp_counted_ptr_inplace<std::thread::_Impl'
+2025-10-09T20:10:46.4590030Z ThreadSanitizer: parsed suppression entry 'ConvertMatchingCGEvents'
+2025-10-09T20:10:46.4590450Z ThreadSanitizer: parsed suppression entry 'AcquireCoalescingStack'
+2025-10-09T20:10:46.4590780Z ThreadSanitizer: parsed suppression entry 'CFRunLoopRunSpecific'
+2025-10-09T20:10:46.4591120Z ThreadSanitizer: parsed suppression entry 'QuartzCore::post_notification'
+2025-10-09T20:10:46.4591770Z ==25085==Adding instrumented range 0x00010244c000-0x000102450000 from library '/Users/runner/work/rsyslog/rsyslog/tests/msleep'
+2025-10-09T20:10:46.4592430Z ==25085==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4592750Z ==25085==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4593030Z ==25085==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4593310Z ==25085==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4593580Z ==25085==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4593860Z ==25085==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4594390Z ==25085==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4594670Z ==25085==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4594940Z ==25085==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4595210Z ==25085==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4595480Z ==25085==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4595750Z ==25085==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4596170Z ==25085==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4596460Z ==25085==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4596740Z ==25085==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4597020Z ==25085==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4597280Z ***** Running under ThreadSanitizer v3 (pid 25085) *****
+2025-10-09T20:10:46.4597600Z Stats: LargeMmapAllocator: allocated 0 times, remains 0 (0 K) max 0 M; by size logs: 
+2025-10-09T20:10:46.4598000Z Stats: LargeMmapAllocator: allocated 0 times, remains 0 (0 K) max 0 M; by size logs: 
+2025-10-09T20:10:46.4598310Z ==25099==Installed the sigaction for signal 11
+2025-10-09T20:10:46.4598510Z ==25099==Installed the sigaction for signal 10
+2025-10-09T20:10:46.4598720Z ==25099==Installed the sigaction for signal 8
+2025-10-09T20:10:46.4599080Z ThreadSanitizer: reading suppressions file at /Users/runner/work/rsyslog/rsyslog/tests/tsan-rt.supp
+2025-10-09T20:10:46.4599460Z ThreadSanitizer: parsing '# supressions for LLVM TSAN
+2025-10-09T20:10:46.4599790Z # doc: https://github.com/google/sanitizers/wiki/ThreadSanitizerSuppressions
+2025-10-09T20:10:46.4600060Z race:^close$
+2025-10-09T20:10:46.4600180Z race:^closeSess$
+2025-10-09T20:10:46.4600320Z race:^bs_arrcmp_glblDbgFiles$
+2025-10-09T20:10:46.4600480Z race:^imptcp_destruct_epd$
+2025-10-09T20:10:46.4600750Z race:doLogMsg
+2025-10-09T20:10:46.4600870Z race:setlocale
+2025-10-09T20:10:46.4600980Z race:doSIGTTIN
+2025-10-09T20:10:46.4601100Z '
+2025-10-09T20:10:46.4601270Z ThreadSanitizer: parsed suppression entry '^close$'
+2025-10-09T20:10:46.4601530Z ThreadSanitizer: parsed suppression entry '^closeSess$'
+2025-10-09T20:10:46.4601850Z ThreadSanitizer: parsed suppression entry '^bs_arrcmp_glblDbgFiles$'
+2025-10-09T20:10:46.4602200Z ThreadSanitizer: parsed suppression entry '^imptcp_destruct_epd$'
+2025-10-09T20:10:46.4602510Z ThreadSanitizer: parsed suppression entry 'doLogMsg'
+2025-10-09T20:10:46.4602780Z ThreadSanitizer: parsed suppression entry 'setlocale'
+2025-10-09T20:10:46.4603060Z ThreadSanitizer: parsed suppression entry 'doSIGTTIN'
+2025-10-09T20:10:46.4603280Z ThreadSanitizer: parsing '<null>'
+2025-10-09T20:10:46.4603460Z ThreadSanitizer: parsing 'race:^_M_rep$
+2025-10-09T20:10:46.4603640Z race:^_M_is_leaked$
+2025-10-09T20:10:46.4603840Z race:std::_Sp_counted_ptr_inplace<std::thread::_Impl
+2025-10-09T20:10:46.4604650Z mutex:ConvertMatchingCGEvents
+2025-10-09T20:10:46.4604830Z mutex:AcquireCoalescingStack
+2025-10-09T20:10:46.4605010Z mutex:CFRunLoopRunSpecific
+2025-10-09T20:10:46.4605180Z mutex:QuartzCore::post_notification
+2025-10-09T20:10:46.4605350Z '
+2025-10-09T20:10:46.4605510Z ThreadSanitizer: parsed suppression entry '^_M_rep$'
+2025-10-09T20:10:46.4606040Z ThreadSanitizer: parsed suppression entry '^_M_is_leaked$'
+2025-10-09T20:10:46.4606410Z ThreadSanitizer: parsed suppression entry 'std::_Sp_counted_ptr_inplace<std::thread::_Impl'
+2025-10-09T20:10:46.4606830Z ThreadSanitizer: parsed suppression entry 'ConvertMatchingCGEvents'
+2025-10-09T20:10:46.4607180Z ThreadSanitizer: parsed suppression entry 'AcquireCoalescingStack'
+2025-10-09T20:10:46.4607510Z ThreadSanitizer: parsed suppression entry 'CFRunLoopRunSpecific'
+2025-10-09T20:10:46.4607860Z ThreadSanitizer: parsed suppression entry 'QuartzCore::post_notification'
+2025-10-09T20:10:46.4608380Z ==25099==Adding instrumented range 0x000102394000-0x000102398000 from library '/Users/runner/work/rsyslog/rsyslog/tests/msleep'
+2025-10-09T20:10:46.4608820Z ==25099==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4609100Z ==25099==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4609960Z ==25099==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4610250Z ==25099==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4610520Z ==25099==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4610790Z ==25099==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4611280Z ==25099==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4611560Z ==25099==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4611830Z ==25099==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4612100Z ==25099==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4612370Z ==25099==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4612650Z ==25099==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4612920Z ==25099==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4613180Z ==25099==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4613450Z ==25099==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4613730Z ==25099==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4613980Z ***** Running under ThreadSanitizer v3 (pid 25099) *****
+2025-10-09T20:10:46.4614310Z Stats: LargeMmapAllocator: allocated 0 times, remains 0 (0 K) max 0 M; by size logs: 
+2025-10-09T20:10:46.4614710Z Stats: LargeMmapAllocator: allocated 0 times, remains 0 (0 K) max 0 M; by size logs: 
+2025-10-09T20:10:46.4615010Z ==25112==Installed the sigaction for signal 11
+2025-10-09T20:10:46.4615210Z ==25112==Installed the sigaction for signal 10
+2025-10-09T20:10:46.4615430Z ==25112==Installed the sigaction for signal 8
+2025-10-09T20:10:46.4615780Z ThreadSanitizer: reading suppressions file at /Users/runner/work/rsyslog/rsyslog/tests/tsan-rt.supp
+2025-10-09T20:10:46.4616160Z ThreadSanitizer: parsing '# supressions for LLVM TSAN
+2025-10-09T20:10:46.4616500Z # doc: https://github.com/google/sanitizers/wiki/ThreadSanitizerSuppressions
+2025-10-09T20:10:46.4616770Z race:^close$
+2025-10-09T20:10:46.4616890Z race:^closeSess$
+2025-10-09T20:10:46.4617030Z race:^bs_arrcmp_glblDbgFiles$
+2025-10-09T20:10:46.4617190Z race:^imptcp_destruct_epd$
+2025-10-09T20:10:46.4617340Z race:doLogMsg
+2025-10-09T20:10:46.4617450Z race:setlocale
+2025-10-09T20:10:46.4617790Z race:doSIGTTIN
+2025-10-09T20:10:46.4617900Z '
+2025-10-09T20:10:46.4618050Z ThreadSanitizer: parsed suppression entry '^close$'
+2025-10-09T20:10:46.4618300Z ThreadSanitizer: parsed suppression entry '^closeSess$'
+2025-10-09T20:10:46.4618600Z ThreadSanitizer: parsed suppression entry '^bs_arrcmp_glblDbgFiles$'
+2025-10-09T20:10:46.4618920Z ThreadSanitizer: parsed suppression entry '^imptcp_destruct_epd$'
+2025-10-09T20:10:46.4619210Z ThreadSanitizer: parsed suppression entry 'doLogMsg'
+2025-10-09T20:10:46.4619470Z ThreadSanitizer: parsed suppression entry 'setlocale'
+2025-10-09T20:10:46.4619720Z ThreadSanitizer: parsed suppression entry 'doSIGTTIN'
+2025-10-09T20:10:46.4619940Z ThreadSanitizer: parsing '<null>'
+2025-10-09T20:10:46.4620310Z ThreadSanitizer: parsing 'race:^_M_rep$
+2025-10-09T20:10:46.4620500Z race:^_M_is_leaked$
+2025-10-09T20:10:46.4620690Z race:std::_Sp_counted_ptr_inplace<std::thread::_Impl
+2025-10-09T20:10:46.4620900Z mutex:ConvertMatchingCGEvents
+2025-10-09T20:10:46.4621070Z mutex:AcquireCoalescingStack
+2025-10-09T20:10:46.4621230Z mutex:CFRunLoopRunSpecific
+2025-10-09T20:10:46.4621390Z mutex:QuartzCore::post_notification
+2025-10-09T20:10:46.4621550Z '
+2025-10-09T20:10:46.4621700Z ThreadSanitizer: parsed suppression entry '^_M_rep$'
+2025-10-09T20:10:46.4621970Z ThreadSanitizer: parsed suppression entry '^_M_is_leaked$'
+2025-10-09T20:10:46.4622320Z ThreadSanitizer: parsed suppression entry 'std::_Sp_counted_ptr_inplace<std::thread::_Impl'
+2025-10-09T20:10:46.4622710Z ThreadSanitizer: parsed suppression entry 'ConvertMatchingCGEvents'
+2025-10-09T20:10:46.4623040Z ThreadSanitizer: parsed suppression entry 'AcquireCoalescingStack'
+2025-10-09T20:10:46.4623640Z ThreadSanitizer: parsed suppression entry 'CFRunLoopRunSpecific'
+2025-10-09T20:10:46.4623980Z ThreadSanitizer: parsed suppression entry 'QuartzCore::post_notification'
+2025-10-09T20:10:46.4624470Z ==25112==Adding instrumented range 0x000104bc4000-0x000104bc8000 from library '/Users/runner/work/rsyslog/rsyslog/tests/msleep'
+2025-10-09T20:10:46.4625000Z ==25112==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4625270Z ==25112==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4625550Z ==25112==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4625810Z ==25112==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4626070Z ==25112==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4626350Z ==25112==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4626620Z ==25112==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4626900Z ==25112==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4627170Z ==25112==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4627430Z ==25112==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4627690Z ==25112==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4628260Z ==25112==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4628520Z ==25112==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4628790Z ==25112==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4629080Z ==25112==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4629360Z ==25112==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4629630Z ***** Running under ThreadSanitizer v3 (pid 25112) *****
+2025-10-09T20:10:46.4629960Z Stats: LargeMmapAllocator: allocated 0 times, remains 0 (0 K) max 0 M; by size logs: 
+2025-10-09T20:10:46.4630670Z Stats: LargeMmapAllocator: allocated 0 times, remains 0 (0 K) max 0 M; by size logs: 
+2025-10-09T20:10:46.4631030Z ==25131==Installed the sigaction for signal 11
+2025-10-09T20:10:46.4631260Z ==25131==Installed the sigaction for signal 10
+2025-10-09T20:10:46.4631460Z ==25131==Installed the sigaction for signal 8
+2025-10-09T20:10:46.4631810Z ThreadSanitizer: reading suppressions file at /Users/runner/work/rsyslog/rsyslog/tests/tsan-rt.supp
+2025-10-09T20:10:46.4632190Z ThreadSanitizer: parsing '# supressions for LLVM TSAN
+2025-10-09T20:10:46.4632510Z # doc: https://github.com/google/sanitizers/wiki/ThreadSanitizerSuppressions
+2025-10-09T20:10:46.4632770Z race:^close$
+2025-10-09T20:10:46.4632900Z race:^closeSess$
+2025-10-09T20:10:46.4633040Z race:^bs_arrcmp_glblDbgFiles$
+2025-10-09T20:10:46.4633230Z race:^imptcp_destruct_epd$
+2025-10-09T20:10:46.4633380Z race:doLogMsg
+2025-10-09T20:10:46.4633510Z race:setlocale
+2025-10-09T20:10:46.4633620Z race:doSIGTTIN
+2025-10-09T20:10:46.4633750Z '
+2025-10-09T20:10:46.4633900Z ThreadSanitizer: parsed suppression entry '^close$'
+2025-10-09T20:10:46.4634390Z ThreadSanitizer: parsed suppression entry '^closeSess$'
+2025-10-09T20:10:46.4634730Z ThreadSanitizer: parsed suppression entry '^bs_arrcmp_glblDbgFiles$'
+2025-10-09T20:10:46.4635080Z ThreadSanitizer: parsed suppression entry '^imptcp_destruct_epd$'
+2025-10-09T20:10:46.4635370Z ThreadSanitizer: parsed suppression entry 'doLogMsg'
+2025-10-09T20:10:46.4638340Z ThreadSanitizer: parsed suppression entry 'setlocale'
+2025-10-09T20:10:46.4638980Z ThreadSanitizer: parsed suppression entry 'doSIGTTIN'
+2025-10-09T20:10:46.4639230Z ThreadSanitizer: parsing '<null>'
+2025-10-09T20:10:46.4639420Z ThreadSanitizer: parsing 'race:^_M_rep$
+2025-10-09T20:10:46.4639620Z race:^_M_is_leaked$
+2025-10-09T20:10:46.4639800Z race:std::_Sp_counted_ptr_inplace<std::thread::_Impl
+2025-10-09T20:10:46.4640010Z mutex:ConvertMatchingCGEvents
+2025-10-09T20:10:46.4640190Z mutex:AcquireCoalescingStack
+2025-10-09T20:10:46.4640350Z mutex:CFRunLoopRunSpecific
+2025-10-09T20:10:46.4640520Z mutex:QuartzCore::post_notification
+2025-10-09T20:10:46.4640680Z '
+2025-10-09T20:10:46.4640850Z ThreadSanitizer: parsed suppression entry '^_M_rep$'
+2025-10-09T20:10:46.4641140Z ThreadSanitizer: parsed suppression entry '^_M_is_leaked$'
+2025-10-09T20:10:46.4641500Z ThreadSanitizer: parsed suppression entry 'std::_Sp_counted_ptr_inplace<std::thread::_Impl'
+2025-10-09T20:10:46.4642070Z ThreadSanitizer: parsed suppression entry 'ConvertMatchingCGEvents'
+2025-10-09T20:10:46.4642420Z ThreadSanitizer: parsed suppression entry 'AcquireCoalescingStack'
+2025-10-09T20:10:46.4642750Z ThreadSanitizer: parsed suppression entry 'CFRunLoopRunSpecific'
+2025-10-09T20:10:46.4643090Z ThreadSanitizer: parsed suppression entry 'QuartzCore::post_notification'
+2025-10-09T20:10:46.4643630Z ==25131==Adding instrumented range 0x000102274000-0x000102278000 from library '/Users/runner/work/rsyslog/rsyslog/tests/msleep'
+2025-10-09T20:10:46.4644110Z ==25131==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4644390Z ==25131==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4644690Z ==25131==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4644990Z ==25131==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4645280Z ==25131==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4645550Z ==25131==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4645840Z ==25131==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4646110Z ==25131==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4646410Z ==25131==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4646680Z ==25131==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4646970Z ==25131==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4647250Z ==25131==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4647530Z ==25131==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4647800Z ==25131==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4648080Z ==25131==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4648340Z ==25131==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4648600Z ***** Running under ThreadSanitizer v3 (pid 25131) *****
+2025-10-09T20:10:46.4648910Z Stats: LargeMmapAllocator: allocated 0 times, remains 0 (0 K) max 0 M; by size logs: 
+2025-10-09T20:10:46.4650020Z Stats: LargeMmapAllocator: allocated 0 times, remains 0 (0 K) max 0 M; by size logs: 
+2025-10-09T20:10:46.4650710Z ==25179==Installed the sigaction for signal 11
+2025-10-09T20:10:46.4650930Z ==25179==Installed the sigaction for signal 10
+2025-10-09T20:10:46.4651150Z ==25179==Installed the sigaction for signal 8
+2025-10-09T20:10:46.4651520Z ThreadSanitizer: reading suppressions file at /Users/runner/work/rsyslog/rsyslog/tests/tsan-rt.supp
+2025-10-09T20:10:46.4651910Z ThreadSanitizer: parsing '# supressions for LLVM TSAN
+2025-10-09T20:10:46.4652580Z # doc: https://github.com/google/sanitizers/wiki/ThreadSanitizerSuppressions
+2025-10-09T20:10:46.4652900Z race:^close$
+2025-10-09T20:10:46.4653020Z race:^closeSess$
+2025-10-09T20:10:46.4653170Z race:^bs_arrcmp_glblDbgFiles$
+2025-10-09T20:10:46.4653340Z race:^imptcp_destruct_epd$
+2025-10-09T20:10:46.4653490Z race:doLogMsg
+2025-10-09T20:10:46.4653700Z race:setlocale
+2025-10-09T20:10:46.4653830Z race:doSIGTTIN
+2025-10-09T20:10:46.4668070Z '
+2025-10-09T20:10:46.4668230Z ThreadSanitizer: parsed suppression entry '^close$'
+2025-10-09T20:10:46.4668500Z ThreadSanitizer: parsed suppression entry '^closeSess$'
+2025-10-09T20:10:46.4668790Z ThreadSanitizer: parsed suppression entry '^bs_arrcmp_glblDbgFiles$'
+2025-10-09T20:10:46.4669120Z ThreadSanitizer: parsed suppression entry '^imptcp_destruct_epd$'
+2025-10-09T20:10:46.4669410Z ThreadSanitizer: parsed suppression entry 'doLogMsg'
+2025-10-09T20:10:46.4669660Z ThreadSanitizer: parsed suppression entry 'setlocale'
+2025-10-09T20:10:46.4669940Z ThreadSanitizer: parsed suppression entry 'doSIGTTIN'
+2025-10-09T20:10:46.4670250Z ThreadSanitizer: parsing '<null>'
+2025-10-09T20:10:46.4670450Z ThreadSanitizer: parsing 'race:^_M_rep$
+2025-10-09T20:10:46.4670640Z race:^_M_is_leaked$
+2025-10-09T20:10:46.4670990Z race:std::_Sp_counted_ptr_inplace<std::thread::_Impl
+2025-10-09T20:10:46.4671230Z mutex:ConvertMatchingCGEvents
+2025-10-09T20:10:46.4671410Z mutex:AcquireCoalescingStack
+2025-10-09T20:10:46.4671580Z mutex:CFRunLoopRunSpecific
+2025-10-09T20:10:46.4671760Z mutex:QuartzCore::post_notification
+2025-10-09T20:10:46.4671940Z '
+2025-10-09T20:10:46.4672100Z ThreadSanitizer: parsed suppression entry '^_M_rep$'
+2025-10-09T20:10:46.4672390Z ThreadSanitizer: parsed suppression entry '^_M_is_leaked$'
+2025-10-09T20:10:46.4672780Z ThreadSanitizer: parsed suppression entry 'std::_Sp_counted_ptr_inplace<std::thread::_Impl'
+2025-10-09T20:10:46.4673220Z ThreadSanitizer: parsed suppression entry 'ConvertMatchingCGEvents'
+2025-10-09T20:10:46.4673580Z ThreadSanitizer: parsed suppression entry 'AcquireCoalescingStack'
+2025-10-09T20:10:46.4673940Z ThreadSanitizer: parsed suppression entry 'CFRunLoopRunSpecific'
+2025-10-09T20:10:46.4674310Z ThreadSanitizer: parsed suppression entry 'QuartzCore::post_notification'
+2025-10-09T20:10:46.4674850Z ==25179==Adding instrumented range 0x000102840000-0x000102844000 from library '/Users/runner/work/rsyslog/rsyslog/tests/msleep'
+2025-10-09T20:10:46.4675290Z ==25179==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4675570Z ==25179==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4675840Z ==25179==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4676110Z ==25179==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4676400Z ==25179==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4676680Z ==25179==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4676950Z ==25179==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4677220Z ==25179==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4677490Z ==25179==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4677750Z ==25179==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4678020Z ==25179==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4678290Z ==25179==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4678560Z ==25179==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4678820Z ==25179==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4679090Z ==25179==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4679350Z ==25179==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4679600Z ***** Running under ThreadSanitizer v3 (pid 25179) *****
+2025-10-09T20:10:46.4679920Z Stats: LargeMmapAllocator: allocated 0 times, remains 0 (0 K) max 0 M; by size logs: 
+2025-10-09T20:10:46.4680500Z Stats: LargeMmapAllocator: allocated 0 times, remains 0 (0 K) max 0 M; by size logs: 
+2025-10-09T20:10:46.4680820Z ==25234==Installed the sigaction for signal 11
+2025-10-09T20:10:46.4681030Z ==25234==Installed the sigaction for signal 10
+2025-10-09T20:10:46.4681230Z ==25234==Installed the sigaction for signal 8
+2025-10-09T20:10:46.4681570Z ThreadSanitizer: reading suppressions file at /Users/runner/work/rsyslog/rsyslog/tests/tsan-rt.supp
+2025-10-09T20:10:46.4681940Z ThreadSanitizer: parsing '# supressions for LLVM TSAN
+2025-10-09T20:10:46.4682270Z # doc: https://github.com/google/sanitizers/wiki/ThreadSanitizerSuppressions
+2025-10-09T20:10:46.4682530Z race:^close$
+2025-10-09T20:10:46.4682640Z race:^closeSess$
+2025-10-09T20:10:46.4682790Z race:^bs_arrcmp_glblDbgFiles$
+2025-10-09T20:10:46.4682960Z race:^imptcp_destruct_epd$
+2025-10-09T20:10:46.4683110Z race:doLogMsg
+2025-10-09T20:10:46.4683220Z race:setlocale
+2025-10-09T20:10:46.4683340Z race:doSIGTTIN
+2025-10-09T20:10:46.4683460Z '
+2025-10-09T20:10:46.4683600Z ThreadSanitizer: parsed suppression entry '^close$'
+2025-10-09T20:10:46.4683880Z ThreadSanitizer: parsed suppression entry '^closeSess$'
+2025-10-09T20:10:46.4684300Z ThreadSanitizer: parsed suppression entry '^bs_arrcmp_glblDbgFiles$'
+2025-10-09T20:10:46.4684640Z ThreadSanitizer: parsed suppression entry '^imptcp_destruct_epd$'
+2025-10-09T20:10:46.4685120Z ThreadSanitizer: parsed suppression entry 'doLogMsg'
+2025-10-09T20:10:46.4685410Z ThreadSanitizer: parsed suppression entry 'setlocale'
+2025-10-09T20:10:46.4685680Z ThreadSanitizer: parsed suppression entry 'doSIGTTIN'
+2025-10-09T20:10:46.4685910Z ThreadSanitizer: parsing '<null>'
+2025-10-09T20:10:46.4686090Z ThreadSanitizer: parsing 'race:^_M_rep$
+2025-10-09T20:10:46.4686260Z race:^_M_is_leaked$
+2025-10-09T20:10:46.4686440Z race:std::_Sp_counted_ptr_inplace<std::thread::_Impl
+2025-10-09T20:10:46.4686650Z mutex:ConvertMatchingCGEvents
+2025-10-09T20:10:46.4686820Z mutex:AcquireCoalescingStack
+2025-10-09T20:10:46.4686990Z mutex:CFRunLoopRunSpecific
+2025-10-09T20:10:46.4687160Z mutex:QuartzCore::post_notification
+2025-10-09T20:10:46.4687330Z '
+2025-10-09T20:10:46.4687490Z ThreadSanitizer: parsed suppression entry '^_M_rep$'
+2025-10-09T20:10:46.4687770Z ThreadSanitizer: parsed suppression entry '^_M_is_leaked$'
+2025-10-09T20:10:46.4688140Z ThreadSanitizer: parsed suppression entry 'std::_Sp_counted_ptr_inplace<std::thread::_Impl'
+2025-10-09T20:10:46.4688540Z ThreadSanitizer: parsed suppression entry 'ConvertMatchingCGEvents'
+2025-10-09T20:10:46.4688890Z ThreadSanitizer: parsed suppression entry 'AcquireCoalescingStack'
+2025-10-09T20:10:46.4689250Z ThreadSanitizer: parsed suppression entry 'CFRunLoopRunSpecific'
+2025-10-09T20:10:46.4689600Z ThreadSanitizer: parsed suppression entry 'QuartzCore::post_notification'
+2025-10-09T20:10:46.4690110Z ==25234==Adding instrumented range 0x000102ef0000-0x000102ef4000 from library '/Users/runner/work/rsyslog/rsyslog/tests/msleep'
+2025-10-09T20:10:46.4690540Z ==25234==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4690810Z ==25234==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4691080Z ==25234==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4691350Z ==25234==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4691610Z ==25234==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4691890Z ==25234==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4692150Z ==25234==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4692410Z ==25234==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4692670Z ==25234==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4692940Z ==25234==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4693200Z ==25234==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4693460Z ==25234==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4693940Z ==25234==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4694210Z ==25234==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4694480Z ==25234==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4694750Z ==25234==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4695000Z ***** Running under ThreadSanitizer v3 (pid 25234) *****
+2025-10-09T20:10:46.4695310Z Stats: LargeMmapAllocator: allocated 0 times, remains 0 (0 K) max 0 M; by size logs: 
+2025-10-09T20:10:46.4695710Z Stats: LargeMmapAllocator: allocated 0 times, remains 0 (0 K) max 0 M; by size logs: 
+2025-10-09T20:10:46.4696090Z rsyslogd: Error while binding tcp socket: Address already in use [v8.2510.0.daily]
+2025-10-09T20:10:46.4696450Z rsyslogd: Error while binding tcp socket: Address already in use [v8.2510.0.daily]
+2025-10-09T20:10:46.4696770Z main Q:Reg: worker start requested, num workers currently 0
+2025-10-09T20:10:46.4697020Z rsyslog debug: main Q:Reg: worker 0x105b03600 started
+2025-10-09T20:10:46.4697270Z main Q:Reg: wrkr start initiated with state 0, num workers now 1
+2025-10-09T20:10:46.4697550Z rsyslog debug: main Q:Reg: started with state 3, num workers now 1
+2025-10-09T20:10:46.4697870Z ==25244==Installed the sigaction for signal 11
+2025-10-09T20:10:46.4698080Z ==25244==Installed the sigaction for signal 10
+2025-10-09T20:10:46.4698270Z ==25244==Installed the sigaction for signal 8
+2025-10-09T20:10:46.4698610Z ThreadSanitizer: reading suppressions file at /Users/runner/work/rsyslog/rsyslog/tests/tsan-rt.supp
+2025-10-09T20:10:46.4698990Z ThreadSanitizer: parsing '# supressions for LLVM TSAN
+2025-10-09T20:10:46.4699300Z # doc: https://github.com/google/sanitizers/wiki/ThreadSanitizerSuppressions
+2025-10-09T20:10:46.4699570Z race:^close$
+2025-10-09T20:10:46.4699680Z race:^closeSess$
+2025-10-09T20:10:46.4699810Z race:^bs_arrcmp_glblDbgFiles$
+2025-10-09T20:10:46.4699970Z race:^imptcp_destruct_epd$
+2025-10-09T20:10:46.4700110Z race:doLogMsg
+2025-10-09T20:10:46.4700220Z race:setlocale
+2025-10-09T20:10:46.4700330Z race:doSIGTTIN
+2025-10-09T20:10:46.4700430Z '
+2025-10-09T20:10:46.4700580Z ThreadSanitizer: parsed suppression entry '^close$'
+2025-10-09T20:10:46.4700830Z ThreadSanitizer: parsed suppression entry '^closeSess$'
+2025-10-09T20:10:46.4701130Z ThreadSanitizer: parsed suppression entry '^bs_arrcmp_glblDbgFiles$'
+2025-10-09T20:10:46.4701460Z ThreadSanitizer: parsed suppression entry '^imptcp_destruct_epd$'
+2025-10-09T20:10:46.4701740Z ThreadSanitizer: parsed suppression entry 'doLogMsg'
+2025-10-09T20:10:46.4701990Z ThreadSanitizer: parsed suppression entry 'setlocale'
+2025-10-09T20:10:46.4702240Z ThreadSanitizer: parsed suppression entry 'doSIGTTIN'
+2025-10-09T20:10:46.4704790Z ThreadSanitizer: parsing '<null>'
+2025-10-09T20:10:46.4705350Z ThreadSanitizer: parsing 'race:^_M_rep$
+2025-10-09T20:10:46.4705850Z race:^_M_is_leaked$
+2025-10-09T20:10:46.4706340Z race:std::_Sp_counted_ptr_inplace<std::thread::_Impl
+2025-10-09T20:10:46.4706960Z mutex:ConvertMatchingCGEvents
+2025-10-09T20:10:46.4707420Z mutex:AcquireCoalescingStack
+2025-10-09T20:10:46.4707870Z mutex:CFRunLoopRunSpecific
+2025-10-09T20:10:46.4708070Z mutex:QuartzCore::post_notification
+2025-10-09T20:10:46.4708240Z '
+2025-10-09T20:10:46.4708420Z ThreadSanitizer: parsed suppression entry '^_M_rep$'
+2025-10-09T20:10:46.4708720Z ThreadSanitizer: parsed suppression entry '^_M_is_leaked$'
+2025-10-09T20:10:46.4709090Z ThreadSanitizer: parsed suppression entry 'std::_Sp_counted_ptr_inplace<std::thread::_Impl'
+2025-10-09T20:10:46.4709480Z ThreadSanitizer: parsed suppression entry 'ConvertMatchingCGEvents'
+2025-10-09T20:10:46.4709820Z ThreadSanitizer: parsed suppression entry 'AcquireCoalescingStack'
+2025-10-09T20:10:46.4710140Z ThreadSanitizer: parsed suppression entry 'CFRunLoopRunSpecific'
+2025-10-09T20:10:46.4710590Z ThreadSanitizer: parsed suppression entry 'QuartzCore::post_notification'
+2025-10-09T20:10:46.4712180Z ==25244==Adding instrumented range 0x00010211c000-0x000102120000 from library '/Users/runner/work/rsyslog/rsyslog/tests/msleep'
+2025-10-09T20:10:46.4712840Z ==25244==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4713140Z ==25244==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4713410Z ==25244==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4713690Z ==25244==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4713970Z ==25244==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4714240Z ==25244==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4714510Z ==25244==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4714780Z ==25244==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4715050Z ==25244==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4715320Z ==25244==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4715600Z ==25244==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4715880Z ==25244==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4716440Z ==25244==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4716870Z ==25244==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4717150Z ==25244==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4717430Z ==25244==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4717700Z ***** Running under ThreadSanitizer v3 (pid 25244) *****
+2025-10-09T20:10:46.4718020Z Stats: LargeMmapAllocator: allocated 0 times, remains 0 (0 K) max 0 M; by size logs: 
+2025-10-09T20:10:46.4718420Z Stats: LargeMmapAllocator: allocated 0 times, remains 0 (0 K) max 0 M; by size logs: 
+2025-10-09T20:10:46.4718740Z ==25269==Installed the sigaction for signal 11
+2025-10-09T20:10:46.4718950Z ==25269==Installed the sigaction for signal 10
+2025-10-09T20:10:46.4719160Z ==25269==Installed the sigaction for signal 8
+2025-10-09T20:10:46.4719510Z ThreadSanitizer: reading suppressions file at /Users/runner/work/rsyslog/rsyslog/tests/tsan-rt.supp
+2025-10-09T20:10:46.4720010Z ThreadSanitizer: parsing '# supressions for LLVM TSAN
+2025-10-09T20:10:46.4720360Z # doc: https://github.com/google/sanitizers/wiki/ThreadSanitizerSuppressions
+2025-10-09T20:10:46.4720640Z race:^close$
+2025-10-09T20:10:46.4720760Z race:^closeSess$
+2025-10-09T20:10:46.4720900Z race:^bs_arrcmp_glblDbgFiles$
+2025-10-09T20:10:46.4721070Z race:^imptcp_destruct_epd$
+2025-10-09T20:10:46.4721210Z race:doLogMsg
+2025-10-09T20:10:46.4721320Z race:setlocale
+2025-10-09T20:10:46.4721430Z race:doSIGTTIN
+2025-10-09T20:10:46.4721530Z '
+2025-10-09T20:10:46.4721680Z ThreadSanitizer: parsed suppression entry '^close$'
+2025-10-09T20:10:46.4721960Z ThreadSanitizer: parsed suppression entry '^closeSess$'
+2025-10-09T20:10:46.4722250Z ThreadSanitizer: parsed suppression entry '^bs_arrcmp_glblDbgFiles$'
+2025-10-09T20:10:46.4722580Z ThreadSanitizer: parsed suppression entry '^imptcp_destruct_epd$'
+2025-10-09T20:10:46.4722860Z ThreadSanitizer: parsed suppression entry 'doLogMsg'
+2025-10-09T20:10:46.4723120Z ThreadSanitizer: parsed suppression entry 'setlocale'
+2025-10-09T20:10:46.4723380Z ThreadSanitizer: parsed suppression entry 'doSIGTTIN'
+2025-10-09T20:10:46.4723600Z ThreadSanitizer: parsing '<null>'
+2025-10-09T20:10:46.4723780Z ThreadSanitizer: parsing 'race:^_M_rep$
+2025-10-09T20:10:46.4723950Z race:^_M_is_leaked$
+2025-10-09T20:10:46.4724130Z race:std::_Sp_counted_ptr_inplace<std::thread::_Impl
+2025-10-09T20:10:46.4724350Z mutex:ConvertMatchingCGEvents
+2025-10-09T20:10:46.4724520Z mutex:AcquireCoalescingStack
+2025-10-09T20:10:46.4724680Z mutex:CFRunLoopRunSpecific
+2025-10-09T20:10:46.4724840Z mutex:QuartzCore::post_notification
+2025-10-09T20:10:46.4725000Z '
+2025-10-09T20:10:46.4725150Z ThreadSanitizer: parsed suppression entry '^_M_rep$'
+2025-10-09T20:10:46.4725410Z ThreadSanitizer: parsed suppression entry '^_M_is_leaked$'
+2025-10-09T20:10:46.4726000Z ThreadSanitizer: parsed suppression entry 'std::_Sp_counted_ptr_inplace<std::thread::_Impl'
+2025-10-09T20:10:46.4726430Z ThreadSanitizer: parsed suppression entry 'ConvertMatchingCGEvents'
+2025-10-09T20:10:46.4726780Z ThreadSanitizer: parsed suppression entry 'AcquireCoalescingStack'
+2025-10-09T20:10:46.4727120Z ThreadSanitizer: parsed suppression entry 'CFRunLoopRunSpecific'
+2025-10-09T20:10:46.4727470Z ThreadSanitizer: parsed suppression entry 'QuartzCore::post_notification'
+2025-10-09T20:10:46.4727960Z ==25269==Adding instrumented range 0x0001027b4000-0x0001027b8000 from library '/Users/runner/work/rsyslog/rsyslog/tests/msleep'
+2025-10-09T20:10:46.4728430Z ==25269==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4728720Z ==25269==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4728990Z ==25269==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4729260Z ==25269==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4729530Z ==25269==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4729820Z ==25269==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4730180Z ==25269==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4730440Z ==25269==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4730700Z ==25269==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4730980Z ==25269==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4731270Z ==25269==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4731540Z ==25269==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4731800Z ==25269==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4732080Z ==25269==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4732350Z ==25269==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4732620Z ==25269==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4732890Z ***** Running under ThreadSanitizer v3 (pid 25269) *****
+2025-10-09T20:10:46.4733200Z Stats: LargeMmapAllocator: allocated 0 times, remains 0 (0 K) max 0 M; by size logs: 
+2025-10-09T20:10:46.4733600Z Stats: LargeMmapAllocator: allocated 0 times, remains 0 (0 K) max 0 M; by size logs: 
+2025-10-09T20:10:46.4733920Z 20:07:43[12]  rsyslogd startup indicator seen, pid  24942
+2025-10-09T20:10:46.4734160Z waiting for file rstb_827335_d720e136xlAI.imdiag.port
+2025-10-09T20:10:46.4734360Z imdiag port: 51244
+2025-10-09T20:10:46.4734530Z waiting for file rstb_827335_d720e136xlAI.tcpflood_port
+2025-10-09T20:10:46.4734730Z TCPFLOOD_PORT now: 51243
+2025-10-09T20:10:46.4734900Z ==25298==Installed the sigaction for signal 11
+2025-10-09T20:10:46.4735100Z ==25298==Installed the sigaction for signal 10
+2025-10-09T20:10:46.4735310Z ==25298==Installed the sigaction for signal 8
+2025-10-09T20:10:46.4735650Z ThreadSanitizer: reading suppressions file at /Users/runner/work/rsyslog/rsyslog/tests/tsan-rt.supp
+2025-10-09T20:10:46.4736020Z ThreadSanitizer: parsing '# supressions for LLVM TSAN
+2025-10-09T20:10:46.4736340Z # doc: https://github.com/google/sanitizers/wiki/ThreadSanitizerSuppressions
+2025-10-09T20:10:46.4736600Z race:^close$
+2025-10-09T20:10:46.4736720Z race:^closeSess$
+2025-10-09T20:10:46.4736850Z race:^bs_arrcmp_glblDbgFiles$
+2025-10-09T20:10:46.4737010Z race:^imptcp_destruct_epd$
+2025-10-09T20:10:46.4737140Z race:doLogMsg
+2025-10-09T20:10:46.4737260Z race:setlocale
+2025-10-09T20:10:46.4737370Z race:doSIGTTIN
+2025-10-09T20:10:46.4737480Z '
+2025-10-09T20:10:46.4737620Z ThreadSanitizer: parsed suppression entry '^close$'
+2025-10-09T20:10:46.4737880Z ThreadSanitizer: parsed suppression entry '^closeSess$'
+2025-10-09T20:10:46.4738180Z ThreadSanitizer: parsed suppression entry '^bs_arrcmp_glblDbgFiles$'
+2025-10-09T20:10:46.4738510Z ThreadSanitizer: parsed suppression entry '^imptcp_destruct_epd$'
+2025-10-09T20:10:46.4738840Z ThreadSanitizer: parsed suppression entry 'doLogMsg'
+2025-10-09T20:10:46.4739140Z ThreadSanitizer: parsed suppression entry 'setlocale'
+2025-10-09T20:10:46.4739460Z ThreadSanitizer: parsed suppression entry 'doSIGTTIN'
+2025-10-09T20:10:46.4739730Z ThreadSanitizer: parsing '<null>'
+2025-10-09T20:10:46.4739940Z ThreadSanitizer: parsing 'race:^_M_rep$
+2025-10-09T20:10:46.4740150Z race:^_M_is_leaked$
+2025-10-09T20:10:46.4740340Z race:std::_Sp_counted_ptr_inplace<std::thread::_Impl
+2025-10-09T20:10:46.4740600Z mutex:ConvertMatchingCGEvents
+2025-10-09T20:10:46.4740780Z mutex:AcquireCoalescingStack
+2025-10-09T20:10:46.4740950Z mutex:CFRunLoopRunSpecific
+2025-10-09T20:10:46.4741120Z mutex:QuartzCore::post_notification
+2025-10-09T20:10:46.4741280Z '
+2025-10-09T20:10:46.4741440Z ThreadSanitizer: parsed suppression entry '^_M_rep$'
+2025-10-09T20:10:46.4741710Z ThreadSanitizer: parsed suppression entry '^_M_is_leaked$'
+2025-10-09T20:10:46.4742090Z ThreadSanitizer: parsed suppression entry 'std::_Sp_counted_ptr_inplace<std::thread::_Impl'
+2025-10-09T20:10:46.4742490Z ThreadSanitizer: parsed suppression entry 'ConvertMatchingCGEvents'
+2025-10-09T20:10:46.4742820Z ThreadSanitizer: parsed suppression entry 'AcquireCoalescingStack'
+2025-10-09T20:10:46.4743260Z ThreadSanitizer: parsed suppression entry 'CFRunLoopRunSpecific'
+2025-10-09T20:10:46.4744180Z ThreadSanitizer: parsed suppression entry 'QuartzCore::post_notification'
+2025-10-09T20:10:46.4744790Z ==25298==Adding instrumented range 0x000100880000-0x000100888000 from library '/Users/runner/work/rsyslog/rsyslog/tests/tcpflood'
+2025-10-09T20:10:46.4745320Z ==25298==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4745630Z ==25298==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4745900Z ==25298==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4746170Z ==25298==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4746440Z ==25298==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4746720Z ==25298==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4747010Z ==25298==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4747300Z ==25298==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4747590Z ==25298==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4747860Z ==25298==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4748140Z ==25298==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4748410Z ==25298==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4748680Z ==25298==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4748950Z ==25298==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4749220Z ==25298==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4749490Z ==25298==Checking file existence is not allowed under sandbox.
+2025-10-09T20:10:46.4749740Z ***** Running under ThreadSanitizer v3 (pid 25298) *****
+2025-10-09T20:10:46.4749980Z -x CAFile not supported in GnuTLS mode - ignored.
+2025-10-09T20:10:46.4750240Z Note: we do NOT VERIFY the remote peer when compiled for GnuTLS.
+2025-10-09T20:10:46.4750570Z When compiled for OpenSSL, we do.
+2025-10-09T20:10:46.4750780Z warning: connect failed, retrying... Connection refused
+2025-10-09T20:10:46.4751030Z warning: connect failed, retrying... Invalid argument
+2025-10-09T20:10:46.4751270Z warning: connect failed, retrying... Invalid argument
+2025-10-09T20:10:46.4751510Z warning: connect failed, retrying... Invalid argument
+2025-10-09T20:10:46.4751760Z warning: connect failed, retrying... Invalid argument
+2025-10-09T20:10:46.4752000Z warning: connect failed, retrying... Invalid argument
+2025-10-09T20:10:46.4752250Z warning: connect failed, retrying... Invalid argument
+2025-10-09T20:10:46.4752490Z warning: connect failed, retrying... Invalid argument
+2025-10-09T20:10:46.4752880Z warning: connect failed, retrying... Invalid argument
+2025-10-09T20:10:46.4753120Z warning: connect failed, retrying... Invalid argument
+2025-10-09T20:10:46.4753360Z warning: connect failed, retrying... Invalid argument
+2025-10-09T20:10:46.4753610Z warning: connect failed, retrying... Invalid argument
+2025-10-09T20:10:46.4753850Z warning: connect failed, retrying... Invalid argument
+2025-10-09T20:10:46.4754180Z warning: connect failed, retrying... Invalid argument
+2025-10-09T20:10:46.4760860Z warning: connect failed, retrying... Invalid argument
+2025-10-09T20:10:46.4761110Z warning: connect failed, retrying... Invalid argument
+2025-10-09T20:10:46.4761350Z warning: connect failed, retrying... Invalid argument
+2025-10-09T20:10:46.4761590Z warning: connect failed, retrying... Invalid argument
+2025-10-09T20:10:46.4761830Z warning: connect failed, retrying... Invalid argument
+2025-10-09T20:10:46.4762060Z warning: connect failed, retrying... Invalid argument
+2025-10-09T20:10:46.4762300Z warning: connect failed, retrying... Invalid argument
+2025-10-09T20:10:46.4762540Z warning: connect failed, retrying... Invalid argument
+2025-10-09T20:10:46.4762780Z warning: connect failed, retrying... Invalid argument
+2025-10-09T20:10:46.4763110Z warning: connect failed, retrying... Invalid argument
+2025-10-09T20:10:46.4763360Z warning: connect failed, retrying... Invalid argument
+2025-10-09T20:10:46.4763590Z warning: connect failed, retrying... Invalid argument
+2025-10-09T20:10:46.4763830Z warning: connect failed, retrying... Invalid argument
+2025-10-09T20:10:46.4764060Z warning: connect failed, retrying... Invalid argument
+2025-10-09T20:10:46.4764300Z warning: connect failed, retrying... Invalid argument
+2025-10-09T20:10:46.4765440Z warning: connect failed, retrying... Invalid argument
+2025-10-09T20:10:46.4765820Z warning: connect failed, retrying... Invalid argument
+2025-10-09T20:10:46.4766090Z warning: connect failed, retrying... Invalid argument
+2025-10-09T20:10:46.4766330Z warning: connect failed, retrying... Invalid argument
+2025-10-09T20:10:46.4766580Z warning: connect failed, retrying... Invalid argument
+2025-10-09T20:10:46.4766820Z warning: connect failed, retrying... Invalid argument
+2025-10-09T20:10:46.4767080Z warning: connect failed, retrying... Invalid argument
+2025-10-09T20:10:46.4767330Z warning: connect failed, retrying... Invalid argument
+2025-10-09T20:10:46.4767570Z warning: connect failed, retrying... Invalid argument
+2025-10-09T20:10:46.4767810Z warning: connect failed, retrying... Invalid argument
+2025-10-09T20:10:46.4768040Z warning: connect failed, retrying... Invalid argument
+2025-10-09T20:10:46.4768270Z warning: connect failed, retrying... Invalid argument
+2025-10-09T20:10:46.4768510Z warning: connect failed, retrying... Invalid argument
+2025-10-09T20:10:46.4768740Z warning: connect failed, retrying... Invalid argument
+2025-10-09T20:10:46.4768980Z warning: connect failed, retrying... Invalid argument
+2025-10-09T20:10:46.4769220Z warning: connect failed, retrying... Invalid argument
+2025-10-09T20:10:46.4769450Z warning: connect failed, retrying... Invalid argument
+2025-10-09T20:10:46.4769730Z warning: connect failed, retrying... Invalid argument
+2025-10-09T20:10:46.4770010Z warning: connect failed, retrying... Invalid argument
+2025-10-09T20:10:46.4770280Z warning: connect failed, retrying... Invalid argument
+2025-10-09T20:10:46.4770520Z warning: connect failed, retrying... Invalid argument
+2025-10-09T20:10:46.4770770Z warning: connect failed, retrying... Invalid argument
+2025-10-09T20:10:46.4770980Z connect(): Invalid argument
+2025-10-09T20:10:46.4771130Z connect(51243) failed
+2025-10-09T20:10:46.4771320Z Error opening connection 0; Invalid argument
+2025-10-09T20:10:46.4771510Z ThreadSanitizer:DEADLYSIGNAL
+2025-10-09T20:10:46.4771960Z ==25298==ERROR: ThreadSanitizer: SEGV on unknown address 0x0000000000f8 (pc 0x000100caee1c bp 0x00016f8125c0 sp 0x00016f812580 T47288)
+2025-10-09T20:10:46.4772750Z ==25298==The signal is caused by a READ memory access.
+2025-10-09T20:10:46.4772990Z ==25298==Hint: address points to the zero page.
+2025-10-09T20:10:46.4773430Z     #0 gnutls_record_send2 <null> (libgnutls.30.dylib:arm64+0x6e1c)
+2025-10-09T20:10:46.4773740Z     #1 sendMessages tcpflood.c:883 (tcpflood:arm64+0x100002254)
+2025-10-09T20:10:46.4774010Z     #2 thrdStarter tcpflood.c:987 (tcpflood:arm64+0x100003bb0)
+2025-10-09T20:10:46.4774350Z     #3 __tsan_thread_start_func <null> (libclang_rt.tsan_osx_dynamic.dylib:arm64e+0x32a70)
+2025-10-09T20:10:46.4774690Z     #4 _pthread_start <null> (libsystem_pthread.dylib:arm64e+0x6c08)
+2025-10-09T20:10:46.4774980Z     #5 thread_start <null> (libsystem_pthread.dylib:arm64e+0x1b7c)
+2025-10-09T20:10:46.4775160Z 
+2025-10-09T20:10:46.4775210Z ==25298==Register values:
+2025-10-09T20:10:46.4775500Z  x[0] = 0x0000000000000000   x[1] = 0x000000016f812a3f   x[2] = 0x00000000000fffff   x[3] = 0x0000000000000000  
+2025-10-09T20:10:46.4775900Z  x[4] = 0x0000000101334b20   x[5] = 0x0000000000000000   x[6] = 0x000000000000000a   x[7] = 0x0000000000000000  
+2025-10-09T20:10:46.4776300Z  x[8] = 0x000000016f812a3f   x[9] = 0x000000000a7f03ff  x[10] = 0x000000000a7f0300  x[11] = 0x00000001035a3f20  
+2025-10-09T20:10:46.4776710Z x[12] = 0x000010020a6005c0  x[13] = 0x0000000000000000  x[14] = 0x0000000000000000  x[15] = 0x0000000000000003  
+2025-10-09T20:10:46.4777210Z x[16] = 0x0000000100caedec  x[17] = 0x00000001013a0b18  x[18] = 0x0000000000000000  x[19] = 0x00000000000fffff  
+2025-10-09T20:10:46.4777620Z x[20] = 0x0000000000000000  x[21] = 0x000000016f812a3f  x[22] = 0x0000000000000000  x[23] = 0x0000000000000037  
+2025-10-09T20:10:46.4778020Z x[24] = 0x0000000000000000  x[25] = 0x000000010088c138  x[26] = 0x0000000000004a79  x[27] = 0x000000010088c208  
+2025-10-09T20:10:46.4778430Z x[28] = 0x0000000000000000     fp = 0x000000016f8125c0     lr = 0x0000000100882258     sp = 0x000000016f812580  
+2025-10-09T20:10:46.4779510Z ThreadSanitizer can not provide additional info.
+2025-10-09T20:10:46.4779960Z SUMMARY: ThreadSanitizer: SEGV (libgnutls.30.dylib:arm64+0x6e1c) in gnutls_record_send2+0x28
+2025-10-09T20:10:46.4780270Z ==25298==ABORTING
+2025-10-09T20:10:46.4780660Z ./diag.sh: line 2057: 25298 Abort trap: 6           ./tcpflood -p51243 -p51243 -m50000 -Ttls -x./tls-certs/ca.pem -Z./tls-certs/cert.pem -z./tls-certs/key.pem
+2025-10-09T20:10:46.4781210Z error during tcpflood on port 51243! see rstb_827335_d720e136xlAI.out.log.save for what was written
+2025-10-09T20:10:46.4781570Z cp: rstb_827335_d720e136xlAI.out.log: No such file or directory
+2025-10-09T20:10:46.4781810Z === Core Dump Detection and Analysis ===
+2025-10-09T20:10:46.4781990Z Searching for core dumps in:
+2025-10-09T20:10:46.4782220Z   - Current directory: /Users/runner/work/rsyslog/rsyslog/tests
+2025-10-09T20:10:46.4783050Z   - /cores/ directory (macOS system cores)
+2025-10-09T20:10:46.4783270Z   - Subdirectories (*.core, core.*)
+2025-10-09T20:10:46.4783460Z No core dumps found. Checking possible reasons:
+2025-10-09T20:10:46.4783670Z   - Core dump creation might be disabled
+2025-10-09T20:10:46.4783890Z   - Insufficient disk space (check df -h output below)
+2025-10-09T20:10:46.4784120Z   - Core dumps might be in unexpected locations
+2025-10-09T20:10:46.4784350Z   - macOS core pattern: kern.corefile: /cores/core-%P
+2025-10-09T20:10:46.4784570Z   - macOS core dump enabled: kern.coredump: 1
+2025-10-09T20:10:46.4784770Z   - Current ulimit -c: unlimited
+2025-10-09T20:10:46.4784960Z   - Checking for segfault evidence:
+2025-10-09T20:10:46.4785140Z === Disk Space Analysis ===
+2025-10-09T20:10:46.4785300Z Disk usage: 72% (Free: 181886960)
+2025-10-09T20:10:46.4785460Z === System Information ===
+2025-10-09T20:10:46.4785880Z Darwin Mac-1760040291085.local 24.6.0 Darwin Kernel Version 24.6.0: Mon Jul 14 11:30:18 PDT 2025; root:xnu-11417.140.69~1/RELEASE_ARM64_VMAPPLE arm64
+2025-10-09T20:10:46.4786270Z ProductName:		macOS
+2025-10-09T20:10:46.4786400Z ProductVersion:		15.6.1
+2025-10-09T20:10:46.4786570Z BuildVersion:		24G90
+2025-10-09T20:10:46.4786720Z === macOS System Status ===
+2025-10-09T20:10:46.4786890Z Memory usage:
+2025-10-09T20:10:46.4787280Z PhysMem: 6760M used (2504M wired, 368M compressor), 387M unused.
+2025-10-09T20:10:46.4787580Z === Recent macOS System Logs ===
+2025-10-09T20:10:46.4787870Z Timestamp                       Thread     Type        Activity             PID    TTL  
+2025-10-09T20:10:46.4788600Z 2025-10-09 20:06:42.342332+0000 0x986d     Default     0x0                  21518  0    rsyslogd: [com.apple.Libsystem.malloc:] rsyslogd(21518,0x1ef3da0c0) malloc: nano zone abandoned due to inability to reserve vm space.
+2025-10-09T20:10:46.4789090Z 
+2025-10-09T20:10:46.4789540Z 2025-10-09 20:06:42.884326+0000 0x984d     Default     0x0                  21500  0    rsyslogd: [com.apple.Libsystem.malloc:] rsyslogd(21500,0x1ef3da0c0) malloc: nano zone abandoned due to inability to reserve vm space.
+2025-10-09T20:10:46.4790090Z 
+2025-10-09T20:10:46.4790560Z 2025-10-09 20:06:42.906409+0000 0x9859     Default     0x0                  21509  0    rsyslogd: [com.apple.Libsystem.malloc:] rsyslogd(21509,0x1ef3da0c0) malloc: nano zone abandoned due to inability to reserve vm space.
+2025-10-09T20:10:46.4791040Z 
+2025-10-09T20:10:46.4791500Z 2025-10-09 20:06:43.000406+0000 0x988b     Default     0x0                  21532  0    rsyslogd: [com.apple.Libsystem.malloc:] rsyslogd(21532,0x1ef3da0c0) malloc: nano zone abandoned due to inability to reserve vm space.
+2025-10-09T20:10:46.4792580Z 
+2025-10-09T20:10:46.4792970Z 2025-10-09 20:06:43.319606+0000 0x986d     Error       0x0                  21518  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4793730Z 2025-10-09 20:06:43.319618+0000 0x986d     Error       0x0                  21518  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4794470Z 2025-10-09 20:06:43.319623+0000 0x986d     Error       0x0                  21518  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4795260Z 2025-10-09 20:06:43.329708+0000 0x9845     Default     0x0                  21495  0    rsyslogd: [com.apple.Libsystem.malloc:] rsyslogd(21495,0x1ef3da0c0) malloc: nano zone abandoned due to inability to reserve vm space.
+2025-10-09T20:10:46.4795710Z 
+2025-10-09T20:10:46.4796110Z 2025-10-09 20:06:43.698327+0000 0x989c     Default     0x0                  21539  0    rsyslogd: [com.apple.Libsystem.malloc:] rsyslogd(21539,0x1ef3da0c0) malloc: nano zone abandoned due to inability to reserve vm space.
+2025-10-09T20:10:46.4796550Z 
+2025-10-09T20:10:46.4796890Z 2025-10-09 20:06:43.974770+0000 0x9859     Error       0x0                  21509  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4797630Z 2025-10-09 20:06:43.974804+0000 0x9859     Error       0x0                  21509  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4798350Z 2025-10-09 20:06:43.974807+0000 0x9859     Error       0x0                  21509  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4799090Z 2025-10-09 20:06:44.337644+0000 0x984d     Error       0x0                  21500  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4799430Z 2025-10-09 20:06:44.337648+0000 0x984d     Error       0x0                  21500  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4800290Z 2025-10-09 20:06:44.337650+0000 0x984d     Error       0x0                  21500  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4800790Z 2025-10-09 20:06:44.725386+0000 0x988b     Error       0x0                  21532  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4801130Z 2025-10-09 20:06:44.725391+0000 0x988b     Error       0x0                  21532  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4801470Z 2025-10-09 20:06:44.725397+0000 0x988b     Error       0x0                  21532  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4801810Z 2025-10-09 20:06:44.741138+0000 0x9845     Error       0x0                  21495  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4802130Z 2025-10-09 20:06:44.741140+0000 0x9845     Error       0x0                  21495  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4802460Z 2025-10-09 20:06:44.741142+0000 0x9845     Error       0x0                  21495  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4803170Z 2025-10-09 20:06:44.948487+0000 0x98c7     Default     0x0                  21558  0    rsyslogd: [com.apple.Libsystem.malloc:] rsyslogd(21558,0x1ef3da0c0) malloc: nano zone abandoned due to inability to reserve vm space.
+2025-10-09T20:10:46.4803180Z 
+2025-10-09T20:10:46.4803570Z 2025-10-09 20:06:45.133228+0000 0x98b9     Default     0x0                  21551  0    rsyslogd: [com.apple.Libsystem.malloc:] rsyslogd(21551,0x1ef3da0c0) malloc: nano zone abandoned due to inability to reserve vm space.
+2025-10-09T20:10:46.4803570Z 
+2025-10-09T20:10:46.4803910Z 2025-10-09 20:06:45.391372+0000 0x98c7     Error       0x0                  21558  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4804240Z 2025-10-09 20:06:45.391383+0000 0x98c7     Error       0x0                  21558  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4804570Z 2025-10-09 20:06:45.391386+0000 0x98c7     Error       0x0                  21558  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4805030Z 2025-10-09 20:06:45.406606+0000 0x989c     Default     0x0                  21539  0    rsyslogd: (Network) [com.apple.network:] networkd_settings_read_from_file initialized networkd settings by reading plist directly
+2025-10-09T20:10:46.4805400Z 2025-10-09 20:06:45.407580+0000 0x989c     Default     0x0                  21539  0    rsyslogd: (Network) [com.apple.network:] networkd_settings_read_from_file initialized networkd settings by reading plist directly
+2025-10-09T20:10:46.4805740Z 2025-10-09 20:06:45.641411+0000 0x989c     Error       0x0                  21539  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4806080Z 2025-10-09 20:06:45.641415+0000 0x989c     Error       0x0                  21539  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4806410Z 2025-10-09 20:06:45.641418+0000 0x989c     Error       0x0                  21539  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4806740Z 2025-10-09 20:06:45.830579+0000 0x98b9     Error       0x0                  21551  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4807120Z 2025-10-09 20:06:45.830593+0000 0x98b9     Error       0x0                  21551  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4807450Z 2025-10-09 20:06:45.830596+0000 0x98b9     Error       0x0                  21551  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4808320Z 2025-10-09 20:06:54.323505+0000 0x9e05     Default     0x0                  22237  0    rsyslogd: [com.apple.Libsystem.malloc:] rsyslogd(22237,0x1ef3da0c0) malloc: nano zone abandoned due to inability to reserve vm space.
+2025-10-09T20:10:46.4808340Z 
+2025-10-09T20:10:46.4808790Z 2025-10-09 20:06:54.488570+0000 0x9eb5     Default     0x0                  22335  0    rsyslogd: [com.apple.Libsystem.malloc:] rsyslogd(22335,0x1ef3da0c0) malloc: nano zone abandoned due to inability to reserve vm space.
+2025-10-09T20:10:46.4808790Z 
+2025-10-09T20:10:46.4809190Z 2025-10-09 20:06:54.671051+0000 0x9e05     Error       0x0                  22237  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4809530Z 2025-10-09 20:06:54.671056+0000 0x9e05     Error       0x0                  22237  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4809990Z 2025-10-09 20:06:54.671059+0000 0x9e05     Error       0x0                  22237  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4810390Z 2025-10-09 20:06:54.773544+0000 0x9e9a     Default     0x0                  22319  0    rsyslogd: [com.apple.Libsystem.malloc:] rsyslogd(22319,0x1ef3da0c0) malloc: nano zone abandoned due to inability to reserve vm space.
+2025-10-09T20:10:46.4810390Z 
+2025-10-09T20:10:46.4810790Z 2025-10-09 20:06:54.971235+0000 0x9e7a     Default     0x0                  22302  0    rsyslogd: [com.apple.Libsystem.malloc:] rsyslogd(22302,0x1ef3da0c0) malloc: nano zone abandoned due to inability to reserve vm space.
+2025-10-09T20:10:46.4810790Z 
+2025-10-09T20:10:46.4811180Z 2025-10-09 20:06:55.433815+0000 0x9ea1     Default     0x0                  22322  0    rsyslogd: [com.apple.Libsystem.malloc:] rsyslogd(22322,0x1ef3da0c0) malloc: nano zone abandoned due to inability to reserve vm space.
+2025-10-09T20:10:46.4811180Z 
+2025-10-09T20:10:46.4811570Z 2025-10-09 20:06:55.508218+0000 0x9f18     Default     0x0                  22387  0    rsyslogd: [com.apple.Libsystem.malloc:] rsyslogd(22387,0x1ef3da0c0) malloc: nano zone abandoned due to inability to reserve vm space.
+2025-10-09T20:10:46.4811570Z 
+2025-10-09T20:10:46.4811910Z 2025-10-09 20:06:55.577987+0000 0x9e9a     Error       0x0                  22319  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4812250Z 2025-10-09 20:06:55.578001+0000 0x9e9a     Error       0x0                  22319  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4812600Z 2025-10-09 20:06:55.578004+0000 0x9e9a     Error       0x0                  22319  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4812950Z 2025-10-09 20:06:55.582032+0000 0x9eb5     Error       0x0                  22335  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4813300Z 2025-10-09 20:06:55.582041+0000 0x9eb5     Error       0x0                  22335  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4813630Z 2025-10-09 20:06:55.582043+0000 0x9eb5     Error       0x0                  22335  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4814030Z 2025-10-09 20:06:55.837851+0000 0x9e7a     Error       0x0                  22302  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4814370Z 2025-10-09 20:06:55.837862+0000 0x9e7a     Error       0x0                  22302  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4814700Z 2025-10-09 20:06:55.837864+0000 0x9e7a     Error       0x0                  22302  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4815050Z 2025-10-09 20:06:55.983618+0000 0x9f18     Error       0x0                  22387  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4815410Z 2025-10-09 20:06:55.983623+0000 0x9f18     Error       0x0                  22387  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4815740Z 2025-10-09 20:06:55.983625+0000 0x9f18     Error       0x0                  22387  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4816180Z 2025-10-09 20:06:56.265588+0000 0x9f73     Default     0x0                  22422  0    rsyslogd: [com.apple.Libsystem.malloc:] rsyslogd(22422,0x1ef3da0c0) malloc: nano zone abandoned due to inability to reserve vm space.
+2025-10-09T20:10:46.4816180Z 
+2025-10-09T20:10:46.4816520Z 2025-10-09 20:06:56.299391+0000 0x9ea1     Error       0x0                  22322  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4816850Z 2025-10-09 20:06:56.299400+0000 0x9ea1     Error       0x0                  22322  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4817190Z 2025-10-09 20:06:56.299403+0000 0x9ea1     Error       0x0                  22322  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4817580Z 2025-10-09 20:06:56.701137+0000 0x9f63     Default     0x0                  22415  0    rsyslogd: [com.apple.Libsystem.malloc:] rsyslogd(22415,0x1ef3da0c0) malloc: nano zone abandoned due to inability to reserve vm space.
+2025-10-09T20:10:46.4817580Z 
+2025-10-09T20:10:46.4817930Z 2025-10-09 20:06:57.150024+0000 0x9f63     Error       0x0                  22415  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4818270Z 2025-10-09 20:06:57.150033+0000 0x9f63     Error       0x0                  22415  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4818640Z 2025-10-09 20:06:57.150035+0000 0x9f63     Error       0x0                  22415  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4818990Z 2025-10-09 20:06:57.160452+0000 0x9f73     Error       0x0                  22422  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4819320Z 2025-10-09 20:06:57.160464+0000 0x9f73     Error       0x0                  22422  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4819660Z 2025-10-09 20:06:57.160466+0000 0x9f73     Error       0x0                  22422  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4820140Z 2025-10-09 20:07:03.411933+0000 0xa364     Default     0x0                  22846  0    rsyslogd: [com.apple.Libsystem.malloc:] rsyslogd(22846,0x1ef3da0c0) malloc: nano zone abandoned due to inability to reserve vm space.
+2025-10-09T20:10:46.4820140Z 
+2025-10-09T20:10:46.4820490Z 2025-10-09 20:07:04.207936+0000 0xa364     Error       0x0                  22846  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4820830Z 2025-10-09 20:07:04.207941+0000 0xa364     Error       0x0                  22846  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4821160Z 2025-10-09 20:07:04.207943+0000 0xa364     Error       0x0                  22846  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4821580Z 2025-10-09 20:07:06.404040+0000 0xa4a5     Default     0x0                  23024  0    rsyslogd: [com.apple.Libsystem.malloc:] rsyslogd(23024,0x1ef3da0c0) malloc: nano zone abandoned due to inability to reserve vm space.
+2025-10-09T20:10:46.4821590Z 
+2025-10-09T20:10:46.4821970Z 2025-10-09 20:07:06.623956+0000 0xa5c4     Default     0x0                  23191  0    rsyslogd: [com.apple.Libsystem.malloc:] rsyslogd(23191,0x1ef3da0c0) malloc: nano zone abandoned due to inability to reserve vm space.
+2025-10-09T20:10:46.4822020Z 
+2025-10-09T20:10:46.4822410Z 2025-10-09 20:07:06.834095+0000 0xa5df     Default     0x0                  23206  0    rsyslogd: [com.apple.Libsystem.malloc:] rsyslogd(23206,0x1ef3da0c0) malloc: nano zone abandoned due to inability to reserve vm space.
+2025-10-09T20:10:46.4822410Z 
+2025-10-09T20:10:46.4822750Z 2025-10-09 20:07:06.915772+0000 0xa4a5     Error       0x0                  23024  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4823080Z 2025-10-09 20:07:06.915782+0000 0xa4a5     Error       0x0                  23024  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4823420Z 2025-10-09 20:07:06.915784+0000 0xa4a5     Error       0x0                  23024  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4823760Z 2025-10-09 20:07:07.463259+0000 0xa5c4     Error       0x0                  23191  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4824090Z 2025-10-09 20:07:07.463263+0000 0xa5c4     Error       0x0                  23191  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4824430Z 2025-10-09 20:07:07.463265+0000 0xa5c4     Error       0x0                  23191  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4824780Z 2025-10-09 20:07:07.502261+0000 0xa5df     Error       0x0                  23206  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4825110Z 2025-10-09 20:07:07.502271+0000 0xa5df     Error       0x0                  23206  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4825440Z 2025-10-09 20:07:07.502310+0000 0xa5df     Error       0x0                  23206  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4825850Z 2025-10-09 20:07:08.002863+0000 0xa6cf     Default     0x0                  23315  0    rsyslogd: [com.apple.Libsystem.malloc:] rsyslogd(23315,0x1ef3da0c0) malloc: nano zone abandoned due to inability to reserve vm space.
+2025-10-09T20:10:46.4825850Z 
+2025-10-09T20:10:46.4826340Z 2025-10-09 20:07:08.171207+0000 0xa6b7     Default     0x0                  23301  0    rsyslogd: [com.apple.Libsystem.malloc:] rsyslogd(23301,0x1ef3da0c0) malloc: nano zone abandoned due to inability to reserve vm space.
+2025-10-09T20:10:46.4826340Z 
+2025-10-09T20:10:46.4826680Z 2025-10-09 20:07:08.898896+0000 0xa6cf     Error       0x0                  23315  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4827000Z 2025-10-09 20:07:08.898909+0000 0xa6cf     Error       0x0                  23315  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4827340Z 2025-10-09 20:07:08.898911+0000 0xa6cf     Error       0x0                  23315  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4827670Z 2025-10-09 20:07:08.899106+0000 0xa6b7     Error       0x0                  23301  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4828000Z 2025-10-09 20:07:08.899111+0000 0xa6b7     Error       0x0                  23301  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4828430Z 2025-10-09 20:07:08.899113+0000 0xa6b7     Error       0x0                  23301  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4828820Z 2025-10-09 20:07:09.608687+0000 0xa7b9     Default     0x0                  23432  0    rsyslogd: [com.apple.Libsystem.malloc:] rsyslogd(23432,0x1ef3da0c0) malloc: nano zone abandoned due to inability to reserve vm space.
+2025-10-09T20:10:46.4828820Z 
+2025-10-09T20:10:46.4829150Z 2025-10-09 20:07:10.293687+0000 0xa7b9     Error       0x0                  23432  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4829480Z 2025-10-09 20:07:10.293692+0000 0xa7b9     Error       0x0                  23432  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4829810Z 2025-10-09 20:07:10.293695+0000 0xa7b9     Error       0x0                  23432  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4830200Z 2025-10-09 20:07:16.452997+0000 0xaa5f     Default     0x0                  23756  0    rsyslogd: [com.apple.Libsystem.malloc:] rsyslogd(23756,0x1ef3da0c0) malloc: nano zone abandoned due to inability to reserve vm space.
+2025-10-09T20:10:46.4830200Z 
+2025-10-09T20:10:46.4830530Z 2025-10-09 20:07:16.914727+0000 0xaa5f     Error       0x0                  23756  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4830860Z 2025-10-09 20:07:16.914734+0000 0xaa5f     Error       0x0                  23756  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4831210Z 2025-10-09 20:07:16.914740+0000 0xaa5f     Error       0x0                  23756  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4831600Z 2025-10-09 20:07:17.285542+0000 0xab14     Default     0x0                  23863  0    rsyslogd: [com.apple.Libsystem.malloc:] rsyslogd(23863,0x1ef3da0c0) malloc: nano zone abandoned due to inability to reserve vm space.
+2025-10-09T20:10:46.4831600Z 
+2025-10-09T20:10:46.4832320Z 2025-10-09 20:07:18.101143+0000 0xab14     Error       0x0                  23863  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4832840Z 2025-10-09 20:07:18.101154+0000 0xab14     Error       0x0                  23863  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4833200Z 2025-10-09 20:07:18.101156+0000 0xab14     Error       0x0                  23863  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4833590Z 2025-10-09 20:07:18.312599+0000 0xabc3     Default     0x0                  23954  0    rsyslogd: [com.apple.Libsystem.malloc:] rsyslogd(23954,0x1ef3da0c0) malloc: nano zone abandoned due to inability to reserve vm space.
+2025-10-09T20:10:46.4833590Z 
+2025-10-09T20:10:46.4833990Z 2025-10-09 20:07:18.799613+0000 0xabe8     Default     0x0                  23973  0    rsyslogd: [com.apple.Libsystem.malloc:] rsyslogd(23973,0x1ef3da0c0) malloc: nano zone abandoned due to inability to reserve vm space.
+2025-10-09T20:10:46.4833990Z 
+2025-10-09T20:10:46.4834340Z 2025-10-09 20:07:19.174686+0000 0xabc3     Error       0x0                  23954  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4834730Z 2025-10-09 20:07:19.174691+0000 0xabc3     Error       0x0                  23954  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4835060Z 2025-10-09 20:07:19.174693+0000 0xabc3     Error       0x0                  23954  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4835400Z 2025-10-09 20:07:19.367582+0000 0xabe8     Error       0x0                  23973  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4835730Z 2025-10-09 20:07:19.367592+0000 0xabe8     Error       0x0                  23973  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4836050Z 2025-10-09 20:07:19.367595+0000 0xabe8     Error       0x0                  23973  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4836440Z 2025-10-09 20:07:20.383351+0000 0xace7     Default     0x0                  24111  0    rsyslogd: [com.apple.Libsystem.malloc:] rsyslogd(24111,0x1ef3da0c0) malloc: nano zone abandoned due to inability to reserve vm space.
+2025-10-09T20:10:46.4836440Z 
+2025-10-09T20:10:46.4837460Z 2025-10-09 20:07:20.795678+0000 0xace7     Error       0x0                  24111  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4837860Z 2025-10-09 20:07:20.795683+0000 0xace7     Error       0x0                  24111  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4838200Z 2025-10-09 20:07:20.795685+0000 0xace7     Error       0x0                  24111  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4838610Z 2025-10-09 20:07:22.212434+0000 0xadcc     Default     0x0                  24221  0    rsyslogd: [com.apple.Libsystem.malloc:] rsyslogd(24221,0x1ef3da0c0) malloc: nano zone abandoned due to inability to reserve vm space.
+2025-10-09T20:10:46.4838610Z 
+2025-10-09T20:10:46.4838960Z 2025-10-09 20:07:22.303861+0000 0xadcc     Error       0x0                  24221  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4839390Z 2025-10-09 20:07:22.303873+0000 0xadcc     Error       0x0                  24221  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4839750Z 2025-10-09 20:07:22.303875+0000 0xadcc     Error       0x0                  24221  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4840160Z 2025-10-09 20:07:23.401799+0000 0xae77     Default     0x0                  24314  0    rsyslogd: [com.apple.Libsystem.malloc:] rsyslogd(24314,0x1ef3da0c0) malloc: nano zone abandoned due to inability to reserve vm space.
+2025-10-09T20:10:46.4840160Z 
+2025-10-09T20:10:46.4840640Z 2025-10-09 20:07:23.670508+0000 0xae77     Error       0x0                  24314  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4841000Z 2025-10-09 20:07:23.670514+0000 0xae77     Error       0x0                  24314  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4841340Z 2025-10-09 20:07:23.670517+0000 0xae77     Error       0x0                  24314  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4841870Z 2025-10-09 20:07:26.157684+0000 0xaf9a     Default     0x0                  24466  0    rsyslogd: [com.apple.Libsystem.malloc:] rsyslogd(24466,0x1ef3da0c0) malloc: nano zone abandoned due to inability to reserve vm space.
+2025-10-09T20:10:46.4841870Z 
+2025-10-09T20:10:46.4842210Z 2025-10-09 20:07:26.256622+0000 0xafd3     Error       0x0                  24466  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4842550Z 2025-10-09 20:07:26.256647+0000 0xafd3     Error       0x0                  24466  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4842880Z 2025-10-09 20:07:26.256653+0000 0xafd3     Error       0x0                  24466  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4843270Z 2025-10-09 20:07:26.433592+0000 0xafce     Default     0x0                  24490  0    rsyslogd: [com.apple.Libsystem.malloc:] rsyslogd(24490,0x1ef3da0c0) malloc: nano zone abandoned due to inability to reserve vm space.
+2025-10-09T20:10:46.4843280Z 
+2025-10-09T20:10:46.4843610Z 2025-10-09 20:07:27.266090+0000 0xafce     Error       0x0                  24490  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4843940Z 2025-10-09 20:07:27.266104+0000 0xafce     Error       0x0                  24490  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4844280Z 2025-10-09 20:07:27.266108+0000 0xafce     Error       0x0                  24490  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4844660Z 2025-10-09 20:07:28.791077+0000 0xb0d1     Default     0x0                  24623  0    rsyslogd: [com.apple.Libsystem.malloc:] rsyslogd(24623,0x1ef3da0c0) malloc: nano zone abandoned due to inability to reserve vm space.
+2025-10-09T20:10:46.4844670Z 
+2025-10-09T20:10:46.4845130Z 2025-10-09 20:07:29.306363+0000 0xb0fa     Default     0x0                  24644  0    rsyslogd: [com.apple.Libsystem.malloc:] rsyslogd(24644,0x1ef3da0c0) malloc: nano zone abandoned due to inability to reserve vm space.
+2025-10-09T20:10:46.4845130Z 
+2025-10-09T20:10:46.4845460Z 2025-10-09 20:07:29.317148+0000 0xb0d1     Error       0x0                  24623  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4845920Z 2025-10-09 20:07:29.317153+0000 0xb0d1     Error       0x0                  24623  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4846260Z 2025-10-09 20:07:29.317155+0000 0xb0d1     Error       0x0                  24623  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4846600Z 2025-10-09 20:07:29.763822+0000 0xb19e     Error       0x0                  24644  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4846920Z 2025-10-09 20:07:29.763827+0000 0xb19e     Error       0x0                  24644  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4847260Z 2025-10-09 20:07:29.763829+0000 0xb19e     Error       0x0                  24644  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4847650Z 2025-10-09 20:07:31.526350+0000 0xb2e6     Default     0x0                  24918  0    rsyslogd: [com.apple.Libsystem.malloc:] rsyslogd(24918,0x1ef3da0c0) malloc: nano zone abandoned due to inability to reserve vm space.
+2025-10-09T20:10:46.4847690Z 
+2025-10-09T20:10:46.4848320Z 2025-10-09 20:07:31.583432+0000 0xb2a2     Default     0x0                  24883  0    rsyslogd: [com.apple.Libsystem.malloc:] rsyslogd(24883,0x1ef3da0c0) malloc: nano zone abandoned due to inability to reserve vm space.
+2025-10-09T20:10:46.4848330Z 
+2025-10-09T20:10:46.4848680Z 2025-10-09 20:07:31.611394+0000 0xb2a2     Error       0x0                  24883  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4849020Z 2025-10-09 20:07:31.611402+0000 0xb2a2     Error       0x0                  24883  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4849350Z 2025-10-09 20:07:31.611404+0000 0xb2a2     Error       0x0                  24883  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4849740Z 2025-10-09 20:07:32.166828+0000 0xb2ef     Default     0x0                  24923  0    rsyslogd: [com.apple.Libsystem.malloc:] rsyslogd(24923,0x1ef3da0c0) malloc: nano zone abandoned due to inability to reserve vm space.
+2025-10-09T20:10:46.4849740Z 
+2025-10-09T20:10:46.4850120Z 2025-10-09 20:07:32.169683+0000 0xb32b     Default     0x0                  24947  0    rsyslogd: [com.apple.Libsystem.malloc:] rsyslogd(24947,0x1ef3da0c0) malloc: nano zone abandoned due to inability to reserve vm space.
+2025-10-09T20:10:46.4850120Z 
+2025-10-09T20:10:46.4850510Z 2025-10-09 20:07:32.474210+0000 0xb321     Default     0x0                  24942  0    rsyslogd: [com.apple.Libsystem.malloc:] rsyslogd(24942,0x1ef3da0c0) malloc: nano zone abandoned due to inability to reserve vm space.
+2025-10-09T20:10:46.4850510Z 
+2025-10-09T20:10:46.4850850Z 2025-10-09 20:07:32.536703+0000 0xb354     Error       0x0                  24918  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4851210Z 2025-10-09 20:07:32.536818+0000 0xb354     Error       0x0                  24918  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4851550Z 2025-10-09 20:07:32.536828+0000 0xb354     Error       0x0                  24918  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4851900Z 2025-10-09 20:07:33.220791+0000 0xb2ef     Error       0x0                  24923  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4852340Z 2025-10-09 20:07:33.220803+0000 0xb2ef     Error       0x0                  24923  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4852690Z 2025-10-09 20:07:33.220808+0000 0xb2ef     Error       0x0                  24923  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4853030Z 2025-10-09 20:07:33.272189+0000 0xb36e     Error       0x0                  24947  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4853360Z 2025-10-09 20:07:33.272196+0000 0xb36e     Error       0x0                  24947  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4853820Z 2025-10-09 20:07:33.272198+0000 0xb36e     Error       0x0                  24947  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4854230Z 2025-10-09 20:07:34.274309+0000 0xb39b     Default     0x0                  24995  0    rsyslogd: [com.apple.Libsystem.malloc:] rsyslogd(24995,0x1ef3da0c0) malloc: nano zone abandoned due to inability to reserve vm space.
+2025-10-09T20:10:46.4854360Z 
+2025-10-09T20:10:46.4854700Z 2025-10-09 20:07:34.673481+0000 0xb3bc     Error       0x0                  24995  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4855030Z 2025-10-09 20:07:34.673487+0000 0xb3bc     Error       0x0                  24995  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4855370Z 2025-10-09 20:07:34.673488+0000 0xb3bc     Error       0x0                  24995  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4855770Z 2025-10-09 20:07:35.949320+0000 0xb43c     Default     0x0                  25075  0    rsyslogd: [com.apple.Libsystem.malloc:] rsyslogd(25075,0x1ef3da0c0) malloc: nano zone abandoned due to inability to reserve vm space.
+2025-10-09T20:10:46.4855780Z 
+2025-10-09T20:10:46.4856120Z 2025-10-09 20:07:36.770093+0000 0xb43c     Error       0x0                  25075  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4856450Z 2025-10-09 20:07:36.770098+0000 0xb43c     Error       0x0                  25075  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4856790Z 2025-10-09 20:07:36.770101+0000 0xb43c     Error       0x0                  25075  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4857170Z 2025-10-09 20:07:40.607389+0000 0xb569     Default     0x0                  25217  0    rsyslogd: [com.apple.Libsystem.malloc:] rsyslogd(25217,0x1ef3da0c0) malloc: nano zone abandoned due to inability to reserve vm space.
+2025-10-09T20:10:46.4857180Z 
+2025-10-09T20:10:46.4857510Z 2025-10-09 20:07:41.817663+0000 0xb321     Error       0x0                  24942  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4857830Z 2025-10-09 20:07:41.817675+0000 0xb321     Error       0x0                  24942  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4858160Z 2025-10-09 20:07:41.817677+0000 0xb321     Error       0x0                  24942  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4858550Z 2025-10-09 20:07:44.177327+0000 0xb569     Error       0x0                  25217  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4858890Z 2025-10-09 20:07:44.177334+0000 0xb569     Error       0x0                  25217  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4859210Z 2025-10-09 20:07:44.177336+0000 0xb569     Error       0x0                  25217  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4859600Z 2025-10-09 20:07:47.726563+0000 0xb7b3     Default     0x0                  25467  0    rsyslogd: [com.apple.Libsystem.malloc:] rsyslogd(25467,0x1ef3da0c0) malloc: nano zone abandoned due to inability to reserve vm space.
+2025-10-09T20:10:46.4859600Z 
+2025-10-09T20:10:46.4860000Z 2025-10-09 20:07:49.882475+0000 0xb7b3     Error       0x0                  25467  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4860340Z 2025-10-09 20:07:49.882508+0000 0xb7b3     Error       0x0                  25467  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4860710Z 2025-10-09 20:07:49.882517+0000 0xb7b3     Error       0x0                  25467  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4861100Z 2025-10-09 20:07:53.923316+0000 0xb9a3     Default     0x0                  25694  0    rsyslogd: [com.apple.Libsystem.malloc:] rsyslogd(25694,0x1ef3da0c0) malloc: nano zone abandoned due to inability to reserve vm space.
+2025-10-09T20:10:46.4861110Z 
+2025-10-09T20:10:46.4861450Z 2025-10-09 20:07:56.366087+0000 0xb9a3     Error       0x0                  25694  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4861780Z 2025-10-09 20:07:56.366099+0000 0xb9a3     Error       0x0                  25694  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4862110Z 2025-10-09 20:07:56.366105+0000 0xb9a3     Error       0x0                  25694  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4862490Z 2025-10-09 20:07:57.540303+0000 0xbadc     Default     0x0                  25846  0    rsyslogd: [com.apple.Libsystem.malloc:] rsyslogd(25846,0x1ef3da0c0) malloc: nano zone abandoned due to inability to reserve vm space.
+2025-10-09T20:10:46.4862490Z 
+2025-10-09T20:10:46.4862870Z 2025-10-09 20:07:58.268320+0000 0xbb42     Default     0x0                  25894  0    rsyslogd: [com.apple.Libsystem.malloc:] rsyslogd(25894,0x1ef3da0c0) malloc: nano zone abandoned due to inability to reserve vm space.
+2025-10-09T20:10:46.4862880Z 
+2025-10-09T20:10:46.4863210Z 2025-10-09 20:07:58.839803+0000 0xbb42     Error       0x0                  25894  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4863530Z 2025-10-09 20:07:58.839814+0000 0xbb42     Error       0x0                  25894  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4863860Z 2025-10-09 20:07:58.839817+0000 0xbb42     Error       0x0                  25894  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4864190Z 2025-10-09 20:07:58.901048+0000 0xbadc     Error       0x0                  25846  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4864560Z 2025-10-09 20:07:58.901054+0000 0xbadc     Error       0x0                  25846  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4864890Z 2025-10-09 20:07:58.901056+0000 0xbadc     Error       0x0                  25846  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4865600Z 2025-10-09 20:08:01.285858+0000 0xbcb0     Default     0x0                  26074  0    rsyslogd: [com.apple.Libsystem.malloc:] rsyslogd(26074,0x1ef3da0c0) malloc: nano zone abandoned due to inability to reserve vm space.
+2025-10-09T20:10:46.4865600Z 
+2025-10-09T20:10:46.4866030Z 2025-10-09 20:08:01.322339+0000 0xbcbb     Default     0x0                  26080  0    rsyslogd: [com.apple.Libsystem.malloc:] rsyslogd(26080,0x1ef3da0c0) malloc: nano zone abandoned due to inability to reserve vm space.
+2025-10-09T20:10:46.4866040Z 
+2025-10-09T20:10:46.4866370Z 2025-10-09 20:08:04.325603+0000 0xbcbb     Error       0x0                  26080  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4866780Z 2025-10-09 20:08:04.325623+0000 0xbcbb     Error       0x0                  26080  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4867120Z 2025-10-09 20:08:04.325626+0000 0xbcbb     Error       0x0                  26080  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4867630Z 2025-10-09 20:08:07.251603+0000 0xbe1d     Default     0x0                  26226  0    rsyslogd: [com.apple.Libsystem.malloc:] rsyslogd(26226,0x1ef3da0c0) malloc: nano zone abandoned due to inability to reserve vm space.
+2025-10-09T20:10:46.4867640Z 
+2025-10-09T20:10:46.4868000Z 2025-10-09 20:08:07.915669+0000 0xbe4b     Error       0x0                  26226  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4868340Z 2025-10-09 20:08:07.915675+0000 0xbe4b     Error       0x0                  26226  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4868670Z 2025-10-09 20:08:07.915678+0000 0xbe4b     Error       0x0                  26226  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4869060Z 2025-10-09 20:08:10.882075+0000 0xbffe     Default     0x0                  26463  0    rsyslogd: [com.apple.Libsystem.malloc:] rsyslogd(26463,0x1ef3da0c0) malloc: nano zone abandoned due to inability to reserve vm space.
+2025-10-09T20:10:46.4869060Z 
+2025-10-09T20:10:46.4869450Z 2025-10-09 20:08:10.916938+0000 0xc028     Default     0x0                  26481  0    rsyslogd: [com.apple.Libsystem.malloc:] rsyslogd(26481,0x1ef3da0c0) malloc: nano zone abandoned due to inability to reserve vm space.
+2025-10-09T20:10:46.4869450Z 
+2025-10-09T20:10:46.4869850Z 2025-10-09 20:08:13.744096+0000 0xc125     Default     0x0                  26598  0    rsyslogd: [com.apple.Libsystem.malloc:] rsyslogd(26598,0x1ef3da0c0) malloc: nano zone abandoned due to inability to reserve vm space.
+2025-10-09T20:10:46.4869850Z 
+2025-10-09T20:10:46.4870190Z 2025-10-09 20:08:14.501169+0000 0xbcb0     Error       0x0                  26074  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4870520Z 2025-10-09 20:08:14.501179+0000 0xbcb0     Error       0x0                  26074  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4871150Z 2025-10-09 20:08:14.501181+0000 0xbcb0     Error       0x0                  26074  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4871490Z 2025-10-09 20:08:14.798766+0000 0xc028     Error       0x0                  26481  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4871850Z 2025-10-09 20:08:14.798772+0000 0xc028     Error       0x0                  26481  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4872230Z 2025-10-09 20:08:14.798775+0000 0xc028     Error       0x0                  26481  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4872590Z 2025-10-09 20:08:16.227588+0000 0xc125     Error       0x0                  26598  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4872920Z 2025-10-09 20:08:16.227616+0000 0xc125     Error       0x0                  26598  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4873310Z 2025-10-09 20:08:16.227634+0000 0xc125     Error       0x0                  26598  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4873700Z 2025-10-09 20:08:17.336717+0000 0xc1d7     Default     0x0                  26668  0    rsyslogd: [com.apple.Libsystem.malloc:] rsyslogd(26668,0x1ef3da0c0) malloc: nano zone abandoned due to inability to reserve vm space.
+2025-10-09T20:10:46.4873710Z 
+2025-10-09T20:10:46.4874040Z 2025-10-09 20:08:17.365111+0000 0xc218     Error       0x0                  26668  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4874370Z 2025-10-09 20:08:17.365118+0000 0xc218     Error       0x0                  26668  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4874710Z 2025-10-09 20:08:17.365120+0000 0xc218     Error       0x0                  26668  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4875120Z 2025-10-09 20:08:17.548880+0000 0xc200     Default     0x0                  26688  0    rsyslogd: [com.apple.Libsystem.malloc:] rsyslogd(26688,0x1ef3da0c0) malloc: nano zone abandoned due to inability to reserve vm space.
+2025-10-09T20:10:46.4875120Z 
+2025-10-09T20:10:46.4875500Z 2025-10-09 20:08:17.984820+0000 0xc243     Default     0x0                  26715  0    rsyslogd: [com.apple.Libsystem.malloc:] rsyslogd(26715,0x1ef3da0c0) malloc: nano zone abandoned due to inability to reserve vm space.
+2025-10-09T20:10:46.4875510Z 
+2025-10-09T20:10:46.4875840Z 2025-10-09 20:08:18.188730+0000 0xc24e     Error       0x0                  26688  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4876170Z 2025-10-09 20:08:18.188735+0000 0xc24e     Error       0x0                  26688  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4876500Z 2025-10-09 20:08:18.188737+0000 0xc24e     Error       0x0                  26688  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4876820Z 2025-10-09 20:08:18.784144+0000 0xc243     Error       0x0                  26715  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4877190Z 2025-10-09 20:08:18.784151+0000 0xc243     Error       0x0                  26715  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4877520Z 2025-10-09 20:08:18.784153+0000 0xc243     Error       0x0                  26715  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4877900Z 2025-10-09 20:08:20.656559+0000 0xc333     Default     0x0                  26831  0    rsyslogd: [com.apple.Libsystem.malloc:] rsyslogd(26831,0x1ef3da0c0) malloc: nano zone abandoned due to inability to reserve vm space.
+2025-10-09T20:10:46.4877910Z 
+2025-10-09T20:10:46.4878240Z 2025-10-09 20:08:22.789147+0000 0xc333     Error       0x0                  26831  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4878570Z 2025-10-09 20:08:22.789158+0000 0xc333     Error       0x0                  26831  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4878900Z 2025-10-09 20:08:22.789160+0000 0xc333     Error       0x0                  26831  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4879310Z 2025-10-09 20:08:23.870883+0000 0xbffe     Error       0x0                  26463  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4879640Z 2025-10-09 20:08:23.870895+0000 0xbffe     Error       0x0                  26463  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4879970Z 2025-10-09 20:08:23.870898+0000 0xbffe     Error       0x0                  26463  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4880350Z 2025-10-09 20:08:25.278275+0000 0xc453     Default     0x0                  26939  0    rsyslogd: [com.apple.Libsystem.malloc:] rsyslogd(26939,0x1ef3da0c0) malloc: nano zone abandoned due to inability to reserve vm space.
+2025-10-09T20:10:46.4880360Z 
+2025-10-09T20:10:46.4880690Z 2025-10-09 20:08:25.734323+0000 0xc4b1     Error       0x0                  26939  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4881020Z 2025-10-09 20:08:25.734332+0000 0xc4b1     Error       0x0                  26939  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4881350Z 2025-10-09 20:08:25.734336+0000 0xc4b1     Error       0x0                  26939  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4881730Z 2025-10-09 20:08:26.119391+0000 0xc488     Default     0x0                  26966  0    rsyslogd: [com.apple.Libsystem.malloc:] rsyslogd(26966,0x1ef3da0c0) malloc: nano zone abandoned due to inability to reserve vm space.
+2025-10-09T20:10:46.4881740Z 
+2025-10-09T20:10:46.4882070Z 2025-10-09 20:08:26.661122+0000 0xc4cb     Error       0x0                  26966  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4882400Z 2025-10-09 20:08:26.661133+0000 0xc4cb     Error       0x0                  26966  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4882730Z 2025-10-09 20:08:26.661135+0000 0xc4cb     Error       0x0                  26966  0    rsyslogd: (libsystem_info.dylib) [com.apple.network.libinfo:si_destination_compare] send failed: Invalid argument
+2025-10-09T20:10:46.4882790Z === Error Logs Collection ===
+2025-10-09T20:10:46.4882880Z Running gather-check-logs.sh (via srcdir/..)...
+2025-10-09T20:10:46.4882970Z find failing tests
+2025-10-09T20:10:46.4883130Z find: ./tests/rstb_096508_aa477339FVWx.spool: No such file or directory
+2025-10-09T20:10:46.4883210Z No failed-tests.log found
+2025-10-09T20:10:46.4883320Z not reporting failure as RSYSLOG_STATSURL is not set
+2025-10-09T20:10:46.4883430Z rsyslog pid file still exists, trying to shutdown...
+2025-10-09T20:10:46.4883690Z rsyslogd debug: info: trying to cooperatively stop input ../plugins/imdiag/.libs/imdiag, timeout 60000 ms
+2025-10-09T20:10:46.4883880Z rsyslogd debug: info: trying to cooperatively stop input imtcp, timeout 60000 ms
+2025-10-09T20:10:46.4883980Z rsyslog debug: main Q:Reg/w0: enter WrkrExecCleanup
+2025-10-09T20:10:46.4884070Z rsyslog debug: 0x105823ec0: worker exiting
+2025-10-09T20:10:46.4884150Z rsyslog debug: main Q:Reg/w0: thread joined
+2025-10-09T20:10:46.4884280Z 20:08:45[74]  FAIL: Test ./imtcp-tls-basic.sh (took 74 seconds)
+2025-10-09T20:10:46.4884370Z FAIL imtcp-tls-basic.sh (exit status: 1)
+2025-10-09T20:10:46.4884590Z Stats: LargeMmapAllocator: allocated 1 times, remains 0 (0 K) max 0 M; by size logs: 19:1; 
+2025-10-09T20:10:46.4885010Z Stats: LargeMmapAllocator: allocated 1 times, remains 0 (0 K) max 0 M; by size logs: 19:1; 
+2025-10-09T20:10:46.4885140Z file: ./tests/test-suite.log
+2025-10-09T20:10:46.4885200Z ==================================================
+2025-10-09T20:10:46.4885270Z    rsyslog 8.2510.0.daily: tests/test-suite.log
+2025-10-09T20:10:46.4885330Z ==================================================
+2025-10-09T20:10:46.4885330Z 
+2025-10-09T20:10:46.4885370Z # TOTAL: 66
+2025-10-09T20:10:46.4885410Z # PASS:  63
+2025-10-09T20:10:46.4885450Z # SKIP:  2
+2025-10-09T20:10:46.4885490Z # XFAIL: 0
+2025-10-09T20:10:46.4885530Z # FAIL:  1
+2025-10-09T20:10:46.4885570Z # XPASS: 0
+2025-10-09T20:10:46.4885610Z # ERROR: 0
+2025-10-09T20:10:46.4885610Z 
+2025-10-09T20:10:46.4967230Z Post job cleanup.
+2025-10-09T20:10:46.7850400Z [command]/opt/homebrew/bin/git version
+2025-10-09T20:10:46.8092380Z git version 2.50.1
+2025-10-09T20:10:46.8151160Z Copying '/Users/runner/.gitconfig' to '/Users/runner/work/_temp/341cb944-e986-4e48-b109-824ac184188b/.gitconfig'
+2025-10-09T20:10:46.8158570Z Temporarily overriding HOME='/Users/runner/work/_temp/341cb944-e986-4e48-b109-824ac184188b' before making global git config changes
+2025-10-09T20:10:46.8160650Z Adding repository directory to the temporary git global config as a safe directory
+2025-10-09T20:10:46.8162660Z [command]/opt/homebrew/bin/git config --global --add safe.directory /Users/runner/work/rsyslog/rsyslog
+2025-10-09T20:10:46.8280410Z [command]/opt/homebrew/bin/git config --local --name-only --get-regexp core\.sshCommand
+2025-10-09T20:10:46.8381640Z [command]/opt/homebrew/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+2025-10-09T20:10:46.9504070Z fatal: No url found for submodule path 'rsyslog' in .gitmodules
+2025-10-09T20:10:46.9550500Z ##[warning]The process '/opt/homebrew/bin/git' failed with exit code 128
+2025-10-09T20:10:46.9663270Z Cleaning up orphan processes


### PR DESCRIPTION
Add job logs to document the investigation and conclusion of a rare `EADDRINUSE` and `tcpflood` SEGV in the `imtcp-tls-basic.sh` test.

The `imtcp-tls-basic.sh` test on macOS runners with ThreadSanitizer occasionally failed with "Address already in use" during TCP socket binding, followed by a `tcpflood` segmentation fault. Analysis of the attached logs indicates this is likely due to a transient port collision/race or a libgnutls bug path under TSAN, rather than a core rsyslog bug, as other similar TLS tests passed. This issue is considered a one-off infrastructure/test flake.

---
<a href="https://cursor.com/background-agent?bcId=bc-2bf3d9e7-d003-4455-b30a-8056207ae69b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2bf3d9e7-d003-4455-b30a-8056207ae69b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

