### PR TITLE
Update dist tarball and sitemap build

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3088,11 +3088,19 @@ fi
 
 
 dnl ---- gather doc files for EXTRA_DIST ----
-# .rst files
+# .rst files and selected assets from doc/source
 doc_src_files=`cd "$srcdir" && find doc/source -type f \( -name '*.rst' -o -name '*.conf' -o -name '*.jpg' -o -name '*.png' \) -print 2>/dev/null | LC_ALL=C sort`
+
+# Additional doc assets that must be shipped in dist tarball
+# - Vendored static JS/CSS used by the docs
+doc_vendor_files=`cd "$srcdir" && find doc/source/_static/vendor -type f -print 2>/dev/null | LC_ALL=C sort`
+# - Documentation build helper scripts and tools
+doc_tools_files=`cd "$srcdir" && find doc/tools -type f -print 2>/dev/null | LC_ALL=C sort`
 
 # assemble; keep paths relative to top (we cd into $srcdir above)
 DOC_FILES="$doc_src_files
+$doc_vendor_files
+$doc_tools_files
 doc/source/conf.py
 doc/source/conf_helpers.py
 doc/source/_ext/edit_on_github.py

--- a/doc/BUILDS_README.md
+++ b/doc/BUILDS_README.md
@@ -23,6 +23,10 @@ installation of other packages for your operating system that are not
 installed by following the current setup/prep directions in the
 [`README.md`](README.md) file.
 
+Note on sitemaps: local and preview builds do not emit `sitemap.xml` by default.
+For production docs where a sitemap is desired, opt in explicitly using either
+`make html-with-sitemap` or pass `-t with_sitemap` to `sphinx-build`.
+
 
 ## Generating release version of the docs
 
@@ -58,6 +62,12 @@ steps in this document.
 1. Tag the stable branch
 1. Push all changes to the remote
 1. Run the `tools/release_build.sh` script
+   - By default this produces HTML without a sitemap. If you require a sitemap
+     for production, either:
+     - run `make html-with-sitemap` and package manually, or
+     - run `sphinx-build -t with_sitemap -b html source build` in place of the
+       script’s build step, or
+     - invoke helper scripts with `--extra "-t with_sitemap"`.
 1. Sync the contents of the `build` directory over to the web server
 1. Sync the latest release doc tarball to where the previous release
    tarball is hosted. Update references to this tarball as necessary.
@@ -149,6 +159,7 @@ branch. Substitute `main` for any other branch that you wish to build.
    that path.
 1. Run `sphinx-build -D release="dev-build" -b html source build` to generate
    HTML format and `sphinx-build -b epub source build` to build an epub file.
+   - To include a sitemap, add `-t with_sitemap` or use `make html-with-sitemap`.
 
 
 
@@ -170,3 +181,4 @@ and is useful to identify a dev build from a release set of documentation.
 1. Run `git checkout main`
 1. Change into the documentation folder: `cd doc`
 1. Run `sphinx-build -b html source build` to generate HTML format and `sphinx-build -b epub source build` to build an epub file.
+   - To include a sitemap, add `-t with_sitemap` or use `make html-with-sitemap`.

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -11,7 +11,7 @@ define add_parallel_jobs
 	$(eval SPHINXOPTS += $(if $(filter -j%,$(SPHINXOPTS)),,$(filter -j%,$(MAKEFLAGS))))
 endef
 
-.PHONY: help clean html singlehtml json alljson
+.PHONY: help clean html html-with-sitemap singlehtml json alljson
 
 help:
 	@$(call add_parallel_jobs)
@@ -23,6 +23,13 @@ clean:
 html:
 	@$(call add_parallel_jobs)
 	@$(SPHINXBUILD) -M html "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+	@echo "Applying Mermaid offline fix..."
+	@python3 ./tools/fix-mermaid-offline.py "$(BUILDDIR)/html"
+
+# Build HTML with sitemap enabled (opt-in)
+html-with-sitemap:
+	@$(call add_parallel_jobs)
+	@$(SPHINXBUILD) -M html "$(SOURCEDIR)" "$(BUILDDIR)" -t with_sitemap $(SPHINXOPTS) $(O)
 	@echo "Applying Mermaid offline fix..."
 	@python3 ./tools/fix-mermaid-offline.py "$(BUILDDIR)/html"
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -92,13 +92,32 @@ Install the base packages for your distro. Only major distros are listed here:
 
 These provide Python 3, `venv`/`pip`, and `git`. If `python3 -m venv` is unavailable on your platform, install `virtualenv` via `pip` and the scripts below will fall back to it automatically.
 
+### Quickstart using make (recommended)
+
+From the repository root:
+
+- Build HTML (no sitemap):
+  - `make -C doc html`
+- Build HTML with sitemap (opt-in):
+  - `make -C doc html-with-sitemap`
+- Build single-page HTML (minimal layout):
+  - `make -C doc singlehtml`
+- List available builders/targets:
+  - `make -C doc help`
+
+Tips:
+- Pass extra Sphinx options via `SPHINXOPTS`, e.g. warnings-as-errors:
+  - `make -C doc html SPHINXOPTS="-W -q --keep-going"`
+- Use parallel jobs: `make -C doc -j4 html` (the Makefile forwards `-j` to Sphinx).
+
 ### Quickstart using helper scripts
 
