### PR TITLE
testbench: ship qradar_json-with-dots in dist

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,10 @@
 --------------------------------------------------------------------------------------
 Scheduled Release 8.2608.0 (aka 2026.08) 2026-08-??
 
+- 2026-07-31: testbench: ship qradar_json-with-dots in dist
+  Include testsuites/qradar_json-with-dots in EXTRA_DIST so
+  data_pipeline-qradar.sh can run from release tarballs.
+  Closes https://github.com/rsyslog/rsyslog/issues/7456
 - 2026-07-15: imjournal: stop invalidation recovery busy-loop
   Reopened journal handles now initialize their change notification state
   before cursor restoration. This prevents journal rotation or invalidation

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -3969,6 +3969,7 @@ EXTRA_DIST += \
 	testsuites/pmnormalize_basic.rulebase \
 	validate_json_equality.py \
 	testsuites/qradar_json \
+	testsuites/qradar_json-with-dots \
 	snmptrapreceiver.py \
 	omamqp1-common.sh
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add `testsuites/qradar_json-with-dots` to `EXTRA_DIST` in `tests/Makefile.am` so `data_pipeline-qradar.sh` works from release tarballs.
- Document the packaging fix in the 8.2608 ChangeLog block.

Closes: https://github.com/rsyslog/rsyslog/issues/7456

## Test plan
- [x] Confirm fixture exists in git and is referenced by `data_pipeline-qradar.sh`
- [x] `make dist` and confirm `tests/testsuites/qradar_json-with-dots` is in the tarball
- [x] `make check TESTS=data_pipeline-qradar.sh` with `--enable-mmjsonparse --enable-mmjsontransform` (PASS)
- [ ] PR-ready local container validation: **not run** (Docker/Podman unavailable in this environment)
- [ ] Hosted CI covers remaining lanes

## Validation notes
- Classification: `testbench-plumbing` / distribution-risk (`devtools/local-validation-plan.sh`)
- Host evidence: dist tarball contains `tests/testsuites/qradar_json-with-dots`; focused test PASS
- **Not fully container-validated**

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-337178e5-e33a-4758-90f9-7c055da30112?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-337178e5-e33a-4758-90f9-7c055da30112&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

