### PR TITLE
packaging: add multi-arch container release publishing

### DIFF
--- a/packaging/docker/.github/workflows/build-user-containers.yml
+++ b/packaging/docker/.github/workflows/build-user-containers.yml
@@ -11,21 +11,25 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        variant: [minimal, standard, collector, dockerlogs]
+        variant: [minimal, standard, collector, dockerlogs, etl]
+        platform: [linux/amd64, linux/arm64]
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        if: ${{ matrix.platform == 'linux/arm64' }}
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
-      - name: Build ${{ matrix.variant }} image
+      - name: Build ${{ matrix.variant }} image for ${{ matrix.platform }}
         working-directory: rsyslog
-        run: make ${{ matrix.variant }}
+        run: make ${{ matrix.variant }} DOCKER_BUILD_PLATFORM=${{ matrix.platform }} VERSION=ci-${{ github.sha }}
 
       - name: List images
         run: docker images

--- a/packaging/docker/rsyslog/Makefile
+++ b/packaging/docker/rsyslog/Makefile
@@ -48,6 +48,24 @@ VCS_REF ?= $(shell git rev-parse --short=12 HEAD 2>/dev/null || echo unknown)
 OCI_BUILD_ARGS = --build-arg BUILD_DATE="$(BUILD_DATE)" \
                  --build-arg VCS_REF="$(VCS_REF)"
 PPA_BUILD_ARGS = --build-arg RSYSLOG_APT_PPA="$(RSYSLOG_APT_PPA)"
+BUILDX_COMMON_ARGS = $(DOCKER_BUILD_FLAGS) \
+                     --platform $(PLATFORMS) \
+                     --push \
+                     $(OCI_BUILD_ARGS) \
+                     --build-arg RSYSLOG_IMG_VERSION=$(VERSION)
+
+# Template: $(call buildx_push_template,<dir>,<variant>,<extra build args>)
+define buildx_push_template
+	@echo "--- Buildx pushing $(1) image: $($(2)_IMAGE_TAG) for $(PLATFORMS) ---"
+	docker buildx build $(BUILDX_COMMON_ARGS) \
+		              -t $($(2)_IMAGE_TAG) \
+		              $(3) \
+		              -f ./$(1)/Dockerfile ./$(1)
+endef
+
+define buildx_tag_latest_template
+	docker buildx imagetools create -t $($(1)_IMAGE_NAME):latest $($(1)_IMAGE_TAG)
+endef
 
 # Manual release publishing is downstream of PPA readiness. Operators must
 # provide the expected rsyslog release version explicitly before stable
@@ -59,6 +77,19 @@ RELEASE_UBUNTU_VERSION ?= 24.04
 # Variable to control cache busting. Set to 'yes' to force a rebuild from scratch for all targets.
 # Example: make all REBUILD=yes
 REBUILD ?= no
+
+# Platforms used by the manual release publish path. Keep local builds
+# single-platform; Buildx multi-platform publishing is only used by the
+# release targets below.
+PLATFORMS ?= linux/amd64,linux/arm64
+
+# Optional single-platform override for local validation builds. CI uses this
+# to smoke-test ARM64 without publishing manifests.
+DOCKER_BUILD_PLATFORM ?=
+DOCKER_PLATFORM_FLAGS =
+ifneq ($(strip $(DOCKER_BUILD_PLATFORM)),)
+    DOCKER_PLATFORM_FLAGS = --platform $(DOCKER_BUILD_PLATFORM)
+endif
 
 # Conditionally add --no-cache flag if REBUILD is 'yes'
 DOCKER_BUILD_FLAGS =
@@ -92,6 +123,8 @@ ETL_IMAGE_TAG = $(strip $(ETL_IMAGE_NAME):$(VERSION))
 .PHONY: all build clean push all_push tag_latest push_latest help \
         minimal standard collector dockerlogs etl \
         build_minimal_image build_standard_image build_collector_image build_dockerlogs_image build_etl_image \
+        buildx_push_minimal buildx_push_standard buildx_push_collector buildx_push_dockerlogs buildx_push_etl \
+        buildx_push_all buildx_tag_latest \
         push_minimal push_standard push_collector push_dockerlogs push_etl \
         rebuild_all check_build_channel check_publish_version check_release_inputs \
         check_ppa_release_ready release_build release_push release_publish
