### PR TITLE
packaging: add EL10 mock CI targets

### DIFF
--- a/.github/workflows/run_checks.yml
+++ b/.github/workflows/run_checks.yml
@@ -756,13 +756,19 @@ jobs:
         run: echo "No relevant package changes detected; skipping Ubuntu package build."
 
   package_build_rpm:
-    name: package build (RPM)
+    name: package build (RPM ${{ matrix.mock_config }})
     needs: [compile, changes]
     if: ${{ needs.compile.result == 'success' && needs.changes.outputs.package_rpm == 'true' }}
     permissions:
       contents: read
     runs-on: ubuntu-22.04
     timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        mock_config:
+          - epel-9-x86_64
+          - epel-10-x86_64
     container:
       image: quay.io/rockylinux/rockylinux:9
       options: --privileged
@@ -807,8 +813,11 @@ jobs:
 
       - name: run RPM build
         if: steps.code_changes.outputs.any_changed == 'true'
+        env:
+          MOCK_CONFIG: ${{ matrix.mock_config }}
         run: |
           chmod -R go+rw .
+          echo "== Selected mock target: $MOCK_CONFIG =="
           echo "== Install EPEL and mock =="
           dnf install -y epel-release
           dnf install -y mock dnf-utils
@@ -828,7 +837,13 @@ jobs:
           dnf config-manager --set-enabled crb
           dnf install -y libestr-devel libfastjson4-devel zlib-devel libuuid-devel libgcrypt-devel libcurl-devel libyaml-devel file protobuf-c-compiler protobuf-c-devel snappy-devel python3-docutils dos2unix
           echo "== Copy mock configs =="
