### PR TITLE
Remove macOS 13 runners

### DIFF
--- a/.github/workflows/run_macos.yml
+++ b/.github/workflows/run_macos.yml
@@ -43,10 +43,6 @@ jobs:
       fail-fast: true
       matrix:
         include:
-          # 1 x from macos-13 (x64 NONE)
-          - os: macos-13
-            arch: x64
-            sanitizer: none
           # 1 x from macos-14 (x64 NONE)
           - os: macos-14
             arch: x64

--- a/.github/workflows/run_macos_weekly.yml
+++ b/.github/workflows/run_macos_weekly.yml
@@ -32,7 +32,7 @@ jobs:
       # We want a full picture weekly
       fail-fast: false
       matrix:
-        os: [macos-13, macos-14, macos-15]
+        os: [macos-14, macos-15]
         arch: [x64, arm64]
         sanitizer: [none, asan, tsan]
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
### Summary (non-technical, complete)
This change removes references to macOS 13 from the CI workflows. The macOS 13 GitHub runners have been retired, and continuing to reference them would lead to workflow failures. This ensures our CI pipelines run only on currently supported macOS versions (14 and 15).

### References
Refs: https://github.com/rsyslog/rsyslog/issues/<id>

### Notes (optional)
- `.github/workflows/run_macos.yml`: Removed the specific `macos-13` matrix entry.
- `.github/workflows/run_macos_weekly.yml`: Removed `macos-13` from the `os` array in the matrix.

---

#### Quick check (optional)
- Commit message follows rules (ASCII; title ≤62, body ≤72; `<component>:`).
- Commit message includes non-technical “why”, Impact (if behavior/tests changed),
  and a one-line Before/After when behavior changed.
- Used the Commit Assistant or mirrored its structure.

---

#### Git workflow tips (optional, but helps reviews)
- Start by crafting the commit message locally (use the Assistant).
- If you already committed, improve it with:
  ```
  git commit --amend
  ```
- Squash related commits before PR where appropriate.
- Push your branch and then open the PR.
- If key info is only in the PR text, maintainers may ask you to move it
  into the commit message for a clean history.

---
<a href="https://cursor.com/background-agent?bcId=bc-a4e3ab4d-6d64-43ae-a686-5f3b3c2f0cec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a4e3ab4d-6d64-43ae-a686-5f3b3c2f0cec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

