### PR TITLE
Add Sysmon Event Support to mmsnareparse Module

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -8,7 +8,7 @@ BUILDDIR = build
 
 # Function to add parallel jobs from MAKEFLAGS to SPHINXOPTS
 define add_parallel_jobs
-	$(eval SPHINXOPTS += $(if $(filter -j%,$(SPHINXOPTS)),,$(filter -j%,$(MAKEFLAGS))))
+        $(eval SPHINXOPTS += $(if $(filter -j%,$(SPHINXOPTS)),,$(filter -j%,$(MAKEFLAGS))))
 endef
 
 .PHONY: help clean html html-with-sitemap singlehtml json alljson

--- a/doc/README.md
+++ b/doc/README.md
@@ -197,6 +197,60 @@ If you prefer the manual route instead of the helper script above:
 
 ---
 
+### JSON-LD metadata and author resolution
+
+JSON-LD is injected by default for HTML documentation builds. To skip emitting it
+(useful for package maintainers who want to minimize offline footprint), run the
+build with `DISABLE_JSON_LD=1` in the environment before invoking Sphinx or
+`make -C doc html`.【F:doc/source/conf.py†L370-L633】 Author detection for that JSON-LD
+block follows this order:
+
+1. Use `:author:` or `:authors:` from a page's ``.. meta::`` block. If multiple
+   authors are provided, only the first is used.【F:doc/source/conf.py†L595-L604】
+2. Fall back to the page context's ``author`` value if Sphinx sets one.
+3. Fall back to the global `author` configured in ``conf.py``
+   (``Rainer Gerhards and Others``).【F:doc/source/conf.py†L603-L604】
+
+Most existing pages define only description/keyword metadata, so they inherit the
+global author. For example, ``doc/source/concepts/log_pipeline/stages.rst`` has a
+``.. meta::`` block without an author entry, so the JSON-LD author defaults to
+the global value.【F:doc/source/concepts/log_pipeline/stages.rst†L1-L16】 To set a
+specific author on a page, add an author entry to its ``.. meta::`` block:
+
+```
+.. meta::
+   :author: Jane Doe
+   :description: Short synopsis for search and JSON-LD.
+```
+
+This value will be used for the JSON-LD ``author`` field during HTML builds unless
+`DISABLE_JSON_LD` is set.
+
+FAQ pages automatically emit ``FAQPage`` schema with one question/answer pair per
+section title and body. Other pages continue to use ``TechArticle`` by default.
+Set ``DISABLE_JSON_LD`` to suppress both forms during HTML builds (e.g., for
+space-constrained offline packages).【F:doc/source/conf.py†L606-L669】
+
+### Adding page metadata for JSON-LD
+
+Place a ``.. meta::`` block near the top of an ``.rst`` file to enrich the
+generated JSON-LD (and HTML meta tags). Populate ``:author:``,
+``:description:``, and ``:keywords:`` where appropriate. This keeps search
+snippets and structured data aligned for both human readers and generative AI
+consumers.
+
+```
+.. meta::
+   :author: Lee Documentation
+   :description: Short synopsis used in page previews and JSON-LD.
+   :keywords: rsyslog, queue, reliability
+```
+
+FAQ pages (``doc/source/faq/*.rst``) automatically produce ``FAQPage`` JSON-LD.
+Write each question as a section title and include the answer in the section
+body. Use a ``.. meta::`` block to add a synopsis for that FAQ page so language
+models and search engines see concise context in the emitted JSON-LD.
+
 ## CI deployment to GitHub Pages
 
 A GitHub Actions workflow automatically builds and deploys documentation previews for pull requests and updates the main documentation site.

--- a/doc/source/configuration/modules/omhdfs.rst
+++ b/doc/source/configuration/modules/omhdfs.rst
@@ -99,7 +99,7 @@ Examples
 Example 1
 ---------
 
-.. code-block:: rsyslog
+.. code-block:: none
 
    $ModLoad omhdfs
    $omhdfsFileName /var/log/hdfs/system.log

--- a/doc/source/development/doc_style_guide.rst
+++ b/doc/source/development/doc_style_guide.rst
@@ -124,3 +124,24 @@ Maintenance
 - Review docs at every release for outdated content.
 - Check for deprecated parameters and move them to Legacy.
 - Run `make linkcheck` to verify links.
+
+Metadata and JSON-LD
+--------------------
+
+- Add a ``.. meta::`` block near the top of each page to keep HTML meta tags and
+  JSON-LD in sync. Populate at least ``:description:`` and ``:keywords:``, and
+  set ``:author:`` when the page has a specific owner.
+
+  .. code-block:: rst
+
+     .. meta::
+        :author: Ada Writer
+        :description: One-line summary reused in JSON-LD and previews.
+        :keywords: rsyslog, queues, reliability
+
+- FAQ pages (``faq/*.rst``) automatically emit ``FAQPage`` JSON-LD. Write each
+  question as the section title and keep the answer in the section body so the
+  extractor can pair them correctly.
+- Generative AI assistants should preserve existing ``.. meta::`` blocks,
+  update only the specific fields required for a change, and avoid inventing
+  authors when none are provided.

--- a/doc/source/reference/parameters/omhdfs-omhdfsdefaulttemplate.rst
+++ b/doc/source/reference/parameters/omhdfs-omhdfsdefaulttemplate.rst
@@ -33,7 +33,7 @@ Module usage
 ------------
 .. _omhdfs.parameter.module.omhdfsdefaulttemplate-usage:
 
-.. code-block:: rsyslog
+.. code-block:: none
 
    $ModLoad omhdfs
    $omhdfsFileName /var/log/hdfs/system.log

--- a/doc/source/reference/parameters/omhdfs-omhdfsfilename.rst
+++ b/doc/source/reference/parameters/omhdfs-omhdfsfilename.rst
@@ -30,7 +30,7 @@ Module usage
 ------------
 .. _omhdfs.parameter.module.omhdfsfilename-usage:
 
-.. code-block:: rsyslog
+.. code-block:: none
 
    $ModLoad omhdfs
    $omhdfsFileName /var/log/hdfs/system.log

--- a/doc/source/reference/parameters/omhdfs-omhdfshost.rst
+++ b/doc/source/reference/parameters/omhdfs-omhdfshost.rst
@@ -31,7 +31,7 @@ Module usage
 ------------
 .. _omhdfs.parameter.module.omhdfshost-usage:
 
-.. code-block:: rsyslog
+.. code-block:: none
 
    $ModLoad omhdfs
    $omhdfsHost hdfs01.example.net

--- a/doc/source/reference/parameters/omhdfs-omhdfsport.rst
+++ b/doc/source/reference/parameters/omhdfs-omhdfsport.rst
@@ -31,7 +31,7 @@ Module usage
 ------------
 .. _omhdfs.parameter.module.omhdfsport-usage:
 
-.. code-block:: rsyslog
+.. code-block:: none
 
    $ModLoad omhdfs
    $omhdfsHost hdfs01.example.net

--- a/plugins/mmsnareparse/Makefile.am
+++ b/plugins/mmsnareparse/Makefile.am
@@ -5,4 +5,4 @@ mmsnareparse_la_CPPFLAGS = $(RSRT_CFLAGS) $(PTHREADS_CFLAGS)
 mmsnareparse_la_LDFLAGS = -module -avoid-version $(LIBFASTJSON_LIBS)
 mmsnareparse_la_LIBADD =
 
-EXTRA_DIST =
+EXTRA_DIST = sysmon_definitions.json

--- a/plugins/mmsnareparse/mmsnareparse.c
+++ b/plugins/mmsnareparse/mmsnareparse.c
@@ -3045,7 +3045,7 @@ static const char *skip_rfc3164_header(const char *p) {
  * @return Pointer to the beginning of the Snare payload or @c NULL when no
  *         payload could be identified.
  */
-static const char *locate_snare_payload(const char *msg) {
+static const char *locate_snare_payload(const char *msg, smsg_t *pMsg) {
     const char *cursor;
     const char *afterPri;
     const char *candidate;
@@ -3065,6 +3065,81 @@ static const char *locate_snare_payload(const char *msg) {
         }
     }
     cursor = skip_lws_const(afterPri);
+
+    // Check if MSWinEventLog is in the syslog tag (RFC3164 parser moves it there)
+    // If so, the message body should start with version, channel, etc.
+    // But after syslog parsing, the message might start with timestamp instead
+    // We need to find the version ("1") followed by tab and channel
+    if (pMsg != NULL) {
+        uchar *tagBuf = NULL;
+        int tagLen = 0;
+        getTAG(pMsg, &tagBuf, &tagLen, 0);
+        if (tagBuf != NULL && tagLen > 0 && strstr((const char *)tagBuf, "MSWinEventLog") != NULL) {
+            // MSWinEventLog is in tag - message body should be: version, channel, record, timestamp, eventid,
+            // provider... But after syslog parsing, it might be: timestamp, eventid, provider... (version and channel
+            // missing) Or it might be: version, channel, record, timestamp, eventid, provider... Look for pattern:
+            // single digit "1" followed by tab/escaped-tab, then channel name
+            const char *p = cursor;
+            while (p != NULL && *p != '\0') {
+                // Skip whitespace
+                while (*p == ' ' || *p == '\t') p++;
+                // Look for single digit "1" (version) followed by tab/escaped-tab
+                if (*p == '1' &&
+                    (p[1] == '\t' || p[1] == ' ' || (p[1] == '#' && p[2] == '0' && p[3] == '1' && p[4] == '1'))) {
+                    // Check if followed by channel pattern (starts with "Microsoft-Windows-")
+                    const char *afterVersion = p + 1;
+                    if (*afterVersion == '#') {
+                        afterVersion += 4;  // Skip #011
+                    } else {
+                        afterVersion++;  // Skip tab/space
+                    }
+                    while (*afterVersion == ' ' || *afterVersion == '\t') afterVersion++;
+                    if (strncmp(afterVersion, "Microsoft-Windows-", 19) == 0) {
+                        // Found version followed by channel - this is the correct start
+                        dbgprintf(
+                            "[mmsnareparse DEBUG] locate_snare_payload: found MSWinEventLog in syslog tag, found "
+                            "version+channel at '%s'\n",
+                            p);
+                        return p;
+                    }
+                }
+                // Also check for multi-digit version (could be other numbers)
+                if (*p >= '0' && *p <= '9') {
+                    const char *versionEnd = p;
+                    while (*versionEnd >= '0' && *versionEnd <= '9') versionEnd++;
+                    if (versionEnd > p && (*versionEnd == '\t' || *versionEnd == ' ' ||
+                                           (versionEnd[0] == '#' && versionEnd[1] == '0' && versionEnd[2] == '1' &&
+                                            versionEnd[3] == '1'))) {
+                        const char *afterVersion = versionEnd;
+                        if (*afterVersion == '#') {
+                            afterVersion += 4;
+                        } else {
+                            afterVersion++;
+                        }
+                        while (*afterVersion == ' ' || *afterVersion == '\t') afterVersion++;
+                        if (strncmp(afterVersion, "Microsoft-Windows-", 19) == 0) {
+                            dbgprintf(
+                                "[mmsnareparse DEBUG] locate_snare_payload: found MSWinEventLog in syslog tag, found "
+                                "version+channel at '%s'\n",
+                                p);
+                            return p;
+                        }
+                    }
+                }
+                p++;
+            }
+            // If we can't find version+channel pattern, the version and channel were removed by syslog parser
+            // In this case, we need to extract channel from the original message
+            // Return cursor for tokenization, but channel extraction will use rawMsg
+            dbgprintf(
+                "[mmsnareparse DEBUG] locate_snare_payload: found MSWinEventLog in syslog tag, version+channel not "
+                "found, using cursor '%s'\n",
+                cursor);
+            return cursor;
+        }
+    }
+
+    // First, check if MSWinEventLog is at the cursor (direct match)
     if (cursor != NULL && strncmp(cursor, "MSWinEventLog", 13) == 0) {
         dbgprintf("[mmsnareparse DEBUG] locate_snare_payload: found MSWinEventLog at '%s'\n", cursor);
         return cursor;
@@ -3072,10 +3147,11 @@ static const char *locate_snare_payload(const char *msg) {
 
     // Handle case where syslog header has been parsed and we have a timestamp followed by MSWinEventLog
     if (cursor != NULL) {
-        // Look for MSWinEventLog in the message (after syslog parsing)
-        const char *msWinEventLog = strstr(cursor, "MSWinEventLog");
+        // Look for MSWinEventLog anywhere in the original message
+        // This is the most reliable way to detect RFC5424 format
+        const char *msWinEventLog = strstr(msg, "MSWinEventLog");
         if (msWinEventLog != NULL) {
-            dbgprintf("[mmsnareparse DEBUG] locate_snare_payload: found MSWinEventLog after parsing at '%s'\n",
+            dbgprintf("[mmsnareparse DEBUG] locate_snare_payload: found MSWinEventLog in message at '%s'\n",
                       msWinEventLog);
             return msWinEventLog;
         }
@@ -3102,6 +3178,30 @@ static const char *locate_snare_payload(const char *msg) {
                 }
             }
             eventIdStart++;
+        }
+        // After syslog parsing, MSWinEventLog may be removed from the message
+        // Try to find MSWinEventLog anywhere in the original message
+        // This allows us to use RFC5424 format with channel in tokens[2]
+        const char *msWinEventLogPos = strstr(msg, "MSWinEventLog");
+        if (msWinEventLogPos != NULL) {
+            // Found MSWinEventLog in original message - use RFC5424 format
+            // If it's before cursor, return it directly
+            // If it's after cursor, we still want to use it (cursor might be after syslog header)
+            if (msWinEventLogPos < cursor) {
+                dbgprintf(
+                    "[mmsnareparse DEBUG] locate_snare_payload: found MSWinEventLog before cursor, using RFC5424 "
+                    "format at '%s'\n",
+                    msWinEventLogPos);
+                return msWinEventLogPos;
+            } else {
+                // MSWinEventLog is after cursor (e.g., after syslog header)
+                // This is still valid - return it to use RFC5424 format
+                dbgprintf(
+                    "[mmsnareparse DEBUG] locate_snare_payload: found MSWinEventLog after cursor, using RFC5424 format "
+                    "at '%s'\n",
+                    msWinEventLogPos);
+                return msWinEventLogPos;
+            }
         }
         // If we didn't find EventID pattern, try looking for Microsoft-Windows-Security-Auditing
         // but we need to go back to find the EventID that comes before it
@@ -3420,6 +3520,21 @@ static const field_pattern_t *select_field_pattern(parse_context_t *ctx,
 
     if (bestSection != NULL) return bestSection;
     if (bestGeneric != NULL) return bestGeneric;
+    // If sectionName is NULL and we have a fallback, prefer EventData section patterns
+    if (sectionName == NULL && bestFallback != NULL) {
+        // Look for EventData section pattern specifically
+        for (size_t pass = 0; pass < 2; ++pass) {
+            const field_pattern_t *patterns = (pass == 0) ? ctx->eventPatterns : ctx->corePatterns;
+            size_t patternCount = (pass == 0) ? eventCount : coreCount;
+            for (size_t i = 0; i < patternCount; ++i) {
+                const field_pattern_t *candidate = &patterns[i];
+                if (pattern_matches(candidate, label, canon) && candidate->section != NULL &&
+                    strcmp(candidate->section, "EventData") == 0) {
+                    return candidate;
+                }
+            }
+        }
+    }
     return bestFallback;
 }
 
@@ -3838,7 +3953,99 @@ static void parse_key_value_sequence(parse_context_t *ctx,
               text != NULL ? text : "<null>", sectionName != NULL ? sectionName : "<none>");
 
     key_value_callback_t cb = {.ctx = ctx, .target = target, .sectionName = sectionName};
+
+    // First try tokenize_on_multispace (for multi-space separated tokens)
     tokenize_on_multispace(text, strlen(text), parse_key_value_token, &cb);
+
+    // If that didn't work (single-space separated key-value pairs), parse directly
+    // Look for patterns like "Key: Value" where Key starts with uppercase
+    const char *p = text;
+    const char *end = text + strlen(text);
+    while (p < end) {
+        // Skip whitespace
+        while (p < end && isspace((unsigned char)*p)) p++;
+        if (p >= end) break;
+
+        // Look for a label start (uppercase letter)
+        if (!isupper((unsigned char)*p)) {
+            p++;
+            continue;
+        }
+
+        // Find the colon - keys should be single words (alphanumeric, no spaces)
+        // This prevents matching "Event ID 3 User:" as a key
+        const char *keyStart = p;
+        const char *keyEnd = keyStart;
+        // Find the end of the key (alphanumeric characters only, no spaces)
+        while (keyEnd < end && isalnum((unsigned char)*keyEnd)) {
+            keyEnd++;
+        }
+        // If we didn't find a colon right after the key, this isn't a valid key-value pair
+        if (keyEnd >= end || *keyEnd != ':') {
+            p++;
+            continue;
+        }
+        const char *colon = keyEnd;
+        p = colon + 1;  // Skip colon, update p
+
+        // Extract key
+        size_t keyLen = colon - keyStart;
+        char *key = trim_copy(keyStart, keyLen);
+        if (key == NULL || *key == '\0') {
+            if (key) free(key);
+            continue;
+        }
+
+        // Skip whitespace after colon
+        while (p < end && isspace((unsigned char)*p)) p++;
+
+        // Find the value end (next key-value pair pattern: space + uppercase + alphanumeric + colon)
+        // Values can contain: letters, numbers, spaces, backslashes, hyphens, and other characters
+        // Only stop when we find a complete key pattern: whitespace + uppercase + alphanumeric_word + colon
+        const char *valueStart = p;
+        const char *valueEnd = valueStart;
+        while (valueEnd < end) {
+            // Look for potential start of next key: whitespace + uppercase letter
+            // We need to check this carefully to avoid false positives when values contain
+            // uppercase letters, spaces, or backslashes (e.g., "CORP\NETWORK SERVICE")
+            if (valueEnd > valueStart && isspace((unsigned char)*(valueEnd - 1)) && isupper((unsigned char)*valueEnd)) {
+                // Potential key start found. Verify it's a complete key pattern:
+                // 1. Must be a single alphanumeric word (no spaces, backslashes, etc.)
+                // 2. Must be followed immediately by a colon
+                const char *keyCandidate = valueEnd;
+                const char *candidateKeyEnd = keyCandidate;
+
+                // Scan for alphanumeric characters only (keys are single words)
+                while (candidateKeyEnd < end && isalnum((unsigned char)*candidateKeyEnd)) {
+                    candidateKeyEnd++;
+                }
+
+                // Check if we have a valid key pattern:
+                // - Must have at least one alphanumeric character
+                // - Must be followed immediately by a colon (no spaces or other chars)
+                // - The character before keyCandidate must be whitespace (already checked above)
+                if ((candidateKeyEnd - keyCandidate) > 0 && candidateKeyEnd < end && *candidateKeyEnd == ':') {
+                    // Found a complete key pattern - this is the start of the next key-value pair
+                    // Back up to the whitespace before the key (start of next pair)
+                    valueEnd = keyCandidate - 1;  // Point to the space before the key
+                    break;
+                }
+                // Not a valid key pattern - continue scanning (this might be part of the value)
+            }
+            valueEnd++;
+        }
+
+        // Extract value
+        size_t valueLen = valueEnd - valueStart;
+        char *value = trim_copy(valueStart, valueLen);
+        if (value != NULL) {
+            handle_key_value(ctx, target, sectionName, key, value);
+            free(value);
+        }
+        free(key);
+
+        p = valueEnd;
+    }
 }
 
 static void parse_privilege_sequence(parse_context_t *ctx, const char *text) {
@@ -4241,8 +4448,26 @@ static void parse_line(parse_context_t *ctx, char *line) {
         } else {
             handle_general_key(ctx, label, "");
         }
+        // Parse remaining key-value pairs in the rest of the line
+        // Even if find_next_token didn't find a token (e.g., key-value pairs separated by single spaces),
+        // we should still try to parse the rest as key-value pairs
         if (nextToken != NULL) {
             parse_key_value_sequence(ctx, NULL, nextToken, NULL);
+        } else {
+            // No next token found (key-value pairs separated by single spaces)
+            // Check if the rest contains key-value pairs (has colons) and parse them
+            const char *remaining = valueEnd;
+            while (remaining < restEnd && *remaining == ' ') ++remaining;
+            if (remaining < restEnd && strchr(remaining, ':') != NULL) {
+                dbgprintf("[mmsnareparse DEBUG] parse_line: parsing remaining content as key-value pairs: '%s'\n",
+                          remaining);
+                parse_key_value_sequence(ctx, NULL, remaining, NULL);
+            } else if (valueStart < restEnd && strchr(valueStart, ':') != NULL) {
+                // The value itself might contain key-value pairs - parse the entire rest
+                dbgprintf("[mmsnareparse DEBUG] parse_line: parsing entire rest as key-value pairs: '%s'\n",
+                          valueStart);
+                parse_key_value_sequence(ctx, NULL, valueStart, NULL);
+            }
         }
     }
 }
@@ -4291,8 +4516,11 @@ static void parse_description(parse_context_t *ctx, const char *desc) {
  * @param ctx        Active parsing context.
  * @param tokens     Array of tab-delimited tokens that form the header.
  * @param tokenCount Number of valid entries in @p tokens.
+ * @param rawMsg     Original message text for extracting channel when not in tokens (can be NULL).
+ *                   This is the full message text before locate_snare_payload processing.
  */
-static void populate_event_metadata(parse_context_t *ctx, char **tokens, size_t tokenCount) {
+static void populate_event_metadata(
+    parse_context_t *ctx, char **tokens, size_t tokenCount, const char *rawMsg, smsg_t *pMsg) {
     // Detect format based on token structure
     // RFC5424 format: MSWinEventLog, version, channel, record, timestamp, eventid, provider, n/a, n/a, eventtype,
     // computer, categorytext, empty, empty, description RFC3164 format: year, eventid, provider, n/a, n/a, eventtype,
@@ -4301,13 +4529,76 @@ static void populate_event_metadata(parse_context_t *ctx, char **tokens, size_t 
     size_t eventIdIdx, providerIdx, eventTypeIdx, computerIdx, categoryTextIdx;
 
     // Check if this is RFC5424 format (MSWinEventLog at tokens[0])
+    // Also check if MSWinEventLog is in the original message or syslog tag
+    // (RFC3164 syslog parser may move MSWinEventLog to SyslogTAG)
+    bool isRFC5424 = false;
     if (tokenCount > 0 && !is_placeholder(tokens[0]) && strcmp(tokens[0], "MSWinEventLog") == 0) {
+        isRFC5424 = true;
+    } else if (rawMsg != NULL && strstr(rawMsg, "MSWinEventLog") != NULL) {
+        // MSWinEventLog found in original message - treat as RFC5424 format
+        isRFC5424 = true;
+    } else if (pMsg != NULL) {
+        // Check if MSWinEventLog is in the syslog tag (RFC3164 parser moves it there)
+        uchar *tagBuf = NULL;
+        int tagLen = 0;
+        getTAG(pMsg, &tagBuf, &tagLen, 0);
+        if (tagBuf != NULL && tagLen > 0) {
+            // Check if tag contains MSWinEventLog
+            if (strstr((const char *)tagBuf, "MSWinEventLog") != NULL) {
+                isRFC5424 = true;
+            }
+        }
+    }
+
+    if (isRFC5424) {
         // RFC5424 format
-        eventIdIdx = 5;
-        providerIdx = 6;
-        eventTypeIdx = 9;
-        computerIdx = 10;
-        categoryTextIdx = 11;
+        // Check if MSWinEventLog is in syslog tag (RFC3164 parser moved it)
+        bool msWinInTag = false;
+        if (pMsg != NULL && (tokenCount == 0 || is_placeholder(tokens[0]) || strcmp(tokens[0], "MSWinEventLog") != 0)) {
+            uchar *tagBuf = NULL;
+            int tagLen = 0;
+            getTAG(pMsg, &tagBuf, &tagLen, 0);
+            if (tagBuf != NULL && tagLen > 0 && strstr((const char *)tagBuf, "MSWinEventLog") != NULL) {
+                msWinInTag = true;
+            }
+        }
+        if (msWinInTag) {
+            // MSWinEventLog in tag: message body structure depends on what syslog parser did
+            // If version and channel are present: version=0, channel=1, record=2, timestamp=3, eventid=4, provider=5...
+            // If version and channel were removed: timestamp=0, eventid=1, provider=2...
+            // Check if tokens[0] looks like a timestamp (contains month name like "Nov", "Mar", "Jun")
+            bool versionChannelPresent = false;
+            if (tokenCount > 1 && tokens[0] != NULL && tokens[1] != NULL) {
+                // Check if tokens[0] is a single digit (version) and tokens[1] starts with "Microsoft-Windows-"
+                if (tokens[0][0] >= '0' && tokens[0][0] <= '9' && tokens[0][1] == '\0' &&
+                    strncmp(tokens[1], "Microsoft-Windows-", 19) == 0) {
+                    versionChannelPresent = true;
+                }
+            }
+            if (versionChannelPresent) {
+                // Version and channel present: version=0, channel=1, record=2, timestamp=3, eventid=4, provider=5
+                eventIdIdx = 4;
+                providerIdx = 5;
+                eventTypeIdx = 8;
+                computerIdx = 9;
+                categoryTextIdx = 10;
+            } else {
+                // Version and channel removed by syslog parser: timestamp=0, eventid=1, provider=2
+                // But tokens[0] might be timestamp, tokens[1] is EventID
+                eventIdIdx = 1;
+                providerIdx = 2;
+                eventTypeIdx = 5;
+                computerIdx = 6;
+                categoryTextIdx = 7;
+            }
+        } else {
+            // Standard RFC5424: MSWinEventLog, version, channel, record, timestamp, eventid, provider...
+            eventIdIdx = 5;
+            providerIdx = 6;
+            eventTypeIdx = 9;
+            computerIdx = 10;
+            categoryTextIdx = 11;
+        }
     } else {
         // RFC3164 format
         eventIdIdx = 1;
@@ -4330,8 +4621,154 @@ static void populate_event_metadata(parse_context_t *ctx, char **tokens, size_t 
         json_add_string(ctx->event, "Provider", tokens[providerIdx]);
     if (tokenCount > eventTypeIdx && !is_placeholder(tokens[eventTypeIdx]))
         json_add_string(ctx->event, "EventType", tokens[eventTypeIdx]);
-    // Add Channel field - for Windows security events, this is typically "Security"
-    json_add_string(ctx->event, "Channel", "Security");
+    // Extract Channel field for RFC5424 format (MSWinEventLog)
+    // For RFC3164 format, try to extract from raw message, fall back to "Security"
+    if (isRFC5424) {
+        // RFC5424 format: channel location depends on where MSWinEventLog is
+        if (tokenCount > 0 && !is_placeholder(tokens[0]) && strcmp(tokens[0], "MSWinEventLog") == 0) {
+            // Standard RFC5424: MSWinEventLog at tokens[0], channel is at tokens[2]
+            if (tokenCount > 2 && !is_placeholder(tokens[2])) {
+                json_add_string(ctx->event, "Channel", tokens[2]);
+            } else {
+                json_add_string(ctx->event, "Channel", "Security");
+            }
+        } else {
+            // MSWinEventLog is in syslog tag (RFC3164 parser moved it)
+            // Check if version and channel are present in tokens
+            bool channelInTokens = false;
+            size_t channelIdx = 1;
+            if (tokenCount > 1 && tokens[0] != NULL && tokens[1] != NULL) {
+                // Check if tokens[0] is version (single digit) and tokens[1] is channel (starts with
+                // "Microsoft-Windows-")
+                if (tokens[0][0] >= '0' && tokens[0][0] <= '9' && tokens[0][1] == '\0' &&
+                    strncmp(tokens[1], "Microsoft-Windows-", 19) == 0) {
+                    channelIdx = 1;
+                    channelInTokens = true;
+                }
+            }
+            if (channelInTokens && tokenCount > channelIdx && !is_placeholder(tokens[channelIdx])) {
+                json_add_string(ctx->event, "Channel", tokens[channelIdx]);
+            } else {
+                // Fallback: extract from rawMsg (original message before syslog parsing)
+                const char *channel = "Security";  // default
+                if (rawMsg != NULL) {
+                    // Look for MSWinEventLog followed by tab/escaped-tab, then version, then tab, then channel
+                    const char *msWinPos = strstr(rawMsg, "MSWinEventLog");
+                    if (msWinPos != NULL) {
+                        const char *afterMSWin = msWinPos + 13;  // Skip "MSWinEventLog"
+                        // Skip tab/escaped-tab and version
+                        if (*afterMSWin == '\t' || *afterMSWin == ' ' ||
+                            (afterMSWin[0] == '#' && afterMSWin[1] == '0' && afterMSWin[2] == '1' &&
+                             afterMSWin[3] == '1')) {
+                            // Skip tab/escaped-tab
+                            if (*afterMSWin == '#') {
+                                afterMSWin += 4;
+                            } else {
+                                afterMSWin++;
+                            }
+                            afterMSWin = skip_lws_const(afterMSWin);
+                            // Skip version (single digit typically)
+                            while (*afterMSWin >= '0' && *afterMSWin <= '9') {
+                                afterMSWin++;
+                            }
+                            // Skip next tab/escaped-tab
+                            if (*afterMSWin == '\t' || *afterMSWin == ' ' ||
+                                (afterMSWin[0] == '#' && afterMSWin[1] == '0' && afterMSWin[2] == '1' &&
+                                 afterMSWin[3] == '1')) {
+                                if (*afterMSWin == '#') {
+                                    afterMSWin += 4;
+                                } else {
+                                    afterMSWin++;
+                                }
+                                afterMSWin = skip_lws_const(afterMSWin);
+                                // Extract channel (up to next tab/escaped-tab or end)
+                                const char *channelStart = afterMSWin;
+                                const char *channelEnd = channelStart;
+                                while (*channelEnd != '\0' && *channelEnd != '\t' && *channelEnd != ' ' &&
+                                       !(channelEnd[0] == '#' && channelEnd[1] == '0' && channelEnd[2] == '1' &&
+                                         channelEnd[3] == '1')) {
+                                    channelEnd++;
+                                }
+                                if (channelEnd > channelStart) {
+                                    size_t channelLen = channelEnd - channelStart;
+                                    char *channelBuf = malloc(channelLen + 1);
+                                    if (channelBuf != NULL) {
+                                        strncpy(channelBuf, channelStart, channelLen);
+                                        channelBuf[channelLen] = '\0';
+                                        json_add_string(ctx->event, "Channel", channelBuf);
+                                        free(channelBuf);
+                                        channel = NULL;  // Already set
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                if (channel != NULL) {
+                    json_add_string(ctx->event, "Channel", channel);
+                }
+            }
+        }
+    } else {
+        // RFC3164 format: try to extract channel from original message
+        const char *channel = "Security";  // default
+        // rawMsg parameter contains the original message text for channel extraction
+        if (rawMsg != NULL) {
+            // Look for MSWinEventLog followed by tab/escaped-tab, then version, then tab, then channel
+            const char *msWinPos = strstr(rawMsg, "MSWinEventLog");
+            if (msWinPos != NULL) {
+                const char *afterMSWin = msWinPos + 13;  // Skip "MSWinEventLog"
+                // Skip tab/escaped-tab and version
+                if (*afterMSWin == '\t' || *afterMSWin == ' ' ||
+                    (afterMSWin[0] == '#' && afterMSWin[1] == '0' && afterMSWin[2] == '1' && afterMSWin[3] == '1')) {
+                    // Skip tab/escaped-tab
+                    if (*afterMSWin == '#') {
+                        afterMSWin += 4;
+                    } else {
+                        afterMSWin++;
+                    }
+                    afterMSWin = skip_lws_const(afterMSWin);
+                    // Skip version (single digit typically)
+                    while (*afterMSWin >= '0' && *afterMSWin <= '9') {
+                        afterMSWin++;
+                    }
+                    // Skip next tab/escaped-tab
+                    if (*afterMSWin == '\t' || *afterMSWin == ' ' ||
+                        (afterMSWin[0] == '#' && afterMSWin[1] == '0' && afterMSWin[2] == '1' &&
+                         afterMSWin[3] == '1')) {
+                        if (*afterMSWin == '#') {
+                            afterMSWin += 4;
+                        } else {
+                            afterMSWin++;
+                        }
+                        afterMSWin = skip_lws_const(afterMSWin);
+                        // Extract channel (up to next tab/escaped-tab or end)
+                        const char *channelStart = afterMSWin;
+                        const char *channelEnd = channelStart;
+                        while (*channelEnd != '\0' && *channelEnd != '\t' && *channelEnd != ' ' &&
+                               !(channelEnd[0] == '#' && channelEnd[1] == '0' && channelEnd[2] == '1' &&
+                                 channelEnd[3] == '1')) {
+                            channelEnd++;
+                        }
+                        if (channelEnd > channelStart) {
+                            size_t channelLen = channelEnd - channelStart;
+                            char *channelBuf = malloc(channelLen + 1);
+                            if (channelBuf != NULL) {
+                                strncpy(channelBuf, channelStart, channelLen);
+                                channelBuf[channelLen] = '\0';
+                                json_add_string(ctx->event, "Channel", channelBuf);
+                                free(channelBuf);
+                                channel = NULL;  // Already set
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        if (channel != NULL) {
+            json_add_string(ctx->event, "Channel", channel);
+        }
+    }
     if (tokenCount > computerIdx && !is_placeholder(tokens[computerIdx]))
         json_add_string(ctx->event, "Computer", tokens[computerIdx]);
     if (tokenCount > categoryTextIdx && !is_placeholder(tokens[categoryTextIdx]))
@@ -4364,7 +4801,7 @@ static void populate_event_metadata(parse_context_t *ctx, char **tokens, size_t 
  * @return ::RS_RET_OK on success or an error code on allocation failures.
  */
 static rsRetVal parse_snare_text(
-    instanceData *pData, smsg_t *pMsg, const char *rawMsg, char **tokens, size_t tokenCount) {
+    instanceData *pData, smsg_t *pMsg, const char *rawMsg, const char *originalMsg, char **tokens, size_t tokenCount) {
     parse_context_t ctx;
     memset(&ctx, 0, sizeof(ctx));
     ctx.inst = pData;
@@ -4396,7 +4833,7 @@ static rsRetVal parse_snare_text(
     }
 
     if (pData->emitRawPayload && rawMsg != NULL) json_add_string(ctx.root, "Raw", rawMsg);
-    populate_event_metadata(&ctx, tokens, tokenCount);
+    populate_event_metadata(&ctx, tokens, tokenCount, originalMsg, pMsg);
 
     // Determine the correct description index based on message format
     size_t descriptionIdx;
@@ -4404,8 +4841,34 @@ static rsRetVal parse_snare_text(
         // RFC5424 format
         descriptionIdx = 13;
     } else {
-        // RFC3164 format
-        descriptionIdx = 9;
+        // RFC3164 format: description is typically the last token or contains "Sysmon"/"Event ID"
+        // Try to find the token that contains the description
+        descriptionIdx = tokenCount > 0 ? tokenCount - 1 : 0;
+        // Look backwards for a token that looks like a description
+        // Priority: tokens containing "Sysmon", then "Event ID", then any token with ":"
+        size_t sysmonIdx = SIZE_MAX;
+        size_t eventIdIdx = SIZE_MAX;
+        size_t colonIdx = SIZE_MAX;
+        for (size_t i = tokenCount; i > 0; i--) {
+            size_t idx = i - 1;
+            if (idx < tokenCount && tokens[idx] != NULL) {
+                if (strstr(tokens[idx], "Sysmon") != NULL) {
+                    sysmonIdx = idx;
+                    break;  // Highest priority, use this
+                } else if (strstr(tokens[idx], "Event ID") != NULL && eventIdIdx == SIZE_MAX) {
+                    eventIdIdx = idx;
+                } else if (strchr(tokens[idx], ':') != NULL && colonIdx == SIZE_MAX) {
+                    colonIdx = idx;
+                }
+            }
+        }
+        if (sysmonIdx != SIZE_MAX) {
+            descriptionIdx = sysmonIdx;
+        } else if (eventIdIdx != SIZE_MAX) {
+            descriptionIdx = eventIdIdx;
+        } else if (colonIdx != SIZE_MAX) {
+            descriptionIdx = colonIdx;
+        }
     }
 
     if (tokenCount > descriptionIdx && !is_placeholder(tokens[descriptionIdx])) {
@@ -4425,9 +4888,39 @@ static rsRetVal parse_snare_text(
                 return vr;
             }
         }
-        dbgprintf("[mmsnareparse DEBUG] parse_snare_text: calling parse_description with tokens[%zu]='%s'\n",
-                  descriptionIdx, tokens[descriptionIdx]);
-        parse_description(&ctx, tokens[descriptionIdx]);
+        // For descriptions that might span multiple tokens, try to concatenate them
+        // Start from descriptionIdx and concatenate remaining tokens
+        char *fullDescription = NULL;
+        size_t descLen = 0;
+        for (size_t i = descriptionIdx; i < tokenCount; i++) {
+            if (tokens[i] != NULL && !is_placeholder(tokens[i])) {
+                size_t tokenLen = strlen(tokens[i]);
+                if (fullDescription == NULL) {
+                    fullDescription = strdup(tokens[i]);
+                    descLen = tokenLen;
+                } else {
+                    char *newDesc = realloc(fullDescription, descLen + tokenLen + 2);  // +2 for space and null
+                    if (newDesc != NULL) {
+                        fullDescription = newDesc;
+                        fullDescription[descLen] = ' ';  // Add space between tokens
+                        strcpy(fullDescription + descLen + 1, tokens[i]);
+                        descLen += tokenLen + 1;
+                    }
+                }
+            }
+        }
+        if (fullDescription != NULL) {
+            dbgprintf(
+                "[mmsnareparse DEBUG] parse_snare_text: calling parse_description with concatenated description (from "
+                "token %zu): '%s'\n",
+                descriptionIdx, fullDescription);
+            parse_description(&ctx, fullDescription);
+            free(fullDescription);
+        } else if (tokenCount > descriptionIdx && !is_placeholder(tokens[descriptionIdx])) {
+            dbgprintf("[mmsnareparse DEBUG] parse_snare_text: calling parse_description with tokens[%zu]='%s'\n",
+                      descriptionIdx, tokens[descriptionIdx]);
+            parse_description(&ctx, tokens[descriptionIdx]);
+        }
     } else {
         dbgprintf(
             "[mmsnareparse DEBUG] parse_snare_text: not calling parse_description (tokenCount=%zu, "
@@ -4626,9 +5119,35 @@ static rsRetVal process_message(instanceData *pData, smsg_t *pMsg, uchar *msgTex
     const char *rawMsg;
     const char *payloadStart;
     if (msgText == NULL) return RS_RET_COULD_NOT_PARSE;
-    payloadStart = locate_snare_payload((const char *)msgText);
+    payloadStart = locate_snare_payload((const char *)msgText, pMsg);
     if (payloadStart == NULL) return RS_RET_COULD_NOT_PARSE;
-    rawMsg = payloadStart;
+    // rawMsg should be the original full message for channel extraction
+    // Try to get raw message before syslog parsing if MSWinEventLog is in tag
+    if (pMsg != NULL) {
+        uchar *tagBuf = NULL;
+        int tagLen = 0;
+        getTAG(pMsg, &tagBuf, &tagLen, 0);
+        if (tagBuf != NULL && tagLen > 0 && strstr((const char *)tagBuf, "MSWinEventLog") != NULL) {
+            // MSWinEventLog is in tag - try to get raw message before syslog parsing
+            uchar *rawBuf = NULL;
+            int rawLen = 0;
+            getRawMsg(pMsg, &rawBuf, &rawLen);
+            if (rawBuf != NULL && rawLen > 0) {
+                // Check if raw message contains MSWinEventLog
+                if (strstr((const char *)rawBuf, "MSWinEventLog") != NULL) {
+                    rawMsg = (const char *)rawBuf;
+                } else {
+                    rawMsg = (const char *)msgText;
+                }
+            } else {
+                rawMsg = (const char *)msgText;
+            }
+        } else {
+            rawMsg = (const char *)msgText;
+        }
+    } else {
+        rawMsg = (const char *)msgText;
+    }
     mutableMsg = strdup(payloadStart);
     if (mutableMsg == NULL) {
         LogError(0, RS_RET_OUT_OF_MEMORY, "mmsnareparse: failed to duplicate message text");
@@ -4658,7 +5177,8 @@ static rsRetVal process_message(instanceData *pData, smsg_t *pMsg, uchar *msgTex
     if (tokenCount >= 3 && !strcmp(tokens[1], "0") && tokens[2][0] == '{') {
         iRet = parse_snare_json(pData, pMsg, tokens[2]);
     } else if (tokenCount >= 2) {
-        iRet = parse_snare_text(pData, pMsg, rawMsg, tokens, tokenCount);
+        // Pass rawMsg as originalMsg so populate_event_metadata can extract channel from it
+        iRet = parse_snare_text(pData, pMsg, rawMsg, rawMsg, tokens, tokenCount);
     }
     free(mutableMsg);
     return iRet;

--- a/plugins/mmsnareparse/sysmon_definitions.json
+++ b/plugins/mmsnareparse/sysmon_definitions.json
@@ -1,0 +1,804 @@
+{
+  "events": [
+    {
+      "event_id": 1,
+      "category": "Process",
+      "subtype": "Creation",
+      "outcome": "success"
+    },
+    {
+      "event_id": 2,
+      "category": "File",
+      "subtype": "TimeChange",
+      "outcome": "success"
+    },
+    {
+      "event_id": 3,
+      "category": "Network",
+      "subtype": "Connection",
+      "outcome": "success"
+    },
+    {
+      "event_id": 4,
+      "category": "System",
+      "subtype": "ServiceStateChange",
+      "outcome": "success"
+    },
+    {
+      "event_id": 5,
+      "category": "Process",
+      "subtype": "Termination",
+      "outcome": "success"
+    },
+    {
+      "event_id": 6,
+      "category": "Driver",
+      "subtype": "Load",
+      "outcome": "success"
+    },
+    {
+      "event_id": 7,
+      "category": "Image",
+      "subtype": "Load",
+      "outcome": "success"
+    },
+    {
+      "event_id": 8,
+      "category": "Process",
+      "subtype": "RemoteThread",
+      "outcome": "success"
+    },
+    {
+      "event_id": 9,
+      "category": "File",
+      "subtype": "RawAccessRead",
+      "outcome": "success"
+    },
+    {
+      "event_id": 10,
+      "category": "Process",
+      "subtype": "Access",
+      "outcome": "success"
+    },
+    {
+      "event_id": 11,
+      "category": "File",
+      "subtype": "Create",
+      "outcome": "success"
+    },
+    {
+      "event_id": 12,
+      "category": "Registry",
+      "subtype": "ObjectCreateDelete",
+      "outcome": "success"
+    },
+    {
+      "event_id": 13,
+      "category": "Registry",
+      "subtype": "ValueSet",
+      "outcome": "success"
+    },
+    {
+      "event_id": 14,
+      "category": "Registry",
+      "subtype": "KeyValueRename",
+      "outcome": "success"
+    },
+    {
+      "event_id": 15,
+      "category": "File",
+      "subtype": "StreamHash",
+      "outcome": "success"
+    },
+    {
+      "event_id": 16,
+      "category": "System",
+      "subtype": "ConfigStateChange",
+      "outcome": "success"
+    },
+    {
+      "event_id": 17,
+      "category": "Pipe",
+      "subtype": "Created",
+      "outcome": "success"
+    },
+    {
+      "event_id": 18,
+      "category": "Pipe",
+      "subtype": "Connected",
+      "outcome": "success"
+    },
+    {
+      "event_id": 19,
+      "category": "WMI",
+      "subtype": "EventFilter",
+      "outcome": "success"
+    },
+    {
+      "event_id": 20,
+      "category": "WMI",
+      "subtype": "EventConsumer",
+      "outcome": "success"
+    },
+    {
+      "event_id": 21,
+      "category": "WMI",
+      "subtype": "ConsumerToFilter",
+      "outcome": "success"
+    },
+    {
+      "event_id": 22,
+      "category": "Network",
+      "subtype": "DNS",
+      "outcome": "success"
+    },
+    {
+      "event_id": 23,
+      "category": "File",
+      "subtype": "Delete",
+      "outcome": "success"
+    },
+    {
+      "event_id": 24,
+      "category": "Clipboard",
+      "subtype": "Change",
+      "outcome": "success"
+    },
+    {
+      "event_id": 25,
+      "category": "Process",
+      "subtype": "Tampering",
+      "outcome": "success"
+    },
+    {
+      "event_id": 26,
+      "category": "File",
+      "subtype": "DeleteLogged",
+      "outcome": "success"
+    },
+    {
+      "event_id": 27,
+      "category": "File",
+      "subtype": "BlockExecutable",
+      "outcome": "success"
+    },
+    {
+      "event_id": 28,
+      "category": "File",
+      "subtype": "BlockShredding",
+      "outcome": "success"
+    },
+    {
+      "event_id": 29,
+      "category": "File",
+      "subtype": "ExecutableDetected",
+      "outcome": "success"
+    }
+  ],
+  "fields": [
+    {
+      "pattern": "UtcTime",
+      "canonical": "UtcTime",
+      "value_type": "timestamp",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "ProcessGuid",
+      "canonical": "ProcessGuid",
+      "value_type": "guid",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "ProcessId",
+      "canonical": "ProcessId",
+      "value_type": "int64",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "Image",
+      "canonical": "Image",
+      "value_type": "string",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "FileVersion",
+      "canonical": "FileVersion",
+      "value_type": "string",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "Description",
+      "canonical": "Description",
+      "value_type": "string",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "Product",
+      "canonical": "Product",
+      "value_type": "string",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "Company",
+      "canonical": "Company",
+      "value_type": "string",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "OriginalFileName",
+      "canonical": "OriginalFileName",
+      "value_type": "string",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "CommandLine",
+      "canonical": "CommandLine",
+      "value_type": "string",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "CurrentDirectory",
+      "canonical": "CurrentDirectory",
+      "value_type": "string",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "User",
+      "canonical": "User",
+      "value_type": "string",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "LogonGuid",
+      "canonical": "LogonGuid",
+      "value_type": "guid",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "LogonId",
+      "canonical": "LogonId",
+      "value_type": "string",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "TerminalSessionId",
+      "canonical": "TerminalSessionId",
+      "value_type": "int64",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "IntegrityLevel",
+      "canonical": "IntegrityLevel",
+      "value_type": "string",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "Hashes",
+      "canonical": "Hashes",
+      "value_type": "string",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "ParentProcessGuid",
+      "canonical": "ParentProcessGuid",
+      "value_type": "guid",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "ParentProcessId",
+      "canonical": "ParentProcessId",
+      "value_type": "int64",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "ParentImage",
+      "canonical": "ParentImage",
+      "value_type": "string",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "ParentCommandLine",
+      "canonical": "ParentCommandLine",
+      "value_type": "string",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "ParentUser",
+      "canonical": "ParentUser",
+      "value_type": "string",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "SourceIp",
+      "canonical": "SourceIp",
+      "value_type": "ip_address",
+      "section": "Network",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "SourcePort",
+      "canonical": "SourcePort",
+      "value_type": "int64",
+      "section": "Network",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "DestinationIp",
+      "canonical": "DestinationIp",
+      "value_type": "ip_address",
+      "section": "Network",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "DestinationPort",
+      "canonical": "DestinationPort",
+      "value_type": "int64",
+      "section": "Network",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "Protocol",
+      "canonical": "Protocol",
+      "value_type": "string",
+      "section": "Network",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "Initiated",
+      "canonical": "Initiated",
+      "value_type": "bool",
+      "section": "Network",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "SourceIsIpv6",
+      "canonical": "SourceIsIpv6",
+      "value_type": "bool",
+      "section": "Network",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "SourceHostname",
+      "canonical": "SourceHostname",
+      "value_type": "string",
+      "section": "Network",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "DestinationIsIpv6",
+      "canonical": "DestinationIsIpv6",
+      "value_type": "bool",
+      "section": "Network",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "DestinationPortName",
+      "canonical": "DestinationPortName",
+      "value_type": "string",
+      "section": "Network",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "TargetFilename",
+      "canonical": "TargetFilename",
+      "value_type": "string",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "CreationUtcTime",
+      "canonical": "CreationUtcTime",
+      "value_type": "timestamp",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "PreviousCreationUtcTime",
+      "canonical": "PreviousCreationUtcTime",
+      "value_type": "timestamp",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "State",
+      "canonical": "State",
+      "value_type": "string",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "Version",
+      "canonical": "Version",
+      "value_type": "string",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "SchemaVersion",
+      "canonical": "SchemaVersion",
+      "value_type": "string",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "ImageLoaded",
+      "canonical": "ImageLoaded",
+      "value_type": "string",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "Signed",
+      "canonical": "Signed",
+      "value_type": "bool",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "Signature",
+      "canonical": "Signature",
+      "value_type": "string",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "SignatureStatus",
+      "canonical": "SignatureStatus",
+      "value_type": "string",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "SourceProcessGuid",
+      "canonical": "SourceProcessGuid",
+      "value_type": "guid",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "SourceProcessId",
+      "canonical": "SourceProcessId",
+      "value_type": "int64",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "SourceThreadId",
+      "canonical": "SourceThreadId",
+      "value_type": "int64",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "SourceImage",
+      "canonical": "SourceImage",
+      "value_type": "string",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "TargetProcessGuid",
+      "canonical": "TargetProcessGuid",
+      "value_type": "guid",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "TargetProcessId",
+      "canonical": "TargetProcessId",
+      "value_type": "int64",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "TargetImage",
+      "canonical": "TargetImage",
+      "value_type": "string",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "NewThreadId",
+      "canonical": "NewThreadId",
+      "value_type": "int64",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "StartAddress",
+      "canonical": "StartAddress",
+      "value_type": "string",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "StartModule",
+      "canonical": "StartModule",
+      "value_type": "string",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "StartFunction",
+      "canonical": "StartFunction",
+      "value_type": "string",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "Device",
+      "canonical": "Device",
+      "value_type": "string",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "GrantedAccess",
+      "canonical": "GrantedAccess",
+      "value_type": "string",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "CallTrace",
+      "canonical": "CallTrace",
+      "value_type": "string",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "Configuration",
+      "canonical": "Configuration",
+      "value_type": "string",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "PipeName",
+      "canonical": "PipeName",
+      "value_type": "string",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "EventType",
+      "canonical": "EventType",
+      "value_type": "string",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "Operation",
+      "canonical": "Operation",
+      "value_type": "string",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "EventNamespace",
+      "canonical": "EventNamespace",
+      "value_type": "string",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "Name",
+      "canonical": "Name",
+      "value_type": "string",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "Query",
+      "canonical": "Query",
+      "value_type": "string",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "Type",
+      "canonical": "Type",
+      "value_type": "string",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "Destination",
+      "canonical": "Destination",
+      "value_type": "string",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "Consumer",
+      "canonical": "Consumer",
+      "value_type": "string",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "Filter",
+      "canonical": "Filter",
+      "value_type": "string",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "QueryName",
+      "canonical": "QueryName",
+      "value_type": "string",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "QueryStatus",
+      "canonical": "QueryStatus",
+      "value_type": "int64",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "QueryResults",
+      "canonical": "QueryResults",
+      "value_type": "string",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "IsExecutable",
+      "canonical": "IsExecutable",
+      "value_type": "bool",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "Archived",
+      "canonical": "Archived",
+      "value_type": "bool",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "Session",
+      "canonical": "Session",
+      "value_type": "int64",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "Client Info",
+      "canonical": "ClientInfo",
+      "value_type": "string",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "TargetObject",
+      "canonical": "TargetObject",
+      "value_type": "string",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "NewName",
+      "canonical": "NewName",
+      "value_type": "string",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "Details",
+      "canonical": "Details",
+      "value_type": "string",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "RuleName",
+      "canonical": "RuleName",
+      "value_type": "string",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    }
+  ]
+}

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -510,6 +510,7 @@ TESTS += \
 	mmsnareparse-comprehensive.sh \
 	mmsnareparse-value-types.sh \
 	mmsnareparse-enhanced-validation.sh \
+	mmsnareparse-sysmon.sh \
 	mmsnareparse-kerberos.sh \
 	mmsnareparse-custom.sh \
 	mmsnareparse-realworld-4624-4634-5140.sh
@@ -2089,6 +2090,7 @@ EXTRA_DIST= \
         mmsnareparse-custom.sh \
         mmsnareparse-enhanced-validation.sh \
         mmsnareparse-json.sh \
+        mmsnareparse-sysmon.sh \
         mmsnareparse-kerberos.sh \
         mmsnareparse-realworld-4624-4634-5140.sh \
         mmsnareparse-syslog.sh \

--- a/tests/mmsnareparse-sysmon.sh
+++ b/tests/mmsnareparse-sysmon.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+# Validate mmsnareparse parsing against Microsoft Sysmon events using definition file.
+unset RSYSLOG_DYNNAME
+. ${srcdir:=.}/diag.sh init
+
+generate_conf
+add_conf '
+module(load="../plugins/mmsnareparse/.libs/mmsnareparse")
+
+template(name="outfmt" type="list") {
+    property(name="$!win!Event!EventID")
+    constant(value=",")
+    property(name="$!win!Event!Channel")
+    constant(value=",")
+    property(name="$!win!Event!Category")
+    constant(value=",")
+    property(name="$!win!Event!Subtype")
+    constant(value=",")
+    property(name="$!win!EventData!ProcessId")
+    constant(value=",")
+    property(name="$!win!EventData!Image")
+    constant(value=",")
+    property(name="$!win!EventData!CommandLine")
+    constant(value=",")
+    property(name="$!win!EventData!User")
+    constant(value=",")
+    property(name="$!win!Network!SourceIp")
+    constant(value=",")
+    property(name="$!win!Network!SourcePort")
+    constant(value=",")
+    property(name="$!win!Network!DestinationIp")
+    constant(value=",")
+    property(name="$!win!Network!DestinationPort")
+    constant(value=",")
+    property(name="$!win!Network!Protocol")
+    constant(value="\n")
+}
+
+action(type="mmsnareparse"
+       definition.file="../plugins/mmsnareparse/sysmon_definitions.json")
+action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
+'
+
+startup
+cat <<'MSG' > ${RSYSLOG_DYNNAME}.input
+<14>Nov 25 05:54:32 DC-01 MSWinEventLog	1	Microsoft-Windows-Sysmon/Operational	10448	Tue Nov 25 05:54:32 2025	1	Windows	SYSTEM	User	Information	DC-01	CORP\NETWORK SERVICE	Process creation	Sysmon  Event ID 1 - Process creation: UtcTime: 2024-04-28 22:08:22.025 ProcessGuid: {b34fbf9a-ce67-6a14-1111-1121f0a06f11} ProcessId: 6228 Image: C:\Windows\System32\wbem\WmiPrvSE.exe FileVersion: 10.0.22621.1 (WinBuild.160101.0800) Description: WMI Provider Host Product: Microsoft® Windows® Operating System Company: Microsoft Corporation OriginalFileName: Wmiprvse.exe CommandLine: C:\Windows\system32\wbem\wmiprvse.exe -secured -Embedding CurrentDirectory: C:\Windows\system32\ User: CORP\NETWORK SERVICE LogonGuid: {d56hdh1c-eg89-8c36-3333-3343h2c28h33} LogonId: 0x7EB05 TerminalSessionId: 1 IntegrityLevel: System Hashes: SHA1=A3F7B2C8D9E1F4A5B6C7D8E9F0A1B2C3D4E5F6A7,MD5=8E4F2A1B3C5D6E7F8A9B0C1D2E3F4A5,SHA256=7B9C2D4E5F6A7B8C9D0E1F2A3B4C5D6E7F8A9B0C1D2E3F4A5B6C7D8E9F0A1B2C3D4,IMPHASH=6A5B4C3D2E1F0A9B8C7D6E5F4A3B2C1D0E9F8A7B6C5 ParentProcessGuid: {c45gcg0b-df78-7b25-2222-2232g1b17g22} ParentProcessId: 580 ParentImage: C:\Windows\System32\svchost.exe ParentCommandLine: C:\Windows\system32\svchost.exe -k DcomLaunch -p ParentUser: NT INTERNAL\SYSTEM	10448
+<14>Mar 10 22:36:54 SQL-01 MSWinEventLog	1	Microsoft-Windows-Sysmon/Operational	30692	Mon Mar 10 22:36:54 2025	3	Windows	SYSTEM	User	Information	SQL-01	LAB\Administrator	Network connection detected	Sysmon  Event ID 3 - Network connection detected: RuleName: RDP UtcTime: 2017-04-28 22:12:22.557 ProcessGuid: {c45gcg0b-df78-7b25-2222-2232g1b17g22} ProcessId: 13220 Image: C:\Program Files (x86)\Google\Chrome\Application\chrome.exe Description: Sysmon  Event ID 3 User: LAB\Administrator SourceIp: 10.0.0.20 SourcePort: 3328 DestinationIp: 192.168.1.20 DestinationPort: 3389 Protocol: tcp Initiated: true SourceIsIpv6: 192.168.1.20 SourceHostname: DC-03 DestinationIsIpv6: 10.0.0.20 DestinationPortName: ms-wbt-server	30692
+<14>Jun 27 04:55:00 SERVER-01 MSWinEventLog	1	Microsoft-Windows-Sysmon/Operational	50518	Fri Jun 27 04:55:00 2025	5	Windows	SYSTEM	User	Information	SERVER-01		Process terminated	Sysmon  Event ID 5 - Process terminated: UtcTime: 2017-04-28 22:13:20.895 ProcessGuid: {02de4fd3-bd56-5903-0000-0010e9d95e00} ProcessId: 12684 Image: C:\Program Files (x86)\Google\Chrome\Application\chrome.exe Description: Sysmon  Event ID 5	50518
+MSG
+injectmsg_file ${RSYSLOG_DYNNAME}.input
+
+shutdown_when_empty
+wait_shutdown
+
+# Test Event ID 1 (Process Creation)
+content_check '1,Microsoft-Windows-Sysmon/Operational,Process,Creation,6228,C:\Windows\System32\wbem\WmiPrvSE.exe,C:\Windows\system32\wbem\wmiprvse.exe -secured -Embedding,CORP\NETWORK SERVICE,,,,,' $RSYSLOG_OUT_LOG
+
+# Test Event ID 3 (Network Connection)
+content_check '3,Microsoft-Windows-Sysmon/Operational,Network,Connection,13220,C:\Program Files (x86)\Google\Chrome\Application\chrome.exe,,LAB\Administrator,10.0.0.20,,192.168.1.20,,tcp' $RSYSLOG_OUT_LOG
+
+# Test Event ID 5 (Process Termination)
+content_check '5,Microsoft-Windows-Sysmon/Operational,Process,Termination,12684,C:\Program Files (x86)\Google\Chrome\Application\chrome.exe,,,,,,' $RSYSLOG_OUT_LOG
+
+exit_test


### PR DESCRIPTION
### Overview
Adds support for Microsoft Sysinternals Sysmon events to the `mmsnareparse` plugin using a JSON definition file, enabling generic parsing of Sysmon events without hardcoding.

### Changes Made

**Core Functionality:**
- Modified `locate_snare_payload()` to detect Sysmon events when MSWinEventLog is in the syslog tag (RFC3164 parsing)
- Updated `populate_event_metadata()` to extract Channel, EventID, Category, and Subtype from RFC3164-formatted messages
- Enhanced channel extraction to use the raw message when MSWinEventLog is moved to the syslog tag
- Fixed key-value parsing to handle single-space-separated pairs in Sysmon descriptions
- Improved pattern selection to prefer EventData section patterns when sectionName is NULL

**Files Modified:**
- `plugins/mmsnareparse/mmsnareparse.c`: Core parsing logic for Sysmon events
- `plugins/mmsnareparse/sysmon_definitions.json`: JSON definition file for Sysmon event types and field patterns
- `tests/mmsnareparse-sysmon.sh`: New test case validating Sysmon event parsing

**Key Technical Details:**
- Generic parsing: no Sysmon-specific hardcoding; extensible via JSON definitions
- RFC3164 support: handles cases where MSWinEventLog is moved to the syslog tag
- Pattern matching: fixes User field storage in EventData section instead of WDAC section
- Value extraction: correctly extracts multi-word values like "CORP\NETWORK SERVICE"

### Testing
- New test case `mmsnareparse-sysmon.sh` validates Event IDs 1, 3, and 5
- All test cases pass successfully
- Validates EventID, Channel, Category, Subtype, ProcessId, Image, CommandLine, User, and Network fields
