### PR TITLE
Address rsyslog pull request feedback

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -38,6 +38,39 @@ extensions = ['edit_on_github',
 edit_on_github_project = 'https://github.com/rsyslog/rsyslog'
 edit_on_github_branch = 'main'
 
+# Offline Mermaid configuration: use vendored JS assets under _static
+MERMAID_JS_PATH = 'vendor/mermaid/mermaid.esm.min.mjs'
+MERMAID_ELK_JS_PATH = 'vendor/mermaid/mermaid-layout-elk.esm.min.mjs'
+D3_JS_PATH = 'vendor/d3/d3.min.js'
+
+try:
+    import sphinxcontrib.mermaid as _sphinx_mermaid  # type: ignore
+except ImportError:  # pragma: no cover
+    _sphinx_mermaid = None
+else:
+    # Configure the extension to load vendored assets instead of CDN URLs
+    mermaid_js_url = MERMAID_JS_PATH
+    d3_js_url = D3_JS_PATH
+    # Some versions may also honor this; harmless if unused
+    mermaid_elk_js_url = MERMAID_ELK_JS_PATH
+
+    # Initialize Mermaid from vendored ESM and register ELK layouts
+    mermaid_init_js = f"""
+(async () => {{
+  const base = (window.DOCUMENTATION_OPTIONS && window.DOCUMENTATION_OPTIONS.URL_ROOT) || './';
+  const mermaidModule = await import(base + '_static/{MERMAID_JS_PATH}');
+  const mermaid = mermaidModule.default ?? mermaidModule;
+  try {{
+    const elkModule = await import(base + '_static/{MERMAID_ELK_JS_PATH}');
+    const elkLayouts = elkModule.default ?? elkModule;
+    mermaid.registerLayoutLoaders(elkLayouts);
+  }} catch (e) {{
+    // Optional: ELK layouts not available
+  }}
+  mermaid.initialize({{ startOnLoad: true }});
+}})();
+""".strip()
+
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 


### PR DESCRIPTION
### Summary (non-technical, complete)
This change ensures that Mermaid diagrams in the Sphinx documentation render correctly during offline builds. Previously, `sphinxcontrib-mermaid` attempted to load assets from a CDN or incorrect local paths, causing build failures without internet access. This PR configures the extension to use vendored JavaScript assets, making the documentation fully self-contained for Mermaid rendering.

### References
Refs: https://github.com/alorbach/rsyslog/pull/57

### Notes (optional)
- This update specifically addresses the offline build issue for Mermaid diagrams in the documentation.
- **Impact:** Sphinx documentation builds with Mermaid diagrams now function correctly without internet access.
- **Before:** Mermaid diagrams failed to render in offline Sphinx builds due to incorrect asset loading.
- **After:** Mermaid diagrams render successfully in offline Sphinx builds using vendored assets.

---

#### Quick check (optional)
- Commit message follows rules (ASCII; title ≤62, body ≤72; `<component>:`).
- Commit message includes non-technical “why”, Impact (if behavior/tests changed),
  and a one-line Before/After when behavior changed.
- Used the Commit Assistant or mirrored its structure.

---
<a href="https://cursor.com/background-agent?bcId=bc-a72e34a7-3d84-46ff-819b-7ea3ca28b905"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a72e34a7-3d84-46ff-819b-7ea3ca28b905"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