@@ -135,6 +168,7 @@ check_build_channel:
 build_minimal_image: check_build_channel ./minimal/Dockerfile ./minimal/rsyslog.conf
 	@echo "--- Building minimal image: $(MINIMAL_IMAGE_TAG) ---"
 	docker build $(DOCKER_BUILD_FLAGS) \
+		              $(DOCKER_PLATFORM_FLAGS) \
 		              -t $(MINIMAL_IMAGE_TAG) \
 		              $(OCI_BUILD_ARGS) \
 		              $(PPA_BUILD_ARGS) \
@@ -146,6 +180,7 @@ build_minimal_image: check_build_channel ./minimal/Dockerfile ./minimal/rsyslog.
 build_standard_image: build_minimal_image ./standard/Dockerfile # Add ./standard/rsyslog.conf if it exists
 	@echo "--- Building standard image: $(STANDARD_IMAGE_TAG) ---"
 	docker build $(DOCKER_BUILD_FLAGS) \
+		              $(DOCKER_PLATFORM_FLAGS) \
 		              -t $(STANDARD_IMAGE_TAG) \
 		              --build-arg BASE_IMAGE_TAG=$(MINIMAL_IMAGE_TAG) \
 		              $(OCI_BUILD_ARGS) \
@@ -160,6 +195,7 @@ build_collector_image: build_standard_image \
                        ./collector/80-file-output.conf
 	@echo "--- Building collector image: $(COLLECTOR_IMAGE_TAG) ---"
 	docker build $(DOCKER_BUILD_FLAGS) \
+		              $(DOCKER_PLATFORM_FLAGS) \
 		              -t $(COLLECTOR_IMAGE_TAG) \
 		              --build-arg BASE_IMAGE_TAG=$(STANDARD_IMAGE_TAG) \
 		              $(OCI_BUILD_ARGS) \
@@ -173,6 +209,7 @@ build_dockerlogs_image: build_standard_image \
                         ./dockerlogs/30-docker.conf
 	@echo "--- Building dockerlogs image: $(DOCKERLOGS_IMAGE_TAG) ---"
 	docker build $(DOCKER_BUILD_FLAGS) \
+		              $(DOCKER_PLATFORM_FLAGS) \
 		              -t $(DOCKERLOGS_IMAGE_TAG) \
 		              --build-arg BASE_IMAGE_TAG=$(STANDARD_IMAGE_TAG) \
 		              $(OCI_BUILD_ARGS) \
@@ -187,6 +224,7 @@ build_etl_image: build_standard_image \
                   ./etl/70-vespa_ai.conf
 	@echo "--- Building ETL image: $(ETL_IMAGE_TAG) ---"
 	docker build $(DOCKER_BUILD_FLAGS) \
+		              $(DOCKER_PLATFORM_FLAGS) \
 		              -t $(ETL_IMAGE_TAG) \
 		              --build-arg BASE_IMAGE_TAG=$(STANDARD_IMAGE_TAG) \
 		              $(OCI_BUILD_ARGS) \
@@ -278,16 +316,55 @@ release_build: check_ppa_release_ready
 	$(MAKE) all VERSION=$(RELEASE_VERSION) PPA_CHANNEL=$(RELEASE_CHANNEL) REBUILD=$(REBUILD)
 
 release_push: check_ppa_release_ready
-	@echo "--- Manual release push for VERSION=$(RELEASE_VERSION) ---"
-	$(MAKE) all_push VERSION=$(RELEASE_VERSION) PPA_CHANNEL=$(RELEASE_CHANNEL) REBUILD=$(REBUILD)
+	@echo "--- Manual multi-platform release push for VERSION=$(RELEASE_VERSION) ---"
+	$(MAKE) buildx_push_all VERSION=$(RELEASE_VERSION) PPA_CHANNEL=$(RELEASE_CHANNEL) REBUILD=$(REBUILD) PLATFORMS=$(PLATFORMS)
 
 release_publish: release_push
 	@if [ "$(PUSH_LATEST)" = "yes" ]; then \
-		echo "--- Updating latest tags for VERSION=$(RELEASE_VERSION) ---"; \
-		$(MAKE) push_latest VERSION=$(RELEASE_VERSION) PPA_CHANNEL=$(RELEASE_CHANNEL) REBUILD=$(REBUILD); \
+		echo "--- Updating multi-platform latest tags for VERSION=$(RELEASE_VERSION) ---"; \
+		$(MAKE) buildx_tag_latest VERSION=$(RELEASE_VERSION); \
 	else \
 		echo "Skipping latest tag update. Set PUSH_LATEST=yes to publish latest."; \
 	fi
