### PR TITLE
Mysql async data race

### DIFF
--- a/plugins/ommysql/ommysql.c
+++ b/plugins/ommysql/ommysql.c
@@ -35,6 +35,7 @@
 #include <errno.h>
 #include <time.h>
 #include <netdb.h>
+#include <pthread.h>
 #include <mysql.h>
 #include <mysqld_error.h>
 #include "conf.h"
@@ -67,6 +68,7 @@ typedef struct _instanceData {
     uchar *configsection; /* MySQL Client Configuration Section */
     uchar *tplName; /* format template to use */
     uchar *socket; /* MySQL socket path */
+    pthread_mutex_t mutInit; /* mutex to protect MySQL initialization */
 } instanceData;
 
 typedef struct wrkrInstanceData {
@@ -109,6 +111,12 @@ ENDinitConfVars
 
 BEGINcreateInstance
     CODESTARTcreateInstance;
+    int r;
+    if ((r = pthread_mutex_init(&pData->mutInit, NULL)) != 0) {
+        LogError(r, RS_RET_ERR, "ommysql: cannot create MySQL initialization mutex, failing this action");
+        ABORT_FINALIZE(RS_RET_ERR);
+    }
+finalize_it:
 ENDcreateInstance
 
 
@@ -140,6 +148,7 @@ BEGINfreeInstance
     free(pData->configsection);
     free(pData->tplName);
     free(pData->socket);
+    pthread_mutex_destroy(&pData->mutInit);
 ENDfreeInstance
 
 
@@ -194,9 +203,14 @@ static void reportDBError(wrkrInstanceData_t *pWrkrData, int bSilent) {
 static rsRetVal initMySQL(wrkrInstanceData_t *pWrkrData, int bSilent) {
     instanceData *pData;
     DEFiRet;
+    int mutexLocked = 0;
 
     assert(pWrkrData->hmysql == NULL);
     pData = pWrkrData->pData;
+
+    /* Protect MySQL initialization from concurrent access by multiple workers */
+    pthread_mutex_lock(&pData->mutInit);
+    mutexLocked = 1;
 
     if (!pWrkrData->threadInitialized) {
         if (mysql_thread_init()) {
@@ -209,44 +223,50 @@ static rsRetVal initMySQL(wrkrInstanceData_t *pWrkrData, int bSilent) {
     pWrkrData->hmysql = mysql_init(NULL);
     if (pWrkrData->hmysql == NULL) {
         LogError(0, RS_RET_SUSPENDED, "can not initialize MySQL handle");
-        iRet = RS_RET_SUSPENDED;
-    } else { /* we could get the handle, now on with work... */
-        mysql_options(pWrkrData->hmysql, MYSQL_READ_DEFAULT_GROUP,
-                      ((pData->configsection != NULL) ? (char *)pData->configsection : "client"));
-        if (pData->configfile != NULL) {
-            FILE *fp;
-            fp = fopen((char *)pData->configfile, "r");
-            int err = errno;
-            if (fp == NULL) {
-                char msg[512];
-                snprintf(msg, sizeof(msg), "Could not open '%s' for reading", pData->configfile);
-                if (bSilent) {
-                    char errStr[512];
-                    rs_strerror_r(err, errStr, sizeof(errStr));
-                    dbgprintf("mysql configuration error(%d): %s - %s\n", err, msg, errStr);
-                } else
-                    LogError(err, NO_ERRCODE, "mysql configuration error: %s\n", msg);
-            } else {
-                fclose(fp);
-                mysql_options(pWrkrData->hmysql, MYSQL_READ_DEFAULT_FILE, pData->configfile);
-            }
-        }
-        /* Connect to database */
-        if (mysql_real_connect(pWrkrData->hmysql, pData->dbsrv, pData->dbuid, pData->dbpwd, pData->dbname,
-                               pData->dbsrvPort, (const char *)pData->socket, 0) == NULL) {
-            reportDBError(pWrkrData, bSilent);
-            closeMySQL(pWrkrData); /* ignore any error we may get */
-            ABORT_FINALIZE(RS_RET_SUSPENDED);
-        }
-        if (mysql_autocommit(pWrkrData->hmysql, 0)) {
-            LogMsg(0, NO_ERRCODE, LOG_WARNING,
-                   "ommysql: activating autocommit failed, "
-                   "some data may be duplicated\n");
-            reportDBError(pWrkrData, 0);
+        ABORT_FINALIZE(RS_RET_SUSPENDED);
+    }
+
+    /* we could get the handle, now on with work... */
+    mysql_options(pWrkrData->hmysql, MYSQL_READ_DEFAULT_GROUP,
+                  ((pData->configsection != NULL) ? (char *)pData->configsection : "client"));
+    if (pData->configfile != NULL) {
+        FILE *fp;
+        fp = fopen((char *)pData->configfile, "r");
+        int err = errno;
+        if (fp == NULL) {
+            char msg[512];
+            snprintf(msg, sizeof(msg), "Could not open '%s' for reading", pData->configfile);
+            if (bSilent) {
+                char errStr[512];
+                rs_strerror_r(err, errStr, sizeof(errStr));
+                dbgprintf("mysql configuration error(%d): %s - %s\n", err, msg, errStr);
+            } else
+                LogError(err, NO_ERRCODE, "mysql configuration error: %s\n", msg);
+        } else {
+            fclose(fp);
+            mysql_options(pWrkrData->hmysql, MYSQL_READ_DEFAULT_FILE, pData->configfile);
         }
     }
 
+    /* Connect to database */
+    if (mysql_real_connect(pWrkrData->hmysql, pData->dbsrv, pData->dbuid, pData->dbpwd, pData->dbname, pData->dbsrvPort,
+                           (const char *)pData->socket, 0) == NULL) {
+        reportDBError(pWrkrData, bSilent);
+        closeMySQL(pWrkrData); /* ignore any error we may get */
+        ABORT_FINALIZE(RS_RET_SUSPENDED);
+    }
+
+    if (mysql_autocommit(pWrkrData->hmysql, 0)) {
+        LogMsg(0, NO_ERRCODE, LOG_WARNING,
+               "ommysql: activating autocommit failed, "
+               "some data may be duplicated\n");
+        reportDBError(pWrkrData, 0);
+    }
+
 finalize_it:
+    if (mutexLocked) {
+        pthread_mutex_unlock(&pData->mutInit);
+    }
     RETiRet;
 }
 


### PR DESCRIPTION
```
### Summary (non-technical, complete)
This change resolves a data race in the `ommysql` plugin that occurred when multiple worker threads concurrently initialized the MySQL client library. By introducing a mutex to serialize the `initMySQL` function, we ensure thread-safe initialization, preventing crashes and potential data corruption, and fixing the `mysql-asyn` test failure detected by ThreadSanitizer.

### References
Refs: (No specific GitHub issue ID was provided, but this addresses the failure in `./tests/mysql-asyn`)

### Notes (optional)
- A `pthread_mutex_t` has been added to the `instanceData` structure.
- The `initMySQL` function is now protected by this mutex, ensuring only one thread can perform MySQL client library initialization at a time.
- The `<pthread.h>` header has been included.
```

---
<a href="https://cursor.com/background-agent?bcId=bc-af015fff-f36a-4b54-92c0-643643c254a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-af015fff-f36a-4b54-92c0-643643c254a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Serializes MySQL client initialization in the ommysql plugin using a mutex to prevent a data race across worker threads. This stops crashes/data corruption and fixes the mysql-asyn test failure reported by ThreadSanitizer.

- **Bug Fixes**
  - Added mutInit to instanceData and initialized/destroyed it during instance lifecycle.
  - Guarded initMySQL with pthread mutexes to serialize mysql_thread_init, mysql_init, and mysql_real_connect.
  - Included pthread.h and resolved the ThreadSanitizer-reported race in mysql-asyn.

<sup>Written for commit 2d82316c43191c9d78df8599bf44192bda8e08fb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

