### PR TITLE
Mysql async data race

### DIFF
--- a/plugins/ommysql/ommysql.c
+++ b/plugins/ommysql/ommysql.c
@@ -37,6 +37,7 @@
 #include <netdb.h>
 #include <mysql.h>
 #include <mysqld_error.h>
+#include <pthread.h>
 #include "conf.h"
 #include "syslogd-types.h"
 #include "srUtils.h"
@@ -67,6 +68,7 @@ typedef struct _instanceData {
     uchar *configsection; /* MySQL Client Configuration Section */
     uchar *tplName; /* format template to use */
     uchar *socket; /* MySQL socket path */
+    pthread_mutex_t mutInit; /* mutex to protect mysql_init() calls */
 } instanceData;
 
 typedef struct wrkrInstanceData {
@@ -109,6 +111,12 @@ ENDinitConfVars
 
 BEGINcreateInstance
     CODESTARTcreateInstance;
+    int r;
+    if ((r = pthread_mutex_init(&pData->mutInit, NULL)) != 0) {
+        LogError(r, RS_RET_ERR, "ommysql: cannot create MySQL initialization mutex, failing this action");
+        ABORT_FINALIZE(RS_RET_ERR);
+    }
+finalize_it:
 ENDcreateInstance
 
 
@@ -136,6 +144,7 @@ static void closeMySQL(wrkrInstanceData_t *pWrkrData) {
 
 BEGINfreeInstance
     CODESTARTfreeInstance;
+    pthread_mutex_destroy(&pData->mutInit);
     free(pData->configfile);
     free(pData->configsection);
     free(pData->tplName);
@@ -206,7 +215,13 @@ static rsRetVal initMySQL(wrkrInstanceData_t *pWrkrData, int bSilent) {
         pWrkrData->threadInitialized = true;
     }
 
+    /* Protect mysql_init() call with mutex to avoid data race when multiple
+     * worker threads initialize connections concurrently. The MySQL client
+     * library may use shared internal state during initialization.
+     */
+    pthread_mutex_lock(&pData->mutInit);
     pWrkrData->hmysql = mysql_init(NULL);
+    pthread_mutex_unlock(&pData->mutInit);
     if (pWrkrData->hmysql == NULL) {
         LogError(0, RS_RET_SUSPENDED, "can not initialize MySQL handle");
         iRet = RS_RET_SUSPENDED;


### PR DESCRIPTION
```
### Summary (non-technical, complete)
This PR resolves a ThreadSanitizer data race in the ommysql module. The race occurred when multiple worker threads attempted to initialize MySQL connections concurrently, as `mysql_init()` was accessing shared internal state without proper synchronization. The fix introduces a mutex to protect these `mysql_init()` calls, ensuring safe and correct concurrent initialization of MySQL handles.

### References
<!-- No specific GitHub issue ID was provided in the task. -->

### Notes (optional)
This change addresses the `mysql-asyn.sh` test failure reported by ThreadSanitizer.

---

#### Quick check (optional)
- Commit message follows rules (ASCII; title ≤62, body ≤72; `<component>:`).
- Commit message includes non-technical “why”, Impact (if behavior/tests changed),
  and a one-line Before/After when behavior changed.
- Used the Commit Assistant or mirrored its structure.
```

---
<a href="https://cursor.com/background-agent?bcId=bc-de4f435f-207a-4c8c-bc0f-45aeb40b671b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-de4f435f-207a-4c8c-bc0f-45aeb40b671b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Protects mysql_init() in ommysql with a mutex to avoid a data race when multiple worker threads initialize MySQL connections. Resolves the ThreadSanitizer warning and stabilizes the mysql-async test.

- **Bug Fixes**
  - Added per-instance pthread mutex (mutInit); initialized/destroyed in lifecycle.
  - Wrapped mysql_init() with lock/unlock to ensure thread-safe connection setup.

<sup>Written for commit b3c3b223fa32a7c5c97b355a582c8ab173ffafbc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