-          cp -v packaging/rpm/etc-mock/*.cfg /etc/mock/ || true
+          # Replace symlink targets with regular files so custom configs do not
+          # overwrite shared mock-core-configs aliases like centos-stream+epel-*.
+          for cfg in packaging/rpm/etc-mock/*.cfg; do
+            dest="/etc/mock/$(basename "$cfg")"
+            rm -f "$dest"
+            cp -v "$cfg" "$dest"
+          done
           mkdir -p build-result /var/lib/mock
           echo "== Run RPM build =="
           bash devtools/run-rpm-build.sh
@@ -841,7 +856,7 @@ jobs:
         if: steps.code_changes.outputs.any_changed == 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: rpms-epel-9-x86_64
+          name: rpms-${{ matrix.mock_config }}
           path: build-result/
           if-no-files-found: error
 

--- a/packaging/rpm/config.sh
+++ b/packaging/rpm/config.sh
@@ -3,7 +3,7 @@
 # Sourced by build-rpms.sh and other scripts.
 
 ARCHOPTIONS="i386 x86_64"
-PLATOPTIONS="epel-8 epel-9 rhel-8 rhel-9"
+PLATOPTIONS="epel-8 epel-9 epel-10 rhel-8 rhel-9 rhel-10"
 
 szBaseDir="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
 szRpmBaseDir="$szBaseDir/rpmbuild"

--- a/packaging/rpm/etc-mock/epel-10-x86_64.cfg
+++ b/packaging/rpm/etc-mock/epel-10-x86_64.cfg
@@ -1,0 +1,40 @@
+# Match upstream mock-core-configs: epel-10-x86_64 aliases
+# centos-stream+epel-10. Keep project-specific repo appends only.
+config_opts['koji_primary_repo'] = 'epel'
+include('templates/centos-stream-10.tpl')
+include('templates/epel-10.tpl')
+
+config_opts['root'] = 'epel-10-x86_64'
+config_opts['description'] = 'CentOS Stream 10 + EPEL'
+config_opts['target_arch'] = 'x86_64'
+config_opts['legal_host_arches'] = ('x86_64',)
+
+config_opts['rpmbuild_networking'] = True
+config_opts['use_host_resolv'] = True
+
+config_opts['dnf.conf'] += """
+[adiscon]
+name=adiscon
+baseurl=https://rpms.adiscon.com/v8-stable/epel-10/$basearch
+skip_if_unavailable=true
+enabled=1
+gpgcheck=1
+gpgkey=https://download.adiscon.com/rpms/RPM-GPG-KEY-Adiscon
+
+[adiscon-2]
+name=adiscon
+baseurl=https://rpms.adiscon.com/v8-stable-build/epel-10/$basearch
+skip_if_unavailable=true
+enabled=1
+gpgcheck=1
+gpgkey=https://download.adiscon.com/rpms/RPM-GPG-KEY-Adiscon
+
+[guardtime]
+name = KSI
+baseurl = https://download.guardtime.com/ksi/rhel/10/$basearch
+skip_if_unavailable=true
+enabled=1
+gpgcheck=1
+repo_gpgcheck=1
+gpgkey=https://download.guardtime.com/ksi/GUARDTIME-GPG-KEY
+"""

--- a/packaging/rpm/etc-mock/rhel-10-x86_64.cfg
+++ b/packaging/rpm/etc-mock/rhel-10-x86_64.cfg
@@ -1,0 +1,39 @@
+include('templates/rhel-10.tpl')
+
+config_opts['target_arch'] = 'x86_64'
+config_opts['legal_host_arches'] = ('x86_64',)
+# Keep the same local chroot package append used by rhel-8/rhel-9 so local and
+# entitlement-based builder hosts stay aligned with the older EL mock configs.
+# templates/rhel-10.tpl already sets a string chroot_setup_cmd, so this append
+# is safe (unlike the earlier EL10 tuple-concat failure).
+config_opts['chroot_setup_cmd'] += ' tar redhat-rpm-config redhat-release which xz sed make bzip2 gzip coreutils unzip shadow-utils diffutils cpio bash gawk rpm-build info patch util-linux findutils grep glibc-minimal-langpack'
+
+config_opts['rpmbuild_networking'] = True
+config_opts['use_host_resolv'] = True
+
+config_opts['dnf.conf'] += """
+[adiscon]
+name=adiscon
+baseurl=https://rpms.adiscon.com/v8-stable/rhel-10/$basearch
+skip_if_unavailable=true
+enabled=1
+gpgcheck=1
+gpgkey=https://download.adiscon.com/rpms/RPM-GPG-KEY-Adiscon
+
+[adiscon-2]
+name=adiscon
+baseurl=https://rpms.adiscon.com/v8-stable-build/rhel-10/$basearch
+skip_if_unavailable=true
+enabled=1
+gpgcheck=1
+gpgkey=https://download.adiscon.com/rpms/RPM-GPG-KEY-Adiscon
+
+[guardtime]
+name = KSI
+baseurl = https://download.guardtime.com/ksi/rhel/10/$basearch
+skip_if_unavailable=true
+enabled=1
+gpgcheck=1
+repo_gpgcheck=1
+gpgkey=https://download.guardtime.com/ksi/GUARDTIME-GPG-KEY
+"""

--- a/packaging/rpm/rpmbuild/SPECS/rsyslog-v8-stable.spec
+++ b/packaging/rpm/rpmbuild/SPECS/rsyslog-v8-stable.spec
@@ -1,4 +1,4 @@
-# SPEC file for EL8 and EL9 (RHEL 7 dropped - components too old)
+# SPEC file for EL8, EL9, and EL10 (RHEL 7 dropped - components too old)
 %define rsyslog_statedir %{_sharedstatedir}/rsyslog
 %define rsyslog_pkidir %{_sysconfdir}/pki/rsyslog
 %define rsyslog_docdir %{_docdir}/%{name}-%{version}
@@ -10,6 +10,20 @@
 %global want_hiredis 1
 %global want_mongodb 1
 %global want_rabbitmq 1
+%endif
+# EL10 (and current CentOS Stream packaging) use unversioned library package
+# names, while Adiscon EL8/EL9 repos still ship the libfastjson4/liblognorm5
+# names used historically by this spec.
+%if 0%{?rhel} >= 10
+%global libfastjson_pkg libfastjson
+%global libfastjson_devel_pkg libfastjson-devel
+%global liblognorm_pkg liblognorm
+%global liblognorm_devel_pkg liblognorm-devel
+%else
+%global libfastjson_pkg libfastjson4
+%global libfastjson_devel_pkg libfastjson4-devel
+%global liblognorm_pkg liblognorm5
+%global liblognorm_devel_pkg liblognorm5-devel
 %endif
 
 Summary: Enhanced system logging and kernel message trapping daemon
@@ -38,7 +52,7 @@ BuildRequires: bison
 BuildRequires: dos2unix
 BuildRequires: flex
 BuildRequires: libgcrypt-devel
-BuildRequires: libfastjson4-devel >= 0.99.8
+BuildRequires: %{libfastjson_devel_pkg} >= 0.99.8
 BuildRequires: libestr-devel >= 0.1.9
 BuildRequires: libtool
 BuildRequires: libuuid-devel
@@ -81,7 +95,7 @@ BuildRequires: ruby-devel
 Requires: logrotate >= 3.5.2
 Requires: bash >= 2.0
 Requires: libestr >= 0.1.11
-Requires: libfastjson4 >= 0.99.8
+Requires: %{libfastjson_pkg} >= 0.99.8
 
 Requires(post): systemd
 Requires(preun): systemd
@@ -133,21 +147,21 @@ BuildRequires: hiredis-devel >= 0.13.1
 Summary: mmfields support 
 Group: System Environment/Daemons
 Requires: %name = %version-%release
-Requires: liblognorm5 >= 2.0.6
-BuildRequires: liblognorm5-devel >= 2.0.6
+Requires: %{liblognorm_pkg} >= 2.0.6
+BuildRequires: %{liblognorm_devel_pkg} >= 2.0.6
 
 %package mmjsonparse
 Summary: mmjsonparse support 
 Group: System Environment/Daemons
 Requires: %name = %version-%release
-Requires: liblognorm5 >= 2.0.6
-BuildRequires: liblognorm5-devel >= 2.0.6
+Requires: %{liblognorm_pkg} >= 2.0.6
+BuildRequires: %{liblognorm_devel_pkg} >= 2.0.6
 
 %package mmnormalize
 Summary: Log normalization support for rsyslog
 Group: System Environment/Daemons
 Requires: %name = %version-%release
-BuildRequires: liblognorm5-devel >= 2.0.6
+BuildRequires: %{liblognorm_devel_pkg} >= 2.0.6
 
 %package mmaudit
 Summary: Message modification module supporting Linux audit format
@@ -168,8 +182,13 @@ Requires: %name = %version-%release
 Summary: MySQL support for rsyslog
 Group: System Environment/Daemons
 Requires: %name = %version-%release
+%if 0%{?rhel} >= 10
+# EL10 provides the MySQL client ABI via MariaDB Connector/C.
+BuildRequires: mariadb-connector-c-devel
+%else
 BuildRequires: mysql >= 4.0
 BuildRequires: mysql-devel >= 4.0
+%endif
 
 %if %{want_mongodb}
 %package mongodb
@@ -333,7 +352,7 @@ BuildRequires: libmaxminddb-devel
 Summary: Log normalization parser module for rsyslog
 Group: System Environment/Daemons
 Requires: %name = %version-%release
-BuildRequires: liblognorm5-devel >= 2.0.6
+BuildRequires: %{liblognorm_devel_pkg} >= 2.0.6
 
 
 %description


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary (non-technical, complete)
Extend RPM packaging CI so Enterprise Linux 10 targets are validated the same way existing EL targets are, reducing release risk as EL10 adoption grows.

### References
Closes: https://github.com/rsyslog/rsyslog/issues/7447

### Notes (optional)
- Squashed to a single commit authored as Andre Lorbach.
- Added `epel-10` / `rhel-10` mock configs and registered them in `packaging/rpm/config.sh`.
- Matrixed `package_build_rpm` over `epel-9-x86_64` and `epel-10-x86_64`, passing `MOCK_CONFIG` via step `env:`.
- Fixed EL10 BuildRequires/Requires package names in `rsyslog-v8-stable.spec` (`libfastjson`, `liblognorm`, `mariadb-connector-c-devel`).
- Custom mock configs replace symlink destinations so `/etc/mock/epel-10-x86_64.cfg` does not overwrite the shared `centos-stream+epel-10` alias.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2cd8db52-ea07-488c-9449-e786fd6db945"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2cd8db52-ea07-488c-9449-e786fd6db945"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

