### PR TITLE
docs(agents): add Cursor Cloud environment setup notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -319,6 +319,39 @@ that still need coverage.
   full-suite run. Report which families were disabled and why when that matters
   for the validation claim.
 
+## Cursor Cloud specific instructions
+
+This section captures durable, non-obvious notes for Cursor Cloud agents. The
+VM startup update script already runs `devtools/codex-setup.sh` plus a few extra
+apt packages, so dependencies are present on session start. Standard build/test
+commands live in the `rsyslog_build` and `rsyslog_test` skills; use those rather
+than duplicating them.
+
+- **Toolchain gotcha (`cannot find -lstdc++`)**: The base VM's
+  `update-alternatives` points `cc`/`c++` at **Clang 18**, and Clang selects the
+  newest GCC toolchain (`gcc-14`) for its C++ stdlib. `codex-setup.sh` installs
+  `gcc-14` but not the matching `libstdc++-14-dev`, so CMake-based dependency
+  builds (e.g. `faup`) fail at the compiler check. The update script installs
+  `libstdc++-14-dev` to fix this; if you ever re-run `codex-setup.sh` on a fresh
+  environment, ensure `libstdc++-14-dev` is present first.
+- **Lint tools not in `codex-setup.sh`**: `clang-format-18` (the exact formatter
+  required by `devtools/format-code.sh`) and `shellcheck` are installed by the
+  update script, not by `codex-setup.sh`. `pycodestyle` comes from
+  `codex-setup.sh`.
+- **Running `rsyslogd` from the build tree**: pass in-tree module dirs via `-M`,
+  e.g. `-M"$(pwd)/plugins/imtcp/.libs:$(pwd)/runtime/.libs:$(pwd)/tools/.libs:$(pwd)/tools"`.
+  Validate config with `./tools/rsyslogd -N1 -f <conf> -M...`; plain-TCP inputs
+  emit expected `streamdriver.mode="0"` insecure-default warnings.
+- **`ss`/`netstat` cannot see listeners** in this VM (restricted `/proc/net`
+  access), even with `sudo`. To confirm a listener is up, connect to the port
+  directly (e.g. bash `/dev/tcp`, or the `tests/tcpflood` helper) instead of
+  relying on socket-listing tools.
+- **No container tooling**: Docker/Podman are not installed in the base VM, so
+  the PR-ready `rsyslog_local_container_testing` gate cannot run here. Host-side
+  build + focused `make check TESTS=...` are the available validation; report
+  container validation as not run unless Docker is installed first (see the
+  Docker-in-Docker setup notes).
+
 ## Agent Chat Keywords
 
 - `SETUP`: Triggers the `rsyslog_build` setup workflow.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary (non-technical, complete)

This change sets up and verifies the rsyslog development environment for Cursor Cloud agents and records the non-obvious caveats discovered during setup so future agents can start services safely without rediscovering them. No source code is modified; only `AGENTS.md` gains a `## Cursor Cloud specific instructions` section.

The dev environment was fully installed, built, run, and tested:

- **Dependencies**: `sudo devtools/codex-setup.sh` (Ubuntu 24.04 dev toolchain + source-built `libfastjson`, `faup`, `libksi`, `librelp`, `qpid-proton`, `librdkafka`, `kafkacat`), plus `libstdc++-14-dev`, `clang-format-18`, and `shellcheck`.
- **Build**: `./autogen.sh --enable-debug --enable-testbench --enable-imdiag --enable-omstdout` then `make -j"$(nproc)" check TESTS=""` → `tools/rsyslogd 8.2608.0.daily` built.
- **Run (hello-world)**: started `rsyslogd` with an `imtcp` input → filter → `omfile` output config, sent a TCP syslog message, and confirmed it was written to the output file.
- **Tests**: `make check TESTS="imtcp-basic.sh omfile-null-filename.sh"` → 2 PASS.
- **Lint**: C format gate (`clang-format-18`), `pycodestyle`, and `shellcheck` all runnable.

Notable non-obvious fix captured in the notes: the base VM's `cc`/`c++` default to Clang 18, which selects the `gcc-14` toolchain, but `codex-setup.sh` does not install the matching `libstdc++-14-dev`; without it, CMake-based dependency builds (e.g. `faup`) fail with `cannot find -lstdc++`.

### References
Refs: N/A (development-environment setup task)

### Notes (optional)
- Docs-only change; standard build/test commands are referenced from the `rsyslog_build` / `rsyslog_test` skills rather than duplicated.
- Docker/Podman are not available in the base VM, so the PR-ready `rsyslog_local_container_testing` gate could not be run here; host-side build and focused tests were used instead.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-048fd1f1-2073-4ee1-8a9f-7371869b1549"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-048fd1f1-2073-4ee1-8a9f-7371869b1549"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

