### PR TITLE
macos: suppress libsystem_trace ASAN false positive in weekly jobs

### DIFF
--- a/.github/workflows/run_macos_weekly.yml
+++ b/.github/workflows/run_macos_weekly.yml
@@ -109,7 +109,8 @@ jobs:
           if [ "${{ matrix.sanitizer }}" = "asan" ]; then
             export ASAN_OPTIONS=":halt_on_error=1:\
               check_initialization_order=1:strict_init_order=1:\
-              detect_stack_use_after_return=1:print_stacktrace=1"
+              detect_stack_use_after_return=1:print_stacktrace=1:\
+              suppressions=$PWD/tests/asan-macos.supp"
           elif [ "${{ matrix.sanitizer }}" = "tsan" ]; then
             export TSAN_OPTIONS=":halt_on_error=1:\
               detect_deadlocks=1:history_size=7:suppressions=$PWD/tests/tsan-rt.supp"

--- a/tests/asan-macos.supp
+++ b/tests/asan-macos.supp
@@ -1,0 +1,4 @@
+# Apple libsystem_trace false positive under ASAN during getaddrinfo init
+# (os_log_create -> _os_trace_get_image_info strcmp into a global redzone).
+# Seen on macos-15 arm64 weekly ASAN in omfwd-rebind-tcp (#7428).
+interceptor_via_fun:_os_trace_get_image_info


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary (non-technical, complete)
This adjusts the weekly macOS ASAN CI configuration to suppress a known false positive coming from Apple’s `libsystem_trace` during `omfwd-rebind-tcp`. It should stop re-opening the tracking issue without changing rsyslog runtime behavior.

### References
Refs: https://github.com/rsyslog/rsyslog/issues/7428

### Notes
- Changes: `tests/asan-macos.supp` + `/.github/workflows/run_macos_weekly.yml`.
- Local validation: `actionlint` on `.github/workflows/run_macos_weekly.yml`; `zizmor --strict-collection` on `.github/workflows`.


<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cc549529-8eac-440f-857f-3ab25ee947f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cc549529-8eac-440f-857f-3ab25ee947f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

