### PR TITLE
imdtls: close sessions that fail peer identity checks

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,12 @@
 --------------------------------------------------------------------------------------
 Scheduled Release 8.2610.0 (aka 2026.10) 2026-10-??
 
+- 2026-08-20: imdtls: reject DTLS peers that fail identity checks
+  Listeners with tls.authmode set to name or fingerprint now close the
+  session when tls.permittedPeer does not match. Previously the check
+  was logged and an unpermitted peer could still submit records.
+  Thanks to Ada Logics and Anthropic Claude for reporting the issue.
+
 --------------------------------------------------------------------------------------
 Scheduled Release 8.2608.0 (aka 2026.08) 2026-08-18
 

--- a/plugins/imdtls/imdtls.c
+++ b/plugins/imdtls/imdtls.c
@@ -96,6 +96,9 @@ struct dtlsClient_s {
     SSL *sslClient; /* DTSL (SSL) Client */
     time_t lastActivityTime; /* Last Activity Time */
     int clientfd; /* ClientFD */
+    /* Set only after imdtls_verify_callback() accepts the peer. DTLSReadClient
+     * must not submit records until this flag is set. */
+    int bAuthorized;
 };
 
 // Use typedef to define a type 'dtlsClient_t' based on 'struct dtlsClient_s'
@@ -368,8 +371,10 @@ finalize_it:
     RETiRet;
 }
 
-/* Verify Callback for X509 Certificate validation. Force visibility as this function is not called anywhere but
- *  only used as callback!
+/* Post-handshake peer identity check for tls.authmode name/fingerprint.
+ * Called explicitly from DTLSAcceptSession() after SSL_accept() succeeds.
+ * A zero return must drop the session; OpenSSL's handshake verify callback
+ * only checks the certificate chain and does not consult permittedPeer.
  */
 static int imdtls_verify_callback(int status, SSL *ssl) {
     DEFiRet;
@@ -557,12 +562,17 @@ static void DTLScleanupSession(instanceConf_t *inst, int idx) {
     }
     inst->dtlsClients[idx]->sslClient = NULL;
     inst->dtlsClients[idx]->lastActivityTime = 0;
+    inst->dtlsClients[idx]->bAuthorized = 0;
 }
 
 static void DTLSAcceptSession(instanceConf_t *inst, int idx) {
     int ret, err;
     SSL *ssl = inst->dtlsClients[idx]->sslClient;
     DBGPRINTF("imdtls: DTLSAcceptSession for Client idx (%d).\n", idx);
+
+    if (ssl == NULL) {
+        return;
+    }
 
     // Check if the handshake has already been completed
     ret = SSL_get_state(ssl);
@@ -574,30 +584,35 @@ static void DTLSAcceptSession(instanceConf_t *inst, int idx) {
             if (err == SSL_ERROR_WANT_READ || err == SSL_ERROR_WANT_WRITE) {
                 // Non-blocking operation did not complete; retry later
                 DBGPRINTF("imdtls: SSL_accept didn't complete (%d). Will retry.\n", err);
+                return;
             } else if (err == SSL_ERROR_SYSCALL) {
                 DBGPRINTF("imdtls: SSL_accept failed SSL_ERROR_SYSCALL idx (%d), removing client.\n", idx);
                 net_ossl.osslLastOpenSSLErrorMsg(NULL, err, ssl, LOG_WARNING, "DTLSHandleSessions", "SSL_accept");
                 DTLScleanupSession(inst, idx);
+                return;
             } else {
                 // An actual error occurred
                 DBGPRINTF("imdtls: SSL_accept failed (%d) idx (%d), removing client.\n", err, idx);
                 net_ossl.osslLastOpenSSLErrorMsg(NULL, err, ssl, LOG_ERR, "DTLSHandleSessions", "SSL_accept");
                 DTLScleanupSession(inst, idx);
-            }
-        } else {
-            DBGPRINTF("imdtls: SSL_accept success idx (%d), adding client.\n", idx);
-            inst->dtlsClients[idx]->lastActivityTime = time(NULL);
-
-            int status = 1;
-            status = imdtls_verify_callback(status, ssl);
-            if (status == 0) {
-                LogMsg(0, RS_RET_NO_ERRCODE, LOG_WARNING, "imdtls: Cert Verify FAILED for DTLS client idx (%d)", idx);
-            } else {
-                DBGPRINTF("imdtls: Cert Verify SUCCESS for DTLS client idx (%d)\n", idx);
+                return;
             }
         }
+        DBGPRINTF("imdtls: SSL_accept success idx (%d), adding client.\n", idx);
+        inst->dtlsClients[idx]->lastActivityTime = time(NULL);
     } else {
         DBGPRINTF("imdtls: SSL_get_state for DTLS client idx (%d) is %d\n", idx, ret);
+    }
+
+    if (!inst->dtlsClients[idx]->bAuthorized) {
+        int status = imdtls_verify_callback(1, ssl);
+        if (status == 0) {
+            LogMsg(0, RS_RET_NO_ERRCODE, LOG_WARNING, "imdtls: Cert Verify FAILED for DTLS client idx (%d)", idx);
+            DTLScleanupSession(inst, idx);
+            return;
+        }
+        inst->dtlsClients[idx]->bAuthorized = 1;
+        DBGPRINTF("imdtls: Cert Verify SUCCESS for DTLS client idx (%d)\n", idx);
     }
 }
 