+
+# --- Multi-platform Release Push Targets ---
+# These targets publish manifest lists directly via Buildx. They intentionally
+# remain separate from the local build/push targets so developer workflows keep
+# using plain docker builds unless release publishing is requested.
+buildx_push_minimal: check_publish_version check_build_channel ./minimal/Dockerfile ./minimal/rsyslog.conf
+	$(call buildx_push_template,minimal,MINIMAL,$(PPA_BUILD_ARGS))
+
+buildx_push_standard: buildx_push_minimal ./standard/Dockerfile
+	$(call buildx_push_template,standard,STANDARD,--build-arg BASE_IMAGE_TAG=$(MINIMAL_IMAGE_TAG))
+
+buildx_push_collector: buildx_push_standard \
+                       ./collector/Dockerfile \
+                       ./collector/10-collector.conf \
+                       ./collector/80-file-output.conf
+	$(call buildx_push_template,collector,COLLECTOR,--build-arg BASE_IMAGE_TAG=$(STANDARD_IMAGE_TAG))
+
+buildx_push_dockerlogs: buildx_push_standard \
+                        ./dockerlogs/Dockerfile \
+                        ./dockerlogs/30-docker.conf
+	$(call buildx_push_template,dockerlogs,DOCKERLOGS,--build-arg BASE_IMAGE_TAG=$(STANDARD_IMAGE_TAG))
+
+buildx_push_etl: buildx_push_standard \
+                  ./etl/Dockerfile \
+                  ./etl/10-collector.conf \
+                  ./etl/70-vespa_ai.conf
+	$(call buildx_push_template,etl,ETL,--build-arg BASE_IMAGE_TAG=$(STANDARD_IMAGE_TAG))
+
+buildx_push_all: buildx_push_collector buildx_push_dockerlogs buildx_push_etl
+	@echo "All multi-platform images pushed successfully with version: $(VERSION)"
+
+buildx_tag_latest: check_publish_version
+	@echo "--- Creating latest manifest tags from VERSION=$(VERSION) ---"
+	$(call buildx_tag_latest_template,STANDARD)
+	$(call buildx_tag_latest_template,MINIMAL)
+	$(call buildx_tag_latest_template,COLLECTOR)
+	$(call buildx_tag_latest_template,DOCKERLOGS)
+	$(call buildx_tag_latest_template,ETL)
+	@echo "All latest manifest tags updated successfully."
 
 # --- Push Targets ---
 push_minimal: check_publish_version build_minimal_image
@@ -386,6 +463,9 @@ help:
 	@echo "                       daily-stable -> ppa:adiscon/daily-stable and tag daily-stable"
 	@echo "  PUSH_LATEST        - Set to 'yes' to let release_publish update ':latest'."
 	@echo "  RELEASE_UBUNTU_VERSION - Ubuntu base used for the PPA readiness check."
+	@echo "  PLATFORMS          - Buildx platforms for release push/publish."
+	@echo "                       Defaults to linux/amd64,linux/arm64."
+	@echo "  DOCKER_BUILD_PLATFORM - Optional single platform for local validation builds."
 	@echo "  REBUILD            - Set to 'yes' to force a full rebuild, bypassing Docker build cache."
 	@echo "                       Example: make all REBUILD=yes"
 	@echo ""

--- a/packaging/docker/rsyslog/README.md
+++ b/packaging/docker/rsyslog/README.md
@@ -75,6 +75,19 @@ make VERSION=2026-03 all_push
 make VERSION=2026-03 push_latest
 ```
 
+The plain Makefile push targets above are single-platform compatibility
+targets. The manual release push and publish targets use Docker Buildx and
+publish multi-platform manifests by default for:
+
+- `linux/amd64`
+- `linux/arm64`
+
+Override the release platform list only when needed:
+
+```bash
+./release-images.sh publish --rsyslog-version 8.2604.0 --platforms linux/amd64,linux/arm64
+```
+
 ## PPA readiness comes first
 
 Release-tagged container images must only be built and pushed after the
@@ -141,11 +154,15 @@ early. If subpackages are still missing, the actual image build fails.
 ./release-images.sh build --rsyslog-version 8.2602.0
 ```
 
