### PR TITLE
Correct spelling errors in documentation

### DIFF
--- a/doc/contrib/cron_build_all_branches.sh
+++ b/doc/contrib/cron_build_all_branches.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Do not allow use of unitilized variables
+# Do not allow use of uninitialized variables
 set -u
 
 # Exit if any statement returns a non-true value
@@ -92,7 +92,7 @@ update_build_conf_variables() {
 
 echo ""
 echo "This script is intended to run with a clean repo version of the code."
-echo "Run the sphinx-build command manually if you want to see your uncommited changes."
+echo "Run the sphinx-build command manually if you want to see your uncommitted changes."
 echo "If you run this script with uncommitted and un-pushed changes, YOU WILL LOSE THOSE CHANGES!"
 echo ""
 echo "Press Enter to continue or Ctrl-C to cancel...."

--- a/doc/tools/release_build.sh
+++ b/doc/tools/release_build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Do not allow use of unitilized variables
+# Do not allow use of uninitialized variables
 set -u
 
 # Exit if any statement returns a non-true value

--- a/doc/utils/release_build.sh
+++ b/doc/utils/release_build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Do not allow use of unitilized variables
+# Do not allow use of uninitialized variables
 set -u
 
 # Exit if any statement returns a non-true value


### PR DESCRIPTION
### Summary (non-technical, complete)
Corrected several spelling errors in documentation-related shell scripts to improve readability and consistency.

### References
Refs:

### Notes (optional)
- Typos like "unitilized" (changed to "uninitialized") and "uncommited" (changed to "uncommitted") were fixed in `doc/contrib/cron_build_all_branches.sh`, `doc/tools/release_build.sh`, and `doc/utils/release_build.sh`.
- `codespell` was used to identify and apply these corrections.
- No functional changes were introduced.

---
<a href="https://cursor.com/background-agent?bcId=bc-f7bc755e-e0e6-42e0-8e4b-b5c3292455b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f7bc755e-e0e6-42e0-8e4b-b5c3292455b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