-We provide simple scripts that create a virtual environment (if missing), install `doc/requirements.txt`, and build the docs.
+We provide simple scripts that create a virtual environment (if missing), install `doc/requirements.txt`, and build the docs. Prefer the Makefile targets above; use these scripts if `make` is unavailable.
 
 -   Linux:
     -   `./doc/tools/build-doc-linux.sh --clean --format html`
     -   Options: `--strict` (treat warnings as errors), `--format html|epub`, `--extra "<opts>"` for extra `sphinx-build` options.
+    -   Optional sitemap: add `--extra "-t with_sitemap"` to enable sitemap generation.
 -   Windows (PowerShell):
     -   `powershell -ExecutionPolicy Bypass -File .\doc\tools\build-doc-windows.ps1 -Clean -Format html`
     -   Options: `-Strict`, `-Format html|epub`, `-Extra "<opts>"`.
@@ -163,14 +182,18 @@ If you prefer the manual route instead of the helper script above:
 
 ### Generate documentation
 
-1.  Generate HTML format:
-    1.  `sphinx-build -b html source build`
+1.  Generate HTML format (Makefile preferred):
+    -   `make -C doc html` (no sitemap)
+    -   `make -C doc html-with-sitemap` (includes sitemap)
+    -   Fallback (no Makefile available): `sphinx-build -b html source build`
+        -   With sitemap: add `-t with_sitemap`
 2.  Generate EPUB format:
-    1.  `sphinx-build -b epub source build`
+    -   `make -C doc epub`
+    -   Fallback: `sphinx-build -b epub source build`
 3.  Review generated contents:
-    -   Open `rsyslog/doc/build/index.html` in a browser.
-    -   Use Calibre, Microsoft Edge, Okular, Google Play Books, or any other
-        EPUB compatible reader to view the `rsyslog/doc/build/rsyslog.epub` file.
+    -   Makefile builds: open `rsyslog/doc/build/html/index.html`.
+    -   Direct Sphinx builds: open `rsyslog/doc/build/index.html`.
+    -   Use any EPUB reader to view `rsyslog/doc/build/rsyslog.epub`.
 
 ---
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -34,7 +34,6 @@ extensions = ['edit_on_github',
               'sphinx.ext.todo',
               'rsyslog_lexer',
               'sphinxcontrib.mermaid',
-              'sphinx_sitemap',
              ]
 edit_on_github_project = 'https://github.com/rsyslog/rsyslog'
 edit_on_github_branch = 'main'
@@ -367,10 +366,20 @@ suppress_warnings = ['epub.unknown_project_files']
 RSYSLOG_BASE_URL = 'https://www.rsyslog.com'
 html_baseurl = f'{RSYSLOG_BASE_URL}/doc/'
 
-# Sitemap configuration to remove language/version from URLs
-sitemap_url_scheme = "{link}"
-sitemap_localtolinks = False
-sitemap_filename = "sitemap.xml"
+# Enable sitemap generation only when explicitly requested
+if tags.has('with_sitemap'):
+    try:
+        import sphinx_sitemap  # type: ignore
+    except ImportError:
+        # Optional extension - sitemap generation skipped if not installed
+        pass
+    else:
+        extensions.append('sphinx_sitemap')
+
+        # Sitemap configuration to remove language/version from URLs
+        sitemap_url_scheme = "{link}"
+        sitemap_localtolinks = False
+        sitemap_filename = "sitemap.xml"
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.


### PR DESCRIPTION
### Summary (non-technical, complete)
This PR ensures that all essential documentation assets, including vendored JavaScript/CSS and build helper scripts, are correctly included in the `make dist` tarball. It also refines the documentation build process by making sitemap generation an opt-in feature, preventing `sitemap.xml` from being created during standard local `make html` builds, which is unnecessary for local viewing. A new `make html-with-sitemap` target is introduced for explicit sitemap generation.

### References
Refs: https://github.com/rsyslog/rsyslog/pull/6260

### Notes (optional)
*   **Impact:** The default `make -C doc html` command no longer generates `sitemap.xml`.
*   **Before:**
    *   `make -C doc html` would generate `sitemap.xml`.
    *   `doc/tools` and `doc/source/_static/vendor` were not included in the `make dist` tarball.
*   **After:**
    *   `make -C doc html` does *not* generate `sitemap.xml`. Use `make -C doc html-with-sitemap` to generate it.
    *   `doc/tools` and `doc/source/_static/vendor` are now included in the `make dist` tarball.

---

#### Quick check (optional)
- Commit message follows rules (ASCII; title ≤62, body ≤72; `<component>:`).
- Commit message includes non-technical “why”, Impact (if behavior/tests changed),
  and a one-line Before/After when behavior changed.
- Used the Commit Assistant or mirrored its structure.

---

#### Git workflow tips (optional, but helps reviews)
- Start by crafting the commit message locally (use the Assistant).
- If you already committed, improve it with:
  ```
  git commit --amend
  ```
- Squash related commits before PR where appropriate.
- Push your branch and then open the PR.
- If key info is only in the PR text, maintainers may ask you to move it
  into the commit message for a clean history.

---
<a href="https://cursor.com/background-agent?bcId=bc-d7c5b81d-dc44-4537-b185-e90d5bed7bd5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d7c5b81d-dc44-4537-b185-e90d5bed7bd5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