-4. Push the release-tagged images:
+4. Push the release-tagged images as multi-platform manifests:
 
 ```bash
 ./release-images.sh push --rsyslog-version 8.2602.0
 ```
+
+This publishes the five image variants for `linux/amd64,linux/arm64`
+by default. Derived images are pushed after their base images so Buildx
+can resolve the correct platform-specific base layers from Docker Hub.
 
 5. Update `latest` only when that is intended:
 
@@ -154,7 +171,15 @@ early. If subpackages are still missing, the actual image build fails.
 ```
 
 If `PUSH_LATEST` is not set to `yes`, `release_publish` pushes only the
-versioned images and leaves `latest` unchanged.
+versioned images and leaves `latest` unchanged. When `latest` is enabled,
+the manifest tags are created from the already-pushed versioned manifests
+instead of retagging local single-platform images.
+
+To override the default release platforms:
+
+```bash
+./release-images.sh publish --rsyslog-version 8.2604.0 --platforms linux/amd64,linux/arm64
+```
 
 For the daily channel:
 
@@ -178,3 +203,6 @@ make all PPA_CHANNEL=daily-stable VERSION=ci-example
 CI validation jobs should use non-release tags such as `ci-<sha>`.
 Release publishing jobs should inject the stable release version
 explicitly, for example `VERSION=2026-03`.
+
+Container CI should validate Dockerfile buildability without publishing.
+Release publishing remains a manual PPA-gated operation.

--- a/packaging/docker/rsyslog/release-images.sh
+++ b/packaging/docker/rsyslog/release-images.sh
@@ -18,6 +18,8 @@ Stable release options:
 
 Additional options:
   --latest                         With publish, also update :latest tags.
+  --platforms <list>               Buildx platforms for push/publish.
+                                   Default: linux/amd64,linux/arm64.
   --rebuild                        Force docker builds to bypass cache.
   --ubuntu-version <version>       Override the readiness-check Ubuntu base.
   -h, --help                       Show this help text.
@@ -26,6 +28,7 @@ Examples:
   ./release-images.sh check --rsyslog-version 8.2604.0
   ./release-images.sh build --rsyslog-version 8.2604.0
   ./release-images.sh publish --rsyslog-version 8.2604.0 --latest
+  ./release-images.sh publish --rsyslog-version 8.2604.0 --platforms linux/amd64,linux/arm64
   ./release-images.sh build --daily
 EOF
 }
@@ -41,6 +44,7 @@ rsyslog_version=""
 push_latest="no"
 rebuild="no"
 release_ubuntu_version=""
+platforms=""
 
 while (($# > 0)); do
 	case "$1" in
@@ -70,6 +74,11 @@ while (($# > 0)); do
 		--latest)
 			push_latest="yes"
 			shift
+			;;
+		--platforms)
+			[[ $# -ge 2 ]] || die "--platforms requires a value"
+			platforms="$2"
+			shift 2
 			;;
 		--rebuild)
 			rebuild="yes"
@@ -135,6 +144,10 @@ fi
 
 if [[ "$push_latest" == "yes" ]]; then
 	make_args+=("PUSH_LATEST=yes")
+fi
+
+if [[ -n "$platforms" ]]; then
+	make_args+=("PLATFORMS=$platforms")
 fi
 
 exec make "${make_args[@]}"


### PR DESCRIPTION
Summary:
Implemented ARM64 Docker image support for issue #6738. Release publishing now uses Docker Buildx multi-platform manifests for `linux/amd64,linux/arm64`, while normal local builds stay single-platform by default.

Changes:
- Added Buildx release push targets for all five published images: `minimal`, `standard`, `collector`, `dockerlogs`, and `etl`.
- Added `--platforms <list>` to `release-images.sh`.
- Added `DOCKER_BUILD_PLATFORM` for non-publishing CI validation.
- Updated container CI to build all five variants for amd64 and arm64.
- Documented the new multi-platform release flow and manifest-based `latest` updates.

Validation:
- `bash packaging/docker/rsyslog/release-images.sh --help` passed.
- `bash -n packaging/docker/rsyslog/release-images.sh` passed.
- `git diff --check` passed.
- Touched files are LF in the worktree.
