### PR TITLE
Rsyslog issue investigation

### DIFF
--- a/plugins/ommysql/ommysql.c
+++ b/plugins/ommysql/ommysql.c
@@ -35,6 +35,7 @@
 #include <errno.h>
 #include <time.h>
 #include <netdb.h>
+#include <pthread.h>
 #include <mysql.h>
 #include <mysqld_error.h>
 #include "conf.h"
@@ -67,6 +68,7 @@ typedef struct _instanceData {
     uchar *configsection; /* MySQL Client Configuration Section */
     uchar *tplName; /* format template to use */
     uchar *socket; /* MySQL socket path */
+    pthread_mutex_t mutInit; /* mutex to protect MySQL initialization */
 } instanceData;
 
 typedef struct wrkrInstanceData {
@@ -109,6 +111,12 @@ ENDinitConfVars
 
 BEGINcreateInstance
     CODESTARTcreateInstance;
+    int r;
+    if ((r = pthread_mutex_init(&pData->mutInit, NULL)) != 0) {
+        LogError(r, RS_RET_ERR, "ommysql: cannot create MySQL initialization mutex, failing this action");
+        ABORT_FINALIZE(RS_RET_ERR);
+    }
+finalize_it:
 ENDcreateInstance
 
 
@@ -140,6 +148,7 @@ BEGINfreeInstance
     free(pData->configsection);
     free(pData->tplName);
     free(pData->socket);
+    pthread_mutex_destroy(&pData->mutInit);
 ENDfreeInstance
 
 
@@ -194,9 +203,14 @@ static void reportDBError(wrkrInstanceData_t *pWrkrData, int bSilent) {
 static rsRetVal initMySQL(wrkrInstanceData_t *pWrkrData, int bSilent) {
     instanceData *pData;
     DEFiRet;
+    int mutexLocked = 0;
 
     assert(pWrkrData->hmysql == NULL);
     pData = pWrkrData->pData;
+
+    /* Protect MySQL initialization from concurrent access by multiple workers */
+    pthread_mutex_lock(&pData->mutInit);
+    mutexLocked = 1;
 
     if (!pWrkrData->threadInitialized) {
         if (mysql_thread_init()) {
@@ -209,44 +223,50 @@ static rsRetVal initMySQL(wrkrInstanceData_t *pWrkrData, int bSilent) {
     pWrkrData->hmysql = mysql_init(NULL);
     if (pWrkrData->hmysql == NULL) {
         LogError(0, RS_RET_SUSPENDED, "can not initialize MySQL handle");
-        iRet = RS_RET_SUSPENDED;
-    } else { /* we could get the handle, now on with work... */
-        mysql_options(pWrkrData->hmysql, MYSQL_READ_DEFAULT_GROUP,
-                      ((pData->configsection != NULL) ? (char *)pData->configsection : "client"));
-        if (pData->configfile != NULL) {
-            FILE *fp;
-            fp = fopen((char *)pData->configfile, "r");
-            int err = errno;
-            if (fp == NULL) {
-                char msg[512];
-                snprintf(msg, sizeof(msg), "Could not open '%s' for reading", pData->configfile);
-                if (bSilent) {
-                    char errStr[512];
-                    rs_strerror_r(err, errStr, sizeof(errStr));
-                    dbgprintf("mysql configuration error(%d): %s - %s\n", err, msg, errStr);
-                } else
-                    LogError(err, NO_ERRCODE, "mysql configuration error: %s\n", msg);
-            } else {
-                fclose(fp);
-                mysql_options(pWrkrData->hmysql, MYSQL_READ_DEFAULT_FILE, pData->configfile);
-            }
-        }
-        /* Connect to database */
-        if (mysql_real_connect(pWrkrData->hmysql, pData->dbsrv, pData->dbuid, pData->dbpwd, pData->dbname,
-                               pData->dbsrvPort, (const char *)pData->socket, 0) == NULL) {
-            reportDBError(pWrkrData, bSilent);
-            closeMySQL(pWrkrData); /* ignore any error we may get */
-            ABORT_FINALIZE(RS_RET_SUSPENDED);
-        }
-        if (mysql_autocommit(pWrkrData->hmysql, 0)) {
-            LogMsg(0, NO_ERRCODE, LOG_WARNING,
-                   "ommysql: activating autocommit failed, "
-                   "some data may be duplicated\n");
-            reportDBError(pWrkrData, 0);
+        ABORT_FINALIZE(RS_RET_SUSPENDED);
+    }
+
+    /* we could get the handle, now on with work... */
+    mysql_options(pWrkrData->hmysql, MYSQL_READ_DEFAULT_GROUP,
+                  ((pData->configsection != NULL) ? (char *)pData->configsection : "client"));
+    if (pData->configfile != NULL) {
+        FILE *fp;
+        fp = fopen((char *)pData->configfile, "r");
+        int err = errno;
+        if (fp == NULL) {
+            char msg[512];
+            snprintf(msg, sizeof(msg), "Could not open '%s' for reading", pData->configfile);
+            if (bSilent) {
+                char errStr[512];
+                rs_strerror_r(err, errStr, sizeof(errStr));
+                dbgprintf("mysql configuration error(%d): %s - %s\n", err, msg, errStr);
+            } else
+                LogError(err, NO_ERRCODE, "mysql configuration error: %s\n", msg);
+        } else {
+            fclose(fp);
+            mysql_options(pWrkrData->hmysql, MYSQL_READ_DEFAULT_FILE, pData->configfile);
         }
     }
 
+    /* Connect to database */
+    if (mysql_real_connect(pWrkrData->hmysql, pData->dbsrv, pData->dbuid, pData->dbpwd, pData->dbname, pData->dbsrvPort,
+                           (const char *)pData->socket, 0) == NULL) {
+        reportDBError(pWrkrData, bSilent);
+        closeMySQL(pWrkrData); /* ignore any error we may get */
+        ABORT_FINALIZE(RS_RET_SUSPENDED);
+    }
+
+    if (mysql_autocommit(pWrkrData->hmysql, 0)) {
+        LogMsg(0, NO_ERRCODE, LOG_WARNING,
+               "ommysql: activating autocommit failed, "
+               "some data may be duplicated\n");
+        reportDBError(pWrkrData, 0);
+    }
+
 finalize_it:
+    if (mutexLocked) {
+        pthread_mutex_unlock(&pData->mutInit);
+    }
     RETiRet;
 }
 


### PR DESCRIPTION
### Summary (non-technical, complete)
This PR resolves a data race in the MySQL client library initialization. Previously, multiple worker threads could attempt to initialize MySQL connections concurrently, potentially leading to crashes or undefined behavior. The change introduces mutex protection to serialize this initialization, ensuring stable and reliable operation of the `ommysql` module.

### References
Fixes: https://github.com/rsyslog/rsyslog/issues/6360

### Notes (optional)
- A `pthread_mutex_t` has been added to the `instanceData` structure.
- The mutex is initialized in `BEGINcreateInstance` and destroyed in `BEGINfreeInstance`.
- Mutex locking and unlocking have been implemented within `initMySQL()` to serialize the MySQL client library initialization process.
- The necessary `#include <pthread.h>` has been added.

---
<a href="https://cursor.com/background-agent?bcId=bc-e9196438-8125-4ebf-9875-95d411b2688e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e9196438-8125-4ebf-9875-95d411b2688e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Serializes MySQL client initialization in ommysql with an instance-scoped mutex to prevent data races and crashes when multiple workers initialize concurrently. Fixes https://github.com/rsyslog/rsyslog/issues/6360.

- **Bug Fixes**
  - Added pthread_mutex_t mutInit to instanceData; initialized in BEGINcreateInstance and destroyed in BEGINfreeInstance.
  - Wrapped initMySQL with pthread_mutex_lock/unlock, releasing on all error paths via finalize_it.
  - Included <pthread.h> to support mutex usage.

<sup>Written for commit 9dc5564cd26dfac4d7d6b1a9ef2cdb1f563a2d0d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

