### PR TITLE
Fix RFC3339 formatting for high-precision secfrac

### DIFF
--- a/runtime/datetime.c
+++ b/runtime/datetime.c
@@ -831,6 +831,24 @@ static int formatTimestampToPgSQL(struct syslogTime *ts, char *pBuf) {
 }
 
 
+static int getNormalizedSecFracPower(const struct syslogTime *ts, int *secfrac) {
+    int precision;
+
+    assert(ts != NULL);
+    assert(secfrac != NULL);
+    assert(ts->secfracPrecision > 0);
+
+    precision = ts->secfracPrecision;
+    *secfrac = ts->secfrac;
+    while (precision > 6) {
+        *secfrac /= 10;
+        --precision;
+    }
+
+    return tenPowers[precision - 1];
+}
+
+
 /**
  * Format a syslogTimestamp to just the fractional seconds.
  * The caller must provide the timestamp as well as a character
@@ -851,8 +869,7 @@ static int formatTimestampSecFrac(struct syslogTime *ts, char *pBuf) {
 
     iBuf = 0;
     if (ts->secfracPrecision > 0) {
-        power = tenPowers[(ts->secfracPrecision - 1) % 6];
-        secfrac = ts->secfrac;
+        power = getNormalizedSecFracPower(ts, &secfrac);
         while (power > 0) {
             digit = secfrac / power;
             secfrac -= digit * power;
@@ -916,8 +933,7 @@ static int formatTimestamp3339(struct syslogTime *ts, char *pBuf) {
 
     if (ts->secfracPrecision > 0) {
         pBuf[iBuf++] = '.';
-        power = tenPowers[(ts->secfracPrecision - 1) % 6];
-        secfrac = ts->secfrac;
+        power = getNormalizedSecFracPower(ts, &secfrac);
         while (power > 0) {
             digit = secfrac / power;
             secfrac -= digit * power;

--- a/tests/timestamp-3339.sh
+++ b/tests/timestamp-3339.sh
@@ -18,6 +18,10 @@ injectmsg_literal "<34>1 2003-11-11T22:04:05.003Z mymachine.example.com su - ID4
 injectmsg_literal "<34>1 2003-11-11T22:04:05.003+02:00 mymachine.example.com su - ID47 - MSG"
 injectmsg_literal "<34>1 2003-11-11T22:04:05.003+01:30 mymachine.example.com su - ID47 - MSG"
 injectmsg_literal "<34>1 2003-11-11T22:04:05.123456+01:30 mymachine.example.com su - ID47 - MSG"
+injectmsg_literal "<34>1 2026-04-27T15:46:41.0300000Z mymachine.example.com su - ID47 - MSG"
+injectmsg_literal "<34>1 2026-04-27T15:46:41.03000000Z mymachine.example.com su - ID47 - MSG"
+injectmsg_literal "<34>1 2026-04-27T15:46:41.000006930Z mymachine.example.com su - ID47 - MSG"
+injectmsg_literal "<34>1 2026-04-27T15:46:41.000022054Z mymachine.example.com su - ID47 - MSG"
 shutdown_when_empty
 wait_shutdown
 
@@ -28,6 +32,10 @@ export EXPECTED='2003-11-11T22:14:15.003Z
 2003-11-11T22:04:05.003Z
 2003-11-11T22:04:05.003+02:00
 2003-11-11T22:04:05.003+01:30
-2003-11-11T22:04:05.123456+01:30'
+2003-11-11T22:04:05.123456+01:30
+2026-04-27T15:46:41.030000Z
+2026-04-27T15:46:41.030000Z
+2026-04-27T15:46:41.000006Z
+2026-04-27T15:46:41.000022Z'
 cmp_exact
 exit_test


### PR DESCRIPTION
Normalize parsed fractional seconds to rsyslog’s six-digit output precision before formatting RFC3339 timestamps. This removes the old modulo divisor behavior that wrapped 7-9 digit secfrac precision and could emit garbage/control bytes such as \x10, \x0c, or u30. Adds regression coverage to timestamp-3339.sh for the reported 7, 8, and 9 digit cases from issue #6768, expecting truncated six-digit RFC3339 output.

<!--
Thanks for your PR!

Commit Assistant (recommended for the commit message):
- Web (humans): https://www.rsyslog.com/tool_rsyslog-commit-assistant
- Base prompt (canonical): https://github.com/rsyslog/rsyslog/blob/main/ai/rsyslog_commit_assistant/base_prompt.txt

Important: put the substance into the **commit message** (not only here).
If needed, amend first (`git commit --amend`) and then open the PR.
-->

### Summary (non-technical, complete)
<!-- Why this change matters: modernization, maintainability, perf/security,
     Docker/CI readiness, or user value. This text should mirror the commit’s
     non-technical intro. -->

### References
<!-- Full GitHub URLs; use Fixes: only if conclusively fixed. -->
Refs: https://github.com/rsyslog/rsyslog/issues/<id>

### Notes (optional)
<!-- Mention tests/docs updates or planned follow-ups. If behavior changed,
     ensure the commit body has a one-line Impact and a one-line Before/After. -->

---

#### Quick check (optional)
- Commit message follows rules (ASCII; title ≤62, body ≤72; `<component>:`).
- Commit message includes non-technical “why”, Impact (if behavior/tests changed),
  and a one-line Before/After when behavior changed.
- Used the Commit Assistant or mirrored its structure.

---

#### Git workflow tips (optional, but helps reviews)
- Start by crafting the commit message locally (use the Assistant).
- If you already committed, improve it with:
  ```
  git commit --amend
  ```
- Squash related commits before PR where appropriate.
- Push your branch and then open the PR.
- If key info is only in the PR text, maintainers may ask you to move it
  into the commit message for a clean history.

