### PR TITLE
Ci macos arm64 race condition

### DIFF
--- a/runtime/tcpsrv.h
+++ b/runtime/tcpsrv.h
@@ -170,6 +170,7 @@ struct tcpsrv_s {
         unsigned int ratelimitInterval;
         unsigned int ratelimitBurst;
         tcps_sess_t **pSessions; /**< array of all of our sessions */
+        pthread_mutex_t mutSessions; /**< mutex protecting pSessions array access */
         unsigned int starvationMaxReads;
         void *pUsr; /**< a user-settable pointer (provides extensibility for "derived classes")*/
         /* callbacks */

--- a/tests/tsan.supp
+++ b/tests/tsan.supp
@@ -12,7 +12,7 @@ fun:doSIGTTIN
 #fun:
 
 # actual bugs that should be fixed ASAP after TSAN is in place:
-fun:TCPSessTblFindFreeSpot
+# fun:TCPSessTblFindFreeSpot - FIXED: protected with mutSessions mutex
 fun:processWorksetItem
 
 fun:doLogMsg


### PR DESCRIPTION
### Summary (non-technical, complete)
This PR fixes a race condition detected by TSAN in the macOS ARM64 CI, specifically within the TCP session table management. Previously, multiple threads could concurrently find and attempt to use the same free session slot, leading to session loss or overwrites. The fix introduces a mutex to protect the session table, ensuring atomic find-and-reserve operations during session creation and safe removal during session closure. This resolves the Time-Of-Check-Time-Of-Use (TOCTOU) vulnerability.

### References
Refs: https://github.com/rsyslog/rsyslog/actions/runs/20708776690/job/59444439825?pr=6415

### Notes (optional)
- The `TCPSessTblFindFreeSpot` entry has been removed from `tests/tsan.supp` as the issue is now resolved.
- **Impact:** Resolves a concurrency bug that could lead to lost TCP sessions or incorrect state, particularly under high load or specific thread scheduling.
- **Before:** `TCPSessTblFindFreeSpot` and subsequent session assignment were not protected, allowing multiple threads to race for the same slot.
- **After:** A mutex (`mutSessions`) now protects the `pSessions` array, making session slot allocation and deallocation atomic. A temporary marker is used during session construction to reserve a slot before the final session pointer is set.

---

#### Quick check (optional)
- Commit message follows rules (ASCII; title ≤62, body ≤72; `<component>:`).
- Commit message includes non-technical “why”, Impact (if behavior/tests changed),
  and a one-line Before/After when behavior changed.
- Used the Commit Assistant or mirrored its structure.

---
<a href="https://cursor.com/background-agent?bcId=bc-3f963b8e-3239-461e-a53c-48bd647d03d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3f963b8e-3239-461e-a53c-48bd647d03d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces thread-safe session table management to eliminate a TOCTOU race during accept/close in non-epoll builds.
> 
> - Adds `pthread_mutex_t mutSessions` to `tcpsrv_t`; initialized in `TCPSessTblInit()` and destroyed in listener deinit
> - Guards `TCPSessTblFindFreeSpot()` use and `pSessions` updates with `mutSessions` in `SessAccept()` (reserve via temporary marker, then set real pointer) and `closeSess()` (clear slot)
> - No session-table path for `ENABLE_IMTCP_EPOLL`; adds unused `iSess` handling only for build consistency
> - Updates `tests/tsan.supp` to remove suppression for `TCPSessTblFindFreeSpot` (now fixed)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c0d5b53bfedaeedcafd05faa4ab7e07277f70639. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->