### PR TITLE
tests: avoid UDP port race in rfctag replacer test

### DIFF
--- a/tests/proprepltest-rfctag-udp.sh
+++ b/tests/proprepltest-rfctag-udp.sh
@@ -1,10 +1,15 @@
 #!/bin/bash
 # add 2018-06-27 by Pascal Withopf, released under ASL 2.0
+# Verify UDP RFC-tag truncation to 32 characters via property replacer.
+# The imudp listener owns an OS-assigned port before tcpflood sends, preventing
+# parallel UDP tests from sharing a preselected port; the ordered truncated tag
+# output is the pass/fail oracle.
 . ${srcdir:=.}/diag.sh init
 generate_conf
+PORT_RCVR_FILE="$RSYSLOG_DYNNAME.imudp.port"
 add_conf '
 module(load="../plugins/imudp/.libs/imudp")
-input(type="imudp" port="'$TCPFLOOD_PORT'")
+input(type="imudp" address="127.0.0.1" port="0" listenPortFileName="'$PORT_RCVR_FILE'")
 
 template(name="outfmt" type="string" string="+%syslogtag:1:32%+\n")
 
@@ -14,6 +19,7 @@ template(name="outfmt" type="string" string="+%syslogtag:1:32%+\n")
 
 '
 startup
+assign_tcpflood_port "$PORT_RCVR_FILE"
 tcpflood -m1 -T "udp" -M "\"<167>Mar  6 16:57:54 172.20.245.8 TAG: Rest of message...\""
 tcpflood -m1 -T "udp" -M "\"<167>Mar  6 16:57:54 172.20.245.8 0 Rest of message...\""
 tcpflood -m1 -T "udp" -M "\"<167>Mar  6 16:57:54 172.20.245.8 01234567890123456789012345678901 Rest of message...\""


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Daily full-distro CI (`fedora_43`) failed on `proprepltest-rfctag-udp.sh` because the test still preselected a UDP port via `get_free_port` before imudp bound it. That is the same class of flake fixed for #7364 in `proprepltest-nolimittag-udp.sh` / `fieldtest-udp.sh`; this leftover test was not updated then.

Evidence from the failing run: tcpflood reported successful UDP sends, the main queue stayed empty (`qsize 0`), and the output file was never created. Sister TCP and already-deflaked UDP tests passed in the same run. This is a testbench flake, not an RFC-tag / property-replacer product bug.

## Change

- Configure imudp with `address="127.0.0.1" port="0" listenPortFileName=...`
- After `startup`, call `assign_tcpflood_port` before tcpflood
- Keep the original truncated-tag expected output
- Document parser invariant, race prevention, and oracle in the test header

Closes https://github.com/rsyslog/rsyslog/issues/7404

## Validation

- `shellcheck -S warning tests/proprepltest-rfctag-udp.sh` — pass
- `bash -n` on the changed test — pass
- `devtools/check-test-antipatterns.sh` — no port-preselection matches
- Host build: `make -j$(nproc) check TESTS=""` — pass
- Focused host tests: `proprepltest-rfctag-udp.sh`, `proprepltest-rfctag.sh`, `proprepltest-nolimittag-udp.sh` — all PASS
- Parallel stress: 5 concurrent `./proprepltest-rfctag-udp.sh` runs — all PASS
- Local Cubic: not installed
- **Not fully container-validated**: Docker/Podman unavailable here; Ubuntu 26.04 `run-ci.sh` check + static analyzer still needed from a container-capable agent or hosted CI
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d78db0a4-8e3a-4764-9ef1-f84b9213018a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d78db0a4-8e3a-4764-9ef1-f84b9213018a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

