### PR TITLE
ci: add DOC_BASE_URL variable for docs Sitemap base

### DIFF
--- a/.github/workflows/doc_deploy_main.yml
+++ b/.github/workflows/doc_deploy_main.yml
@@ -3,6 +3,7 @@ name: Deploy documentation to GitHub Pages
 # Builds docs with Google Analytics and deploys to https://<site>/doc/
 # Uses rsyslog/rsyslog_dev_doc_base_ubuntu:22.04 Docker container for the Sphinx build.
 # Add GOOGLE_ANALYTICS_ID as a repository secret before use.
+# Set DOC_BASE_URL repository variable (e.g. https://docs.rsyslog.com) for Sitemap base; otherwise uses github.io URL.
 
 on:
   push:
@@ -28,11 +29,13 @@ jobs:
       - name: Build documentation in Docker container
         env:
           GOOGLE_ANALYTICS_ID: ${{ secrets.GOOGLE_ANALYTICS_ID }}
+          DOC_BASE_URL: ${{ vars.DOC_BASE_URL }}
         run: |
           chmod +x doc/tools/inside_docker_doc_html.sh
           docker run --rm \
             -u "$(id -u):$(id -g)" \
             -e GOOGLE_ANALYTICS_ID \
+            -e DOC_BASE_URL \
             -e PYTHONUNBUFFERED=1 \
             -v "$(pwd)":/rsyslog \
             --entrypoint /rsyslog/doc/tools/inside_docker_doc_html.sh \
@@ -61,14 +64,17 @@ jobs:
           path: preview-site
 
       - name: Prepare Pages artifact with /doc/ subdirectory
+        env:
+          DOC_BASE_URL: ${{ vars.DOC_BASE_URL }}
         run: |
           set -e
           mkdir -p pages-deployment/doc
           rsync -a --delete preview-site/ pages-deployment/doc/
           cp doc/tools/pages-root-index.html pages-deployment/index.html
-          # robots.txt: allow only /doc/, sitemap URL from github.repository
+          # robots.txt: allow only /doc/, sitemap URL from DOC_BASE_URL or github.repository
           REPO="${{ github.repository }}"
-          BASE="https://${REPO%/*}.github.io/${REPO#*/}"
+          DEFAULT_BASE="https://${REPO%/*}.github.io/${REPO#*/}"
+          BASE="${DOC_BASE_URL:-$DEFAULT_BASE}"
           {
             sed '/^# Sitemap/d' doc/tools/pages-robots.txt
             echo "Sitemap: ${BASE}/doc/sitemap.xml"

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -380,9 +380,11 @@ suppress_warnings = ['epub.unknown_project_files']
 # -- Options for HTML output ---------------------------------------------------
 
 # The base URL which points to the root of the HTML documentation.
-# It is used to indicate the location of document like canonical_url.
-RSYSLOG_BASE_URL = 'https://www.rsyslog.com'
-html_baseurl = f'{RSYSLOG_BASE_URL}/doc/'
+# It is used to indicate the location of document like canonical_url and sitemap.
+# DOC_BASE_URL env (e.g. https://docs.rsyslog.com) overrides when set (CI deploy).
+RSYSLOG_BASE_URL = 'https://docs.rsyslog.com'
+_doc_base = os.environ.get('DOC_BASE_URL', '').rstrip('/')
+html_baseurl = f'{_doc_base}/doc/' if _doc_base else f'{RSYSLOG_BASE_URL}/doc/'
 
 DISABLE_JSON_LD = os.environ.get('DISABLE_JSON_LD', '').lower() in ('1', 'true', 'yes')
 ENABLE_JSON_LD = not DISABLE_JSON_LD


### PR DESCRIPTION
Adds DOC_BASE_URL repository variable so the docs Sitemap in robots.txt can use https://docs.rsyslog.com instead of rsyslog.github.io. Forks without the variable keep the github.io URL.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use DOC_BASE_URL to set the docs base so robots.txt Sitemap and Sphinx html_baseurl point to the custom domain. robots.txt falls back to the github.io URL when unset; Sphinx defaults to https://docs.rsyslog.com.

- **Migration**
  - Set repository variable DOC_BASE_URL to https://docs.rsyslog.com.

<sup>Written for commit d34fc125743e8c7430443cc1005062a192add822. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

