### PR TITLE
Apply omlibdbi doc fixes from PR

### DIFF
--- a/doc/source/reference/parameters/omlibdbi-db.rst
+++ b/doc/source/reference/parameters/omlibdbi-db.rst
@@ -36,7 +36,7 @@ Input usage
 
 .. code-block:: rsyslog
 
-   action(type="omlibdbi" driver="mysql" server="db.example.net" \
+   action(type="omlibdbi" driver="mysql" server="db.example.net"
           uid="dbwriter" pwd="sup3rSecret" db="syslog")
 
 Legacy names (for reference)

--- a/doc/source/reference/parameters/omlibdbi-driver.rst
+++ b/doc/source/reference/parameters/omlibdbi-driver.rst
@@ -47,7 +47,7 @@ Input usage
 
 .. code-block:: rsyslog
 
-   action(type="omlibdbi" driver="mysql" server="db.example.net" \
+   action(type="omlibdbi" driver="mysql" server="db.example.net"
           uid="dbwriter" pwd="sup3rSecret" db="syslog")
 
 Legacy names (for reference)

--- a/doc/source/reference/parameters/omlibdbi-pwd.rst
+++ b/doc/source/reference/parameters/omlibdbi-pwd.rst
@@ -35,7 +35,7 @@ Input usage
 
 .. code-block:: rsyslog
 
-   action(type="omlibdbi" driver="mysql" server="db.example.net" \
+   action(type="omlibdbi" driver="mysql" server="db.example.net"
           uid="dbwriter" pwd="sup3rSecret" db="syslog")
 
 Legacy names (for reference)

--- a/doc/source/reference/parameters/omlibdbi-server.rst
+++ b/doc/source/reference/parameters/omlibdbi-server.rst
@@ -36,7 +36,7 @@ Input usage
 
 .. code-block:: rsyslog
 
-   action(type="omlibdbi" driver="mysql" server="db.example.net" \
+   action(type="omlibdbi" driver="mysql" server="db.example.net"
           uid="dbwriter" pwd="sup3rSecret" db="syslog")
 
 Legacy names (for reference)

--- a/doc/source/reference/parameters/omlibdbi-template.rst
+++ b/doc/source/reference/parameters/omlibdbi-template.rst
@@ -49,8 +49,8 @@ Input usage
 
 .. code-block:: rsyslog
 
-   action(type="omlibdbi" driver="mysql" server="db.example.net" \
-          uid="dbwriter" pwd="sup3rSecret" db="syslog" \
+   action(type="omlibdbi" driver="mysql" server="db.example.net"
+          uid="dbwriter" pwd="sup3rSecret" db="syslog"
           template="structuredDb")
 
 See also

--- a/doc/source/reference/parameters/omlibdbi-uid.rst
+++ b/doc/source/reference/parameters/omlibdbi-uid.rst
@@ -36,7 +36,7 @@ Input usage
 
 .. code-block:: rsyslog
 
-   action(type="omlibdbi" driver="mysql" server="db.example.net" \
+   action(type="omlibdbi" driver="mysql" server="db.example.net"
           uid="dbwriter" pwd="sup3rSecret" db="syslog")
 
 Legacy names (for reference)


### PR DESCRIPTION
### Summary (non-technical, complete)
This PR updates the documentation for `omlibdbi` module parameters by removing stray line-continuation escapes (`\`) from `action()` code examples. This change ensures that the sample configurations are directly copy-pasteable and align with modern rsyslog configuration practices, improving user experience.

### References
Refs: https://github.com/rsyslog/rsyslog/pull/6325

### Notes (optional)
This is a documentation-only change. No tests were run.

---

#### Quick check (optional)
- Commit message follows rules (ASCII; title ≤62, body ≤72; `<component>:`).
- Commit message includes non-technical “why”, Impact (if behavior/tests changed),
  and a one-line Before/After when behavior changed.
- Used the Commit Assistant or mirrored its structure.

---
<a href="https://cursor.com/background-agent?bcId=bc-61e1f032-5ba3-4e48-b008-5b79bf25d22b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-61e1f032-5ba3-4e48-b008-5b79bf25d22b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