@@ -612,9 +627,16 @@ static void DTLSTerminateClients(instanceConf_t *inst) {
 
 static void DTLSReadClient(instanceConf_t *inst, int idx, short revents) {
     int err;
-    SSL *ssl = inst->dtlsClients[idx]->sslClient;
+    SSL *ssl;
     DBGPRINTF("imdtls: DEBUG Check Client activity on index %d.\n", idx);
     if (revents & POLLIN) {
+        if (!inst->dtlsClients[idx]->bAuthorized) {
+            DTLSAcceptSession(inst, idx);
+            if (inst->dtlsClients[idx]->sslClient == NULL || !inst->dtlsClients[idx]->bAuthorized) {
+                return;
+            }
+        }
+        ssl = inst->dtlsClients[idx]->sslClient;
         if (ssl == NULL) {
             DBGPRINTF("imdtls: DTLSHandleSessions MISSING SSL OBJ for index %d.\n", idx);
             return;
@@ -817,6 +839,7 @@ static void DTLSHandleSessions(instanceConf_t *inst) {
                         if (inst->dtlsClients[i]->sslClient == NULL) {
                             inst->dtlsClients[i]->sslClient = ssl;
                             inst->dtlsClients[i]->lastActivityTime = time(NULL);
+                            inst->dtlsClients[i]->bAuthorized = 0;
                             DBGPRINTF("imdtls: New Client added at idx %d.\n", i);
                             DTLSAcceptSession(inst, i);
                             addedClient = 1;

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -2075,7 +2075,8 @@ TESTS_IMDTLS = \
 	imdtls-basic-tlscommands.sh \
 	imdtls-basic-timeout.sh \
 	imdtls-error-cert.sh \
-	imdtls-sessionbreak.sh
+	imdtls-sessionbreak.sh \
+	imdtls-tls-name-unpermitted.sh
 
 TESTS_IMDTLS_VALGRIND = \
 	imdtls-basic-vg.sh \

--- a/tests/imdtls-tls-name-unpermitted.sh
+++ b/tests/imdtls-tls-name-unpermitted.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# added 2026-08-20 by alorbach
+# This file is part of the rsyslog project, released under ASL 2.0
+#
+# Verify that imdtls tls.authmode="name" plus tls.permittedpeer rejects a
+# CA-signed client whose certificate identity is not on the allow-list.
+# The client presents the testbench certificate (CN=rsyslog-client / SAN
+# testbench.rsyslog.com), which chains to tls.cacert, but the listener only
+# permits "trusted-host.corp".
+#
+# Oracle: wait until the configured omfile contains the identity-check
+# failure diagnostic, then prove the injected syslog payload is absent.
+# That wait is the handshake/auth completion signal; no extra sleep is
+# used. tcpflood --check-only continues if the dropped session makes the
+# client exit non-zero after a completed handshake.
+. ${srcdir:=.}/diag.sh init
+export NUMMESSAGES=1
+generate_conf
+PORT_RCVR_FILE="$RSYSLOG_DYNNAME.imdtls.port"
+
+add_conf '
+module(	load="../plugins/imdtls/.libs/imdtls" )
+input(	type="imdtls"
+	port="0"
+	listenPortFileName="'$PORT_RCVR_FILE'"
+	tls.authmode="name"
+	tls.permittedpeer="trusted-host.corp"
+	tls.cacert="'$srcdir/tls-certs/ca.pem'"
+	tls.mycert="'$srcdir/tls-certs/cert.pem'"
+	tls.myprivkey="'$srcdir/tls-certs/key.pem'")
+
+action(type="omfile" file="'$RSYSLOG_OUT_LOG'")
+'
+startup
+assign_file_content PORT_RCVR "$PORT_RCVR_FILE"
+
+tcpflood --check-only -b1 -W1000 -p"$PORT_RCVR" -m"$NUMMESSAGES" -Tdtls \
+	-x"$srcdir/tls-certs/ca.pem" -Z"$srcdir/tls-certs/cert.pem" \
+	-z"$srcdir/tls-certs/key.pem"
+
+wait_content "Cert Verify FAILED" "$RSYSLOG_OUT_LOG"
+shutdown_when_empty
+wait_shutdown
+content_check "Cert Verify FAILED"
+check_not_present "msgnum:"
+exit_test

--- a/tests/sndrcv_dtls_certvalid_permitted.sh
+++ b/tests/sndrcv_dtls_certvalid_permitted.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 # This file is part of the rsyslog project, released under ASL 2.0
-# Verify successful cert-valid DTLS transfer when the peer name is explicitly
-# permitted. The receiver must record the exact injected message sequence.
+# Verify successful DTLS transfer when tls.authmode="name" and the sender
+# certificate SAN (testbench.rsyslog.com) is listed in tls.permittedpeer.
+# The receiver must record the exact injected message sequence.
 . ${srcdir:=.}/diag.sh init
 export RSTB_IMDIAG_INJECT_DELAY_MODE=full
 printf 'using TLS driver: %s\n' ${RS_TLS_DRIVER:=gtls}
@@ -29,7 +30,7 @@ input(	type="imdtls"
 	tls.mycert="'$srcdir'/tls-certs/cert.pem"
 	tls.myprivkey="'$srcdir'/tls-certs/key.pem"
 	tls.authmode="name"
-	tls.permittedpeer="rsyslog"
+	tls.permittedpeer="testbench.rsyslog.com"
 )
 
 template(name="outfmt" type="string" string="%msg:F,58:2%\n")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary (non-technical, complete)

`tls.permittedPeer` is supposed to restrict which certificate identities may send DTLS syslog. Operators who set that allow-list need the restriction to actually drop unpermitted peers.

### References

Private vulnerability report under maintainer triage. Credit requested for Ada Logics and Anthropic Claude in any later advisory.

### Notes

After `SSL_accept()` succeeds, `imdtls` already checked the peer name or fingerprint, logged `Cert Verify FAILED` on mismatch, and then kept the session. A CA-signed client that was not on the allow-list could still submit records.

This change closes that session immediately and records authorization only after the identity check succeeds. `DTLSReadClient()` will not submit records until that flag is set.

Impact: unpermitted name/fingerprint DTLS peers are disconnected.
Before: identity failure was logged and records were still accepted.
After: identity failure closes the session and drops the records.

Host-side tests run in this environment:

- `./tests/imdtls-tls-name-unpermitted.sh`
- `./tests/imdtls-basic.sh`
- `./tests/imdtls-basic-timeout.sh`
- `./tests/sndrcv_dtls_certvalid_permitted.sh` (now uses SAN `testbench.rsyslog.com`)
- `./tests/imdtls-error-cert.sh`
- `make distcheck TEST_RUN_TYPE=MOCK-OK`

The existing permitted-peer success test previously used `tls.permittedpeer="rsyslog"`, which does not match the testbench certificate. That test was passing because the failed identity check was ignored. It now permits `testbench.rsyslog.com`.

Docker/Podman are not installed in this environment, so PR-ready local container validation was not run.

[imdtls_permittedpeer_host_tests.log](https://cursor.com/agents/bc-718afbad-3828-4c79-8767-122f17a5fda6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fimdtls_permittedpeer_host_tests.log)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-718afbad-3828-4c79-8767-122f17a5fda6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-718afbad-3828-4c79-8767-122f17a5fda6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

