### PR TITLE
Rsyslog issue 6360 plan

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -2124,6 +2124,9 @@ EXTRA_DIST= \
     mmexternal-SegFault-empty-jroot-vg.sh \
     testsuites/mmexternal-SegFault-mm-python.py \
     testsuites/mmsnareparse/sample-custom-pattern.data \
+    testsuites/mmsnareparse/sample-windows2022-security.data \
+    testsuites/mmsnareparse/sample-windows2025-security.data \
+    testsuites/mmsnareparse/sample-events.data \
     mmsnareparse-basic.sh \
     mmsnareparse-comprehensive.sh \
     mmsnareparse-comprehensive-vg.sh \


### PR DESCRIPTION
### Summary (non-technical, complete)
This change resolves an issue where `mmsnareparse` test data files were not included in the `make dist` tarball, leading to build failures on platforms like Launchpad. By adding the missing `.data` files to `EXTRA_DIST`, the tests will now have the necessary resources to run correctly in distributed builds.

### References
Refs: https://github.com/rsyslog/rsyslog/issues/6360

### Notes (optional)
This fix directly addresses existing test failures in `make dist` environments.

---
<a href="https://cursor.com/background-agent?bcId=bc-98537ccf-2525-48df-93b6-f128b5ad60ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-98537ccf-2525-48df-93b6-f128b5ad60ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Include missing mmsnareparse sample .data files in EXTRA_DIST so make dist tarballs ship all test resources. Fixes distributed build/test failures (e.g., Launchpad) and addresses rsyslog issue #6360.

<sup>Written for commit f159e0801891ad4033e16e000d74ce3073c7544d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

