### PR TITLE
omsnmp: fix legacy config path and session strings

### DIFF
--- a/packaging/docker/dev_env/debian/base/13/Dockerfile
+++ b/packaging/docker/dev_env/debian/base/13/Dockerfile
@@ -48,6 +48,7 @@ RUN 	apt-get update && \
 	pkg-config \
 	postgresql-client \
 	python3-docutils \
+	python3-pip \
 	python3-pysnmp4 \
 	python3-pysnmp4-apps \
 	python3-pysnmp4-mibs \
@@ -59,7 +60,8 @@ RUN 	apt-get update && \
 	zlib1g-dev \
 	libmongoc-dev \
 	zstd \
-	&& apt clean
+	&& apt-get clean && \
+	rm -rf /var/lib/apt/lists/*
 #	libbson-dev
 #	libgrok1 libgrok-dev
 #	software-properties-common
@@ -76,7 +78,9 @@ RUN	apt-get update -y && \
 	apt-get install -y \
 	libestr-dev \
 	libfastjson-dev \
-	libsodium-dev
+	libsodium-dev && \
+	apt-get clean && \
+	rm -rf /var/lib/apt/lists/*
 
 # Create libgcrypt-config wrapper for Debian 13 compatibility
 # (libgcrypt-config is not provided in Debian 13, but pkg-config is available)
@@ -186,6 +190,8 @@ RUN	cd helper-projects && \
 	rm -r librelp && \
 	cd ..
 
+RUN	pip install --no-cache-dir pyasn1 pysnmp --break-system-packages --upgrade
+
 # next ENV is specifically for running scan-build - so we do not need to
 # change scripts if at a later time we can move on to a newer version
 ENV	SCAN_BUILD=scan-build \
@@ -263,10 +269,7 @@ ENV	RSYSLOG_CONFIGURE_OPTIONS \
 	--enable-pmsnare \
 	--enable-relp \
 	--enable-snmp \
-	# SNMP Tests disabled due to Python 3.12+ compatibility issues
-	# TODO: Re-enable once pysnmp is updated to support Python 3.12+
-	# See: https://github.com/rsyslog/rsyslog/issues/5999
-	#--enable-snmp-tests \
+	--enable-snmp-tests \
 	--enable-usertools \
 	--enable-valgrind \
 	\

--- a/packaging/docker/dev_env/debian/base/sid/Dockerfile
+++ b/packaging/docker/dev_env/debian/base/sid/Dockerfile
@@ -47,6 +47,7 @@ RUN 	apt-get update && \
 	pkg-config \
 	postgresql-client \
 	python3-docutils \
+	python3-pip \
 	python3-pysnmp4 \
 	python3-pysnmp4-apps \
 	python3-pysnmp4-mibs \
@@ -58,7 +59,8 @@ RUN 	apt-get update && \
 	zlib1g-dev \
 	libmongoc-dev \
 	zstd \
-	&& apt clean
+	&& apt-get clean && \
+	rm -rf /var/lib/apt/lists/*
 #	libbson-dev
 #	libgrok1 libgrok-dev
 #	software-properties-common
@@ -75,7 +77,9 @@ RUN	apt-get update -y && \
 	apt-get install -y \
 	libestr-dev \
 	libfastjson-dev \
-	libsodium-dev
+	libsodium-dev && \
+	apt-get clean && \
+	rm -rf /var/lib/apt/lists/*
 
 WORKDIR	/home/devel
 RUN	groupadd rsyslog \
@@ -172,6 +176,8 @@ RUN	cd helper-projects && \
 	rm -r librelp && \
 	cd ..
 
+RUN	pip install --no-cache-dir pyasn1 pysnmp --break-system-packages --upgrade
+
 # next ENV is specifically for running scan-build - so we do not need to
 # change scripts if at a later time we can move on to a newer version
 ENV	SCAN_BUILD=scan-build \
@@ -247,10 +253,7 @@ ENV	RSYSLOG_CONFIGURE_OPTIONS \
 	--enable-pmsnare \
 	--enable-relp \
 	--enable-snmp \
-	# SNMP Tests disabled due to Python 3.12+ compatibility issues
-	# TODO: Re-enable once pysnmp is updated to support Python 3.12+
-	# See: https://github.com/rsyslog/rsyslog/issues/5999
-	#--enable-snmp-tests \
+	--enable-snmp-tests \
 	--enable-usertools \
 	--enable-valgrind \
 	\


### PR DESCRIPTION
### Summary (non-technical, complete)

Re-enables SNMP tests in Debian 13 and Debian sid Dockerfiles. Previously, these tests were disabled due to `python3-pysnmp4` incompatibility with Python 3.12+. The fix involves installing `python3-pip` and then upgrading `pysnmp` and `pyasn1` via pip, mirroring the solution used in Ubuntu 24.04.

## Summary
- omsnmp: harden SNMP session init by using heap-backed peername/community
  strings, and free them after snmp_open().
- omsnmp: free all instance-owned config strings in freeInstance() and ensure
  szTransport is default-initialized.
- omsnmp: align legacy selector config path with the modern path (request 2
  templates, set defaults, init_snmp ordering, add SNMPv1 source template).
- Stop tracking local helper script test-snmp-debian13.sh (kept locally).

## Test plan
- Ran Debian 13 container SNMP tests:
  - tests/sndrcv_omsnmpv1_udp.sh
  - tests/sndrcv_omsnmpv1_udp_invalidoid.sh
  - tests/sndrcv_omsnmpv1_udp_dynsource.sh

### References
Refs: https://github.com/rsyslog/rsyslog/issues/5999

### Notes (optional)
- The `--break-system-packages` flag is used for pip installations to manage potential conflicts with system packages.
- This approach aligns with how Ubuntu 24.04 handles pysnmp compatibility for Python 3.12+.